### PR TITLE
Distinguish between "copy" and "duplicate"

### DIFF
--- a/calendar-bundle/contao/languages/en/tl_calendar.xlf
+++ b/calendar-bundle/contao/languages/en/tl_calendar.xlf
@@ -80,6 +80,9 @@
       <trans-unit id="tl_calendar.children.1">
         <source>Edit the events of calendar ID %s</source>
       </trans-unit>
+      <trans-unit id="tl_calendar.copy.0">
+        <source>Duplicate</source>
+      </trans-unit>
       <trans-unit id="tl_calendar.copy.1">
         <source>Duplicate calendar ID %s</source>
       </trans-unit>

--- a/calendar-bundle/contao/languages/en/tl_calendar_events.xlf
+++ b/calendar-bundle/contao/languages/en/tl_calendar_events.xlf
@@ -285,7 +285,7 @@
         <source>Edit the content elements of event ID %s</source>
       </trans-unit>
       <trans-unit id="tl_calendar_events.copy.1">
-        <source>Duplicate event ID %s</source>
+        <source>Copy event ID %s</source>
       </trans-unit>
       <trans-unit id="tl_calendar_events.cut.1">
         <source>Move event ID %s</source>

--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -2427,16 +2427,16 @@
         <source>Move element ID %s</source>
       </trans-unit>
       <trans-unit id="DCA.copy.0">
-        <source>Duplicate</source>
+        <source>Copy</source>
       </trans-unit>
       <trans-unit id="DCA.copy.1">
-        <source>Duplicate element ID %s</source>
+        <source>Copy element ID %s</source>
       </trans-unit>
       <trans-unit id="DCA.copyChildren.0">
-        <source>Duplicate recursively</source>
+        <source>Copy recursively</source>
       </trans-unit>
       <trans-unit id="DCA.copyChildren.1">
-        <source>Duplicate element ID %s with child nodes</source>
+        <source>Copy element ID %s with child nodes</source>
       </trans-unit>
       <trans-unit id="DCA.delete.0">
         <source>Delete</source>

--- a/core-bundle/contao/languages/en/tl_article.xlf
+++ b/core-bundle/contao/languages/en/tl_article.xlf
@@ -150,7 +150,7 @@
         <source>Edit the content elements of article ID %s</source>
       </trans-unit>
       <trans-unit id="tl_article.copy.1">
-        <source>Duplicate article ID %s</source>
+        <source>Copy article ID %s</source>
       </trans-unit>
       <trans-unit id="tl_article.cut.1">
         <source>Move article ID %s</source>

--- a/core-bundle/contao/languages/en/tl_content.xlf
+++ b/core-bundle/contao/languages/en/tl_content.xlf
@@ -714,7 +714,7 @@
         <source>Move content element ID %s</source>
       </trans-unit>
       <trans-unit id="tl_content.copy.1">
-        <source>Duplicate content element ID %s</source>
+        <source>Copy content element ID %s</source>
       </trans-unit>
       <trans-unit id="tl_content.delete.1">
         <source>Delete content element ID %s</source>

--- a/core-bundle/contao/languages/en/tl_favorites.xlf
+++ b/core-bundle/contao/languages/en/tl_favorites.xlf
@@ -26,9 +26,6 @@
       <trans-unit id="tl_favorites.cut.1">
         <source>Move favorite ID %s</source>
       </trans-unit>
-      <trans-unit id="tl_favorites.copy.1">
-        <source>Duplicate favorite ID %s</source>
-      </trans-unit>
       <trans-unit id="tl_favorites.delete.1">
         <source>Delete favorite ID %s</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_files.xlf
+++ b/core-bundle/contao/languages/en/tl_files.xlf
@@ -192,7 +192,7 @@
         <source>Move file or folder "%s"</source>
       </trans-unit>
       <trans-unit id="tl_files.copy.1">
-        <source>Duplicate file or folder "%s"</source>
+        <source>Copy file or folder "%s"</source>
       </trans-unit>
       <trans-unit id="tl_files.edit.1">
         <source>Edit file or folder "%s"</source>

--- a/core-bundle/contao/languages/en/tl_form.xlf
+++ b/core-bundle/contao/languages/en/tl_form.xlf
@@ -203,6 +203,9 @@
       <trans-unit id="tl_form.children.1">
         <source>Edit the form fields of form ID %s</source>
       </trans-unit>
+      <trans-unit id="tl_form.copy.0">
+        <source>Duplicate</source>
+      </trans-unit>
       <trans-unit id="tl_form.copy.1">
         <source>Duplicate form ID %s</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_form_field.xlf
+++ b/core-bundle/contao/languages/en/tl_form_field.xlf
@@ -366,7 +366,7 @@
         <source>Move form field ID %s</source>
       </trans-unit>
       <trans-unit id="tl_form_field.copy.1">
-        <source>Duplicate form field ID %s</source>
+        <source>Copy form field ID %s</source>
       </trans-unit>
       <trans-unit id="tl_form_field.delete.1">
         <source>Delete form field ID %s</source>

--- a/core-bundle/contao/languages/en/tl_image_size.xlf
+++ b/core-bundle/contao/languages/en/tl_image_size.xlf
@@ -159,7 +159,7 @@
         <source>Move image size ID %s</source>
       </trans-unit>
       <trans-unit id="tl_image_size.copy.1">
-        <source>Duplicate image size ID %s</source>
+        <source>Copy image size ID %s</source>
       </trans-unit>
       <trans-unit id="tl_image_size.delete.1">
         <source>Delete image size ID %s</source>

--- a/core-bundle/contao/languages/en/tl_image_size_item.xlf
+++ b/core-bundle/contao/languages/en/tl_image_size_item.xlf
@@ -45,7 +45,7 @@
         <source>Move media query ID %s</source>
       </trans-unit>
       <trans-unit id="tl_image_size_item.copy.1">
-        <source>Duplicate media query ID %s</source>
+        <source>Copy media query ID %s</source>
       </trans-unit>
       <trans-unit id="tl_image_size_item.delete.1">
         <source>Delete media query ID %s</source>

--- a/core-bundle/contao/languages/en/tl_layout.xlf
+++ b/core-bundle/contao/languages/en/tl_layout.xlf
@@ -360,7 +360,7 @@
         <source>Edit page layout ID %s</source>
       </trans-unit>
       <trans-unit id="tl_layout.copy.1">
-        <source>Duplicate page layout ID %s</source>
+        <source>Copy page layout ID %s</source>
       </trans-unit>
       <trans-unit id="tl_layout.cut.1">
         <source>Move page layout ID %s</source>

--- a/core-bundle/contao/languages/en/tl_member.xlf
+++ b/core-bundle/contao/languages/en/tl_member.xlf
@@ -197,6 +197,9 @@
       <trans-unit id="tl_member.edit.1">
         <source>Edit member ID %s</source>
       </trans-unit>
+      <trans-unit id="tl_member.copy.0">
+        <source>Duplicate</source>
+      </trans-unit>
       <trans-unit id="tl_member.copy.1">
         <source>Duplicate member ID %s</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_member_group.xlf
+++ b/core-bundle/contao/languages/en/tl_member_group.xlf
@@ -59,6 +59,9 @@
       <trans-unit id="tl_member_group.edit.1">
         <source>Edit member group ID %s</source>
       </trans-unit>
+      <trans-unit id="tl_member_group.copy.0">
+        <source>Duplicate</source>
+      </trans-unit>
       <trans-unit id="tl_member_group.copy.1">
         <source>Duplicate member group ID %s</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_module.xlf
+++ b/core-bundle/contao/languages/en/tl_module.xlf
@@ -499,7 +499,7 @@ If you did not request this e-mail, please contact the website administrator.
         <source>Edit module ID %s</source>
       </trans-unit>
       <trans-unit id="tl_module.copy.1">
-        <source>Duplicate module ID %s</source>
+        <source>Copy module ID %s</source>
       </trans-unit>
       <trans-unit id="tl_module.cut.1">
         <source>Move module ID %s</source>

--- a/core-bundle/contao/languages/en/tl_page.xlf
+++ b/core-bundle/contao/languages/en/tl_page.xlf
@@ -477,10 +477,10 @@
         <source>Move page ID %s</source>
       </trans-unit>
       <trans-unit id="tl_page.copy.1">
-        <source>Duplicate page ID %s</source>
+        <source>Copy page ID %s</source>
       </trans-unit>
       <trans-unit id="tl_page.copyChildren.1">
-        <source>Duplicate page ID %s with its subpages</source>
+        <source>Copy page ID %s with its subpages</source>
       </trans-unit>
       <trans-unit id="tl_page.delete.1">
         <source>Delete page ID %s</source>

--- a/core-bundle/contao/languages/en/tl_user.xlf
+++ b/core-bundle/contao/languages/en/tl_user.xlf
@@ -299,6 +299,9 @@
       <trans-unit id="tl_user.edit.1">
         <source>Edit user ID %s</source>
       </trans-unit>
+      <trans-unit id="tl_user.copy.0">
+        <source>Duplicate</source>
+      </trans-unit>
       <trans-unit id="tl_user.copy.1">
         <source>Duplicate user ID %s</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_user_group.xlf
+++ b/core-bundle/contao/languages/en/tl_user_group.xlf
@@ -74,6 +74,9 @@
       <trans-unit id="tl_user_group.edit.1">
         <source>Edit user group ID %s</source>
       </trans-unit>
+      <trans-unit id="tl_user_group.copy.0">
+        <source>Duplicate</source>
+      </trans-unit>
       <trans-unit id="tl_user_group.copy.1">
         <source>Duplicate user group ID %s</source>
       </trans-unit>

--- a/faq-bundle/contao/languages/en/tl_faq_category.xlf
+++ b/faq-bundle/contao/languages/en/tl_faq_category.xlf
@@ -47,6 +47,9 @@
       <trans-unit id="tl_faq_category.children.1">
         <source>Edit the questions of category ID %s</source>
       </trans-unit>
+      <trans-unit id="tl_faq_category.copy.0">
+        <source>Duplicate</source>
+      </trans-unit>
       <trans-unit id="tl_faq_category.copy.1">
         <source>Duplicate category ID %s</source>
       </trans-unit>

--- a/news-bundle/contao/languages/en/tl_news_archive.xlf
+++ b/news-bundle/contao/languages/en/tl_news_archive.xlf
@@ -62,6 +62,9 @@
       <trans-unit id="tl_news_archive.children.1">
         <source>Edit the news items of news archive ID %s</source>
       </trans-unit>
+      <trans-unit id="tl_news_archive.copy.0">
+        <source>Duplicate</source>
+      </trans-unit>
       <trans-unit id="tl_news_archive.copy.1">
         <source>Duplicate news archive ID %s</source>
       </trans-unit>

--- a/newsletter-bundle/contao/languages/en/tl_newsletter_channel.xlf
+++ b/newsletter-bundle/contao/languages/en/tl_newsletter_channel.xlf
@@ -71,6 +71,9 @@
       <trans-unit id="tl_newsletter_channel.children.1">
         <source>Edit the newsletters of channel ID %s</source>
       </trans-unit>
+      <trans-unit id="tl_newsletter_channel.copy.0">
+        <source>Duplicate</source>
+      </trans-unit>
       <trans-unit id="tl_newsletter_channel.copy.1">
         <source>Duplicate channel ID %s</source>
       </trans-unit>


### PR DESCRIPTION
Since we change several labels in Contao 5.6, we can also fix something that has bothered me for quite some time:

If the the `copy` operation

* instantly duplicates an element (list view), keep saying _Duplicate_.
* copies an element to the clipboard so it can be pasted in the next step, say _Copy_ instead.
