### PR TITLE
Catch parse errors in the auto service registration

### DIFF
--- a/manager-bundle/skeleton/config/services.php
+++ b/manager-bundle/skeleton/config/services.php
@@ -40,9 +40,9 @@ return static function (ContainerConfigurator $configurator) use ($container): v
         // Trigger __destruct handler
         unset($config);
     } catch (ParseError $e) {
-        // Re-throw parse errors, otherwise you are having a hard time debugging why your service is not registered.
+        // Re-throw parse errors. Otherwise, you might have a hard time debugging why your service is not registered.
         throw $e;
-    } catch (Throwable $e) {
+    } catch (Throwable) {
         // Ignore failed autoloading
     }
 

--- a/manager-bundle/skeleton/config/services.php
+++ b/manager-bundle/skeleton/config/services.php
@@ -39,7 +39,12 @@ return static function (ContainerConfigurator $configurator) use ($container): v
 
         // Trigger __destruct handler
         unset($config);
-    } catch (Throwable) {
+    } catch (Throwable $e) {
+        // Throw parse errors. Otherwise, you are having a hard time debugging why your service is not registered.
+        if ($e instanceof ParseError) {
+            throw $e;
+        }
+
         // Ignore failed autoloading
     }
 

--- a/manager-bundle/skeleton/config/services.php
+++ b/manager-bundle/skeleton/config/services.php
@@ -39,12 +39,10 @@ return static function (ContainerConfigurator $configurator) use ($container): v
 
         // Trigger __destruct handler
         unset($config);
+    } catch (ParseError $e) {
+        // Re-throw parse errors, otherwise you are having a hard time debugging why your service is not registered.
+        throw $e;
     } catch (Throwable $e) {
-        // Throw parse errors. Otherwise, you are having a hard time debugging why your service is not registered.
-        if ($e instanceof ParseError) {
-            throw $e;
-        }
-
         // Ignore failed autoloading
     }
 


### PR DESCRIPTION
In our "auto service registration feature", we skip services that cannot be loaded/error. 
We have to do this because we don't know if all classes are suitable for Symfony services.

However, if you have a typo in your class and you get a parser error, you'll never notice why your service has not been registered. I think we can safely throw this and inform the user in this case.