### PR TITLE
Apply a space within the ParsedSequence docType

### DIFF
--- a/core-bundle/src/InsertTag/ParsedSequence.php
+++ b/core-bundle/src/InsertTag/ParsedSequence.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\InsertTag;
 
 /**
- * @implements \IteratorAggregate<int,InsertTag|InsertTagResult|string>
+ * @implements \IteratorAggregate<int, InsertTag|InsertTagResult|string>
  */
 final class ParsedSequence implements \IteratorAggregate, \Countable
 {


### PR DESCRIPTION
* Fixes https://github.com/contao/contao/actions/runs/16067417697/job/45344450358?pr=8523

```diff
 /**
- * @implements \IteratorAggregate<int,InsertTag|InsertTagResult|string>
+ * @implements \IteratorAggregate<int, InsertTag|InsertTagResult|string>
  */
 final class ParsedSequence implements \IteratorAggregate, \Countable
 {
    ----------- end diff -----------
```

Applied checkers:

 * Contao\EasyCodingStandard\Fixer\TypeHintOrderFixer
 * **PhpCsFixerCustomFixers\Fixer\PhpdocTypesCommaSpacesFixer**
