### PR TITLE
Add a PROCESS_CONSUMER_NAME env variable to all initiated subprocesses

### DIFF
--- a/core-bundle/src/Util/ProcessUtil.php
+++ b/core-bundle/src/Util/ProcessUtil.php
@@ -57,7 +57,7 @@ class ProcessUtil implements ResetInterface
     {
         // Use PhpSubprocess introduced in Symfony 6.4 to respect command line arguments
         // used to invoke the current process.
-        return new PhpSubprocess([$this->getConsolePath(), $command, ...$commandArguments], php: [$this->getPhpBinary()]);
+        return new PhpSubprocess([$this->getConsolePath(), $command, ...$commandArguments], env: ['PROCESS_CONSUMER_NAME' => 'contao-'.bin2hex(random_bytes(5))], php: [$this->getPhpBinary()]);
     }
 
     public function reset(): void


### PR DESCRIPTION
Fixes N/A

<!--
Bugfixes should be based on the 5.3 branch and features on the 5.x branch.
Select the correct branch in the "base:" drop-down menu above.

Pull requests for Contao 4.13 are no longer merged upstream into Contao 5!
If you want to fix a bug in Contao 4.13, please create a pull request for
Contao 5.3 first and then a separate backport pull request for Contao 4.13.
-->

Whoever worked with Symfony messenger with a stream-based driver like REDIS knows the issue:
Having multiple workers consuming the stream might result in deadlocks.

The error message is "Could not acknowledge redis message" and occurs when having multiple workers.

<img width="830" alt="Screenshot 2025-07-07 at 19 43 50" src="https://github.com/user-attachments/assets/21dce312-92e4-4a03-82d1-d32a9082da77" />

------

Also [Symfony docs](https://symfony.com/doc/current/messenger.html#redis-transport) warn about this behavior: 
> There should never be more than one `messenger:consume` command running with the same combination of `stream`, `group` and `consumer`, or messages could end up being handled more than once.

<img width="808" alt="Screenshot 2025-07-07 at 19 41 36" src="https://github.com/user-attachments/assets/4bda5d4b-b565-46a7-9b5b-aeca038f3a96" />

-----

And this is why I propose to pass a random unique variable to all subprocesses initiated by Contao.
This way I can configure my messenger like this: `MESSENGER_DSN=%env(MESSENGER_TRANSPORT_DSN)%?consumer=%env(PROCESS_CONSUMER_NAME)%`

PS: Initially I wanted to only seed the env variable for `messenger:consume` subprocesses, but we are unable to change the method signature of `createSymfonyConsoleProcess()`. So we simply add the env var to all processes.
