### PR TITLE
Fix side-effects in `Document::getContentCrawler()`

### DIFF
--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -79,9 +79,10 @@ class Document
     }
 
     /**
-     * Returns a Symfony DomDocument component Crawler instance of the original document body.
-     * You are free to modify the contents of the Crawler instance. Every subsequent call to this
-     * method will ensure you get a new instance of the original contents.
+     * Returns a Symfony DomDocument component Crawler instance of the original
+     * document body. You are free to modify the contents of the Crawler instance.
+     * Every subsequent call to this method will ensure you get a new instance of the
+     * original contents.
      */
     public function getContentCrawler(): Crawler
     {

--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -87,18 +87,14 @@ class Document
     public function getContentCrawler(): Crawler
     {
         // Try re-using an already parsed document if possible for performance reasons
-        if (null === $this->originalDocument) {
+        if (!$this->originalDocument) {
             $crawler = new Crawler($this->body);
 
             $originalDocument = $crawler->getNode(0)?->ownerDocument;
 
             if ($originalDocument instanceof \DOMDocument) {
                 $this->originalDocument = $originalDocument;
-
-                return new Crawler($this->originalDocument->cloneNode(true));
             }
-
-            return $crawler;
         }
 
         if ($this->originalDocument instanceof \DOMDocument) {

--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class Document
 {
-    private Crawler|null $crawler = null;
+    private \DOMDocument|null $originalDocument = null;
 
     private array|null $jsonLds = null;
 
@@ -78,9 +78,34 @@ class Document
         return $this->body;
     }
 
+    /**
+     * Returns a Symfony DomDocument component Crawler instance of the original document body.
+     * You are free to modify the contents of the Crawler instance. Every subsequent call to this
+     * method will ensure you get a new instance of the original contents.
+     */
     public function getContentCrawler(): Crawler
     {
-        return $this->crawler ??= new Crawler($this->body);
+        // Try re-using an already parsed document if possible for performance reasons
+        if (null === $this->originalDocument) {
+            $crawler = new Crawler($this->body);
+
+            $originalDocument = $crawler->getNode(0)?->ownerDocument;
+
+            if ($originalDocument instanceof \DOMDocument) {
+                $this->originalDocument = $originalDocument;
+
+                return new Crawler($this->originalDocument->cloneNode(true));
+            }
+
+            return $crawler;
+        }
+
+        if ($this->originalDocument instanceof \DOMDocument) {
+            return new Crawler($this->originalDocument->cloneNode(true));
+        }
+
+        // Somehow cannot use the existing document, let's re-parse
+        return new Crawler($this->body);
     }
 
     public function extractCanonicalUri(): UriInterface|null

--- a/core-bundle/tests/Search/DocumentTest.php
+++ b/core-bundle/tests/Search/DocumentTest.php
@@ -15,11 +15,34 @@ namespace Contao\CoreBundle\Tests\Search;
 use Contao\CoreBundle\Search\Document;
 use Nyholm\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class DocumentTest extends TestCase
 {
+    public function testFetchingDocumentCrawlerReturnsNewInstance(): void
+    {
+        $html = '<body><style>body { background: grey; }</style></body>';
+        $request = Request::create('https://example.com/foo?bar=baz');
+        $response = new Response($html, 200, ['content-type' => ['text/html']]);
+        $document = Document::createFromRequestResponse($request, $response);
+
+        $crawler = $document->getContentCrawler();
+        $this->assertSame($crawler->html(), $html);
+
+        // Simulate some listener doing something with the document crawler and remove
+        // all <style> tags
+        $crawler->filterXPath('//style')->each(static fn (Crawler $node) => $node->getNode(0)->parentNode->removeChild($node->getNode(0)));
+
+        // Assert that our crawler indeed removed the style tags
+        $this->assertSame('<body></body>', $crawler->html());
+
+        // Now some other listener gets the crawler again, this must be untouched
+        $crawler = $document->getContentCrawler();
+        $this->assertSame($crawler->html(), $html);
+    }
+
     public function testCreatesADocumentFromRequestAndResponse(): void
     {
         $request = Request::create('https://example.com/foo?bar=baz');


### PR DESCRIPTION
Currently, if multiple listeners (or just consumers) of `Document::getContentCrawler()` work with the `Crawler` instance and e.g. add or remove nodes, they will affect each other which is never the desired outcome.

We have to make sure, those instances always represent the original document body.

The easiest fix would've been to not re-use any object but just simply always return `new Crawler($this->body)` but this would mean that the HTML gets parsed for every single call again. So I tried to be smart about this.
