### PR TITLE
Use `Backend::addToUrl()` when switching to "edit multiple" mode

### DIFF
--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -200,11 +200,11 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 
 			if (Input::post('edit') !== null)
 			{
-				$this->redirect(str_replace('act=select', 'act=editAll', Environment::get('requestUri')));
+				$this->redirect(Backend::addToUrl('act=editAll'));
 			}
 			elseif (Input::post('delete') !== null)
 			{
-				$this->redirect(str_replace('act=select', 'act=deleteAll', Environment::get('requestUri')));
+				$this->redirect(Backend::addToUrl('act=deleteAll'));
 			}
 			elseif (Input::post('cut') !== null || Input::post('copy') !== null || Input::post('copyMultiple') !== null)
 			{

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -168,15 +168,15 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 			if (Input::post('edit') !== null)
 			{
-				$this->redirect(str_replace('act=select', 'act=editAll', Environment::get('requestUri')));
+				$this->redirect(Backend::addToUrl('act=editAll'));
 			}
 			elseif (Input::post('delete') !== null)
 			{
-				$this->redirect(str_replace('act=select', 'act=deleteAll', Environment::get('requestUri')));
+				$this->redirect(Backend::addToUrl('act=deleteAll'));
 			}
 			elseif (Input::post('override') !== null)
 			{
-				$this->redirect(str_replace('act=select', 'act=overrideAll', Environment::get('requestUri')));
+				$this->redirect(Backend::addToUrl('act=overrideAll'));
 			}
 			elseif (Input::post('cut') !== null || Input::post('copy') !== null || Input::post('copyMultiple') !== null)
 			{
@@ -196,7 +196,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					// Support copyAll in the list view (see #7499)
 					if ((Input::post('copy') !== null || Input::post('copyMultiple') !== null) && ($GLOBALS['TL_DCA'][$strTable]['list']['sorting']['mode'] ?? 0) < self::MODE_PARENT)
 					{
-						$this->redirect(str_replace('act=select', 'act=copyAll', Environment::get('requestUri')));
+						$this->redirect(Backend::addToUrl('act=copyAll'));
 					}
 				}
 


### PR DESCRIPTION
In 5.x-dev, if you select multiple records an click on `Edit`, you will get the request token warning. That's because `act=select` is prefetched (= has no request token), but the `editAll` and other actions require a request token.

Technically, `prefetch = true` was added in 5.5 on the `all` operation, but it did not work. This was fixed with https://github.com/contao/contao/pull/8346 which caused this issue.