### PR TITLE
Replace insert tags in `ariaLabel` in `ModuleNavigation`

### DIFF
--- a/core-bundle/contao/modules/ModuleNavigation.php
+++ b/core-bundle/contao/modules/ModuleNavigation.php
@@ -76,7 +76,7 @@ class ModuleNavigation extends Module
 			$host = $objRootPage->domain;
 		}
 
-		$this->Template->ariaLabel = StringUtil::specialchars($this->ariaLabel);
+		$this->Template->ariaLabel = System::getContainer()->get('contao.insert_tag.parser')->replaceInline(StringUtil::specialchars($this->ariaLabel));
 		$this->Template->request = StringUtil::ampersand(Environment::get('requestUri'));
 		$this->Template->skipId = 'skipNavigation' . $this->id;
 		$this->Template->skipNavigation = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['skipNavigation']);


### PR DESCRIPTION
Currently it is not possible to use insert tags in the navigation module, because they are escaped in [HtmlAttributes](https://github.com/contao/contao/blob/5.x/core-bundle/src/String/HtmlAttributes.php#L446).

This would be useful if you want to reuse the same navigation module for multiple page trees in different languages, for example with an aria-label like this:
`{{iflng::en}}Main menu{{iflng::de}}Hauptmenü{{iflng}}`

This PR replaces the insert tags directly in the module before they get passed to HtmlAttributes in the template.