### PR TITLE
Remove `noSearch` from `news_feed` and use permission for `newsArchives` options

### DIFF
--- a/news-bundle/config/services.yaml
+++ b/news-bundle/config/services.yaml
@@ -42,7 +42,7 @@ services:
         class: Contao\NewsBundle\EventListener\DataContainer\PageListener
         arguments:
             - '@database_connection'
-            - '@security.helper'
+            - '@security.authorization_checker'
 
     contao_news.listener.data_container.start_stop_validation:
         class: Contao\CoreBundle\EventListener\DataContainer\StartStopValidationListener

--- a/news-bundle/contao/dca/tl_page.php
+++ b/news-bundle/contao/dca/tl_page.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0-or-later
  */
 
-$GLOBALS['TL_DCA']['tl_page']['palettes']['news_feed'] = '{title_legend},title,type;{routing_legend},alias,routePath,routePriority,routeConflicts;{archives_legend},newsArchives;{feed_legend},feedFormat,feedSource,maxFeedItems,feedFeatured,feedDescription;{image_legend},imgSize;{cache_legend:hide},includeCache;{expert_legend:hide},cssClass,sitemap,hide,noSearch;{publish_legend},published,start,stop';
+$GLOBALS['TL_DCA']['tl_page']['palettes']['news_feed'] = '{title_legend},title,type;{routing_legend},alias,routePath,routePriority,routeConflicts;{archives_legend},newsArchives;{feed_legend},feedFormat,feedSource,maxFeedItems,feedFeatured,feedDescription;{image_legend},imgSize;{cache_legend:hide},includeCache;{expert_legend:hide},cssClass,sitemap,hide;{publish_legend},published,start,stop';
 
 $GLOBALS['TL_DCA']['tl_page']['fields']['newsArchives'] = array(
 	'exclude' => true,


### PR DESCRIPTION
This removes the `noSearch` field from the `news_feed` palette (see https://github.com/contao/contao/pull/8252#discussion_r2169907777). By removing the `noSearch` field, the `config.onload` callback for `tl_page` also becomes unnecessary.

Furthermore I noticed that we aren't using Voters when filtering the news archive options, thus I decided to adjust the `options_callback` accordingly.

Overall this saves a few lines of code.