### PR TITLE
Remove the redundant `title` attribute on the top link

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/toplink.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/toplink.html.twig
@@ -6,7 +6,6 @@
         {% set link_attributes = attrs()
             .set('href', '#top')
             .set('data-toplink')
-            .setIfExists('title', link_text)
             .mergeWith(link_attributes|default)
         %}
         <a{% block link_attributes %}{{ link_attributes }}{% endblock %}>

--- a/core-bundle/tests/Controller/ContentElement/ToplinkControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ToplinkControllerTest.php
@@ -63,7 +63,7 @@ class ToplinkControllerTest extends ContentElementTestCase
 
         yield 'user defined value' => [
             'All the way up!',
-            '<a href="#top" data-toplink title="All the way up!">All the way up!</a>',
+            '<a href="#top" data-toplink>All the way up!</a>',
         ];
     }
 


### PR DESCRIPTION
Related: https://github.com/contao/contao/issues/7464, https://github.com/contao/contao/pull/7839, https://github.com/contao/contao/pull/8240, https://github.com/contao/contao/pull/8439, https://github.com/contao/contao/pull/8440, #8464