### PR TITLE
Handle empty `Content-Type` header in CORS

### DIFF
--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -78,7 +78,7 @@ class RequestTokenListener
 
     public static function isSimpleCorsRequest(Request $request): bool
     {
-        $contentType = HeaderUtils::split($request->headers->get('content-type'), ';')[0] ?? '';
+        $contentType = HeaderUtils::split($request->headers->get('content-type', ''), ';')[0] ?? '';
 
         return \in_array(
             strtolower($contentType),

--- a/core-bundle/tests/EventListener/RequestTokenListenerTest.php
+++ b/core-bundle/tests/EventListener/RequestTokenListenerTest.php
@@ -342,6 +342,13 @@ class RequestTokenListenerTest extends TestCase
         $this->assertTrue(RequestTokenListener::isSimpleCorsRequest($request));
     }
 
+    public function testSimpleCorsRequestHandlesMissingContentTypeHeader(): void
+    {
+        $request = new Request();
+
+        $this->assertFalse(RequestTokenListener::isSimpleCorsRequest($request));
+    }
+
     public static function simpleCorsRequestContentTypeProvider(): array
     {
         return [

--- a/core-bundle/tests/EventListener/RequestTokenListenerTest.php
+++ b/core-bundle/tests/EventListener/RequestTokenListenerTest.php
@@ -342,13 +342,6 @@ class RequestTokenListenerTest extends TestCase
         $this->assertTrue(RequestTokenListener::isSimpleCorsRequest($request));
     }
 
-    public function testSimpleCorsRequestHandlesMissingContentTypeHeader(): void
-    {
-        $request = new Request();
-
-        $this->assertFalse(RequestTokenListener::isSimpleCorsRequest($request));
-    }
-
     public static function simpleCorsRequestContentTypeProvider(): array
     {
         return [
@@ -365,6 +358,11 @@ class RequestTokenListenerTest extends TestCase
             'text plain UTF-8 flowed' => ['text/plain; charset=UTF-8; format=flowed'],
             'text plain uppercase' => ['TEXT/PLAIN'],
         ];
+    }
+
+    public function testSimpleCorsRequestHandlesMissingContentTypeHeader(): void
+    {
+        $this->assertFalse(RequestTokenListener::isSimpleCorsRequest(new Request()));
     }
 
     private function validateRequestTokenForRequest(Request $request, bool $shouldValidate = true): void


### PR DESCRIPTION
`HeaderUtils::split` only accepts a string, so if no `content-type` header is given, it would currently fail because `null` is passed. This was introduced in https://github.com/contao/contao/pull/8224