### PR TITLE
Use `::` to reference controller methods (Symfony 6+ compatibility)

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
@@ -122,7 +122,7 @@ class RegisterPagesPass implements CompilerPassInterface
         if (isset($attributes['method'])) {
             $definition->setPublic(true);
 
-            return $controller.':'.$attributes['method'];
+            return $controller.'::'.$attributes['method'];
         }
 
         if (($class = $definition->getClass()) && method_exists($class, '__invoke')) {

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterPagesPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterPagesPassTest.php
@@ -180,7 +180,7 @@ class RegisterPagesPassTest extends TestCase
                         $definition = $arguments[1];
                         $this->assertInstanceOf(Definition::class, $definition);
 
-                        return 'test.controller:action' === $definition->getArgument(5)['_controller'];
+                        return 'test.controller::action' === $definition->getArgument(5)['_controller'];
                     },
                 ),
             )


### PR DESCRIPTION
**Affects:** 
- Contao 5.x since Symfony 6

**Description:**
Fragments with custom method calling are broken since Symfony 6. This is caused of the used single colon reference `serviceOrFcqn:action` instead of `serviceOrFcqn::action`.

This pull request updated the code to replace ":" with "::" for referencing controller methods. Symfony 6 has dropped support for single colon references, see https://github.com/symfony/symfony/commit/16fcdda18ed8c00b1fdc61527229e6436b1ccf6f, - https://github.com/symfony/symfony/commit/e88cec6d3254ebd79817f2fe13ab513bbf970eb0

