### PR TITLE
Bump Doctrine to stable release and allow version 3 also

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "doctrine/collections": "^2.1",
         "doctrine/dbal": "^3.6.2",
         "doctrine/doctrine-bundle": "^2.8",
-        "doctrine/orm": "^2.17",
+        "doctrine/orm": "2.17 || ^3.4",
         "doctrine/persistence": "^3.2",
         "dragonmantank/cron-expression": "^3.1",
         "enshrined/svg-sanitize": "^0.21",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -67,7 +67,7 @@
         "doctrine/collections": "^2.1",
         "doctrine/dbal": "^3.6.2",
         "doctrine/doctrine-bundle": "^2.8",
-        "doctrine/orm": "^2.20 || ^3.4",
+        "doctrine/orm": "^2.17 || ^3.4",
         "doctrine/persistence": "^3.2",
         "dragonmantank/cron-expression": "^3.1",
         "debril/feed-io": "^6.0",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -67,7 +67,7 @@
         "doctrine/collections": "^2.1",
         "doctrine/dbal": "^3.6.2",
         "doctrine/doctrine-bundle": "^2.8",
-        "doctrine/orm": "^2.17",
+        "doctrine/orm": "^2.20 || ^3.4",
         "doctrine/persistence": "^3.2",
         "dragonmantank/cron-expression": "^3.1",
         "debril/feed-io": "^6.0",


### PR DESCRIPTION
For PHP 8.4 with property hooks you need ORM 3.4+

