### PR TITLE
Fix the DCA loading performance in dev mode

### DIFF
--- a/core-bundle/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/contao/library/Contao/DcaLoader.php
@@ -172,7 +172,7 @@ class DcaLoader extends Controller
 		$strCachePath = $strCacheDir . '/contao/dca/' . $this->strTable . '.php';
 
 		// Try to load from cache
-		if (file_exists($strCachePath) && (!System::getContainer()->getParameter('kernel.debug') || isset(self::$freshPaths[$strCachePath])))
+		if ((!System::getContainer()->getParameter('kernel.debug') || isset(self::$freshPaths[$strCachePath])) && file_exists($strCachePath))
 		{
 			include $strCachePath;
 		}

--- a/core-bundle/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/contao/library/Contao/DcaLoader.php
@@ -35,7 +35,7 @@ class DcaLoader extends Controller
 	protected static $arrLoaded = array();
 
 	/**
-	 * @todo Replace with a more performant implementation based on the symfony ConfigCache
+	 * @todo Replace with a more performant implementation based on the Symfony ConfigCache
 	 *
 	 * @var array<string, true>
 	 */
@@ -191,6 +191,7 @@ class DcaLoader extends Controller
 			{
 				$dumper = new CombinedFileDumper($filesystem, new PhpFileLoader(), Path::join($strCacheDir, 'contao/dca'));
 				$dumper->dump($files, $this->strTable . '.php', array('type' => 'namespaced'));
+
 				self::$freshPaths[$strCachePath] = true;
 
 				try


### PR DESCRIPTION
Fixes #8474 until we implement a real solution using the symfony `ConfigCache`.