### PR TITLE
Remove the `title` attribute from the search results

### DIFF
--- a/core-bundle/contao/templates/search/search_default.html5
+++ b/core-bundle/contao/templates/search/search_default.html5
@@ -5,7 +5,7 @@
     <?php $this->insert('image', (array) $this->image) ?>
   <?php endif; ?>
 
-  <h3><a href="<?= $this->href ?>" title="<?= $this->title ?>"><?= $this->link ?></a></h3>
+  <h3><a href="<?= $this->href ?>"><?= $this->link ?></a></h3>
 
   <?php if ($this->context): ?>
     <p class="context"><?= $this->context ?></p>


### PR DESCRIPTION
Currently the title attribute on a search results `<a>` tag has basically the same value as the inner text of the anchor, which is not great for accessibility. 
This PR removes the title attribute from the `search_default` template.

Related: #7464 