### PR TITLE
Use the default translations for the "new" button

### DIFF
--- a/calendar-bundle/contao/languages/en/tl_calendar.xlf
+++ b/calendar-bundle/contao/languages/en/tl_calendar.xlf
@@ -62,9 +62,6 @@
       <trans-unit id="tl_calendar.feeds.1">
         <source>Manage calendar feeds</source>
       </trans-unit>
-      <trans-unit id="tl_calendar.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_calendar.new.1">
         <source>Create a new calendar</source>
       </trans-unit>

--- a/calendar-bundle/contao/languages/en/tl_calendar_events.xlf
+++ b/calendar-bundle/contao/languages/en/tl_calendar_events.xlf
@@ -266,9 +266,6 @@
       <trans-unit id="tl_calendar_events.years">
         <source>year(s)</source>
       </trans-unit>
-      <trans-unit id="tl_calendar_events.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_calendar_events.new.1">
         <source>Create a new event</source>
       </trans-unit>

--- a/calendar-bundle/contao/languages/en/tl_calendar_feed.xlf
+++ b/calendar-bundle/contao/languages/en/tl_calendar_feed.xlf
@@ -74,9 +74,6 @@
       <trans-unit id="tl_calendar_feed.source_text">
         <source>Full articles</source>
       </trans-unit>
-      <trans-unit id="tl_calendar_feed.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_calendar_feed.new.1">
         <source>Create a new feed</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_content.xlf
+++ b/core-bundle/contao/languages/en/tl_content.xlf
@@ -701,9 +701,6 @@
       <trans-unit id="tl_content.vimeo_dnt">
         <source>Prevent session data tracking</source>
       </trans-unit>
-      <trans-unit id="tl_content.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_content.new.1">
         <source>Add a new content element</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_form.xlf
+++ b/core-bundle/contao/languages/en/tl_form.xlf
@@ -185,9 +185,6 @@
       <trans-unit id="tl_form.template_legend">
         <source>Template settings</source>
       </trans-unit>
-      <trans-unit id="tl_form.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_form.new.1">
         <source>Create a new form</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_form_field.xlf
+++ b/core-bundle/contao/languages/en/tl_form_field.xlf
@@ -350,9 +350,6 @@
       <trans-unit id="tl_form_field.invisible_legend">
         <source>Visibility</source>
       </trans-unit>
-      <trans-unit id="tl_form_field.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_form_field.new.1">
         <source>Create a new form field</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_image_size.xlf
+++ b/core-bundle/contao/languages/en/tl_image_size.xlf
@@ -137,9 +137,6 @@
       <trans-unit id="tl_image_size.preserveMetadataOptions.delete">
         <source>Remove all metadata fields</source>
       </trans-unit>
-      <trans-unit id="tl_image_size.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_image_size.new.1">
         <source>Create a new image size</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_image_size_item.xlf
+++ b/core-bundle/contao/languages/en/tl_image_size_item.xlf
@@ -29,9 +29,6 @@
       <trans-unit id="tl_image_size_item.visibility_legend">
         <source>Visibility</source>
       </trans-unit>
-      <trans-unit id="tl_image_size_item.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_image_size_item.new.1">
         <source>Create a new media query</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_layout.xlf
+++ b/core-bundle/contao/languages/en/tl_layout.xlf
@@ -347,9 +347,6 @@
       <trans-unit id="tl_layout.analytics_matomo">
         <source>Matomo</source>
       </trans-unit>
-      <trans-unit id="tl_layout.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_layout.new.1">
         <source>Create a new page layout</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_member.xlf
+++ b/core-bundle/contao/languages/en/tl_member.xlf
@@ -185,9 +185,6 @@
       <trans-unit id="tl_member.captchaDetails">
         <source>Verification</source>
       </trans-unit>
-      <trans-unit id="tl_member.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_member.new.1">
         <source>Create a new member</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_member_group.xlf
+++ b/core-bundle/contao/languages/en/tl_member_group.xlf
@@ -47,9 +47,6 @@
       <trans-unit id="tl_member_group.account_legend">
         <source>Group settings</source>
       </trans-unit>
-      <trans-unit id="tl_member_group.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_member_group.new.1">
         <source>Create a new member group</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_module.xlf
+++ b/core-bundle/contao/languages/en/tl_module.xlf
@@ -486,9 +486,6 @@ If you did not request this e-mail, please contact the website administrator.
       <trans-unit id="tl_module.close_delete">
         <source>Irrevocably delete account</source>
       </trans-unit>
-      <trans-unit id="tl_module.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_module.new.1">
         <source>Create a new module</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_page.xlf
+++ b/core-bundle/contao/languages/en/tl_page.xlf
@@ -485,9 +485,6 @@
       <trans-unit id="tl_page.layout_inherit">
         <source>Inherit page layout</source>
       </trans-unit>
-      <trans-unit id="tl_page.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_page.new.1">
         <source>Create a new page</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_theme.xlf
+++ b/core-bundle/contao/languages/en/tl_theme.xlf
@@ -113,9 +113,6 @@
       <trans-unit id="tl_theme.editmeta">
         <source>Edit the theme settings</source>
       </trans-unit>
-      <trans-unit id="tl_theme.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_theme.new.1">
         <source>Create a new theme</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_user.xlf
+++ b/core-bundle/contao/languages/en/tl_user.xlf
@@ -287,9 +287,6 @@
       <trans-unit id="tl_user.useTwoFactor">
         <source>Use two-factor authentication</source>
       </trans-unit>
-      <trans-unit id="tl_user.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_user.new.1">
         <source>Create a new user</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_user_group.xlf
+++ b/core-bundle/contao/languages/en/tl_user_group.xlf
@@ -62,9 +62,6 @@
       <trans-unit id="tl_user_group.account_legend">
         <source>Group settings</source>
       </trans-unit>
-      <trans-unit id="tl_user_group.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_user_group.new.1">
         <source>Create a new user group</source>
       </trans-unit>

--- a/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
@@ -228,4 +228,30 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
             throw new \RuntimeException(static::class.' has already been initialized.');
         }
     }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    protected function getLabelAndTitle(string $table, string $key, int|string|null $id = null): array
+    {
+        $label = $GLOBALS['TL_LANG'][$table][$key] ?? $GLOBALS['TL_LANG']['DCA'][$key] ?? null;
+
+        if (null === $label) {
+            return [$key, ''];
+        }
+
+        if (\is_string($label)) {
+            $label = [null, $label];
+        }
+
+        if (null !== $id) {
+            $label[1] = \sprintf($label[1], $id);
+        }
+
+        if (!isset($label[0])) {
+            $label[0] = $GLOBALS['TL_LANG']['DCA'][$key][0] ?? $label[1];
+        }
+
+        return $label;
+    }
 }

--- a/core-bundle/src/DataContainer/DataContainerGlobalOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/DataContainerGlobalOperationsBuilder.php
@@ -118,13 +118,14 @@ class DataContainerGlobalOperationsBuilder extends AbstractDataContainerOperatio
             $url .= '&amp;pid='.$pid;
         }
 
-        $labelNew = $GLOBALS['TL_LANG'][$this->table]['new'] ?? $GLOBALS['TL_LANG']['DCA']['new'];
+        [$label, $title] = $this->getLabelAndTitle($this->table, 'new');
+
         $href = $this->framework->getAdapter(Backend::class)->addToUrl($url, true, [], false);
 
         $this->append([
             'href' => $href,
-            'label' => $labelNew[0] ?? 'new',
-            'title' => $labelNew[1] ?? null,
+            'label' => $label,
+            'title' => $title,
             'attributes' => (new HtmlAttributes())->addClass('header_new')->set('accesskey', 'n')->set('data-action', 'contao--scroll-offset#store'),
             'method' => 'POST',
             'primary' => true,

--- a/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
@@ -145,7 +145,7 @@ class DataContainerOperationsBuilder extends AbstractDataContainerOperationsBuil
             default => $type,
         };
 
-        [$label, $title] = $this->getLabelAndTitle($type);
+        [$label, $title] = $this->getLabelAndTitle($this->table, $type, $this->id);
 
         if (null === $href) {
             $this->append([
@@ -324,29 +324,5 @@ class DataContainerOperationsBuilder extends AbstractDataContainerOperationsBuil
             'iconAttributes' => $iconAttributes,
             'primary' => $config['primary'] ?? null,
         ];
-    }
-
-    /**
-     * @return array{0: string, 1: string}
-     */
-    private function getLabelAndTitle(string $key): array
-    {
-        $label = $GLOBALS['TL_LANG'][$this->table][$key] ?? $GLOBALS['TL_LANG']['DCA'][$key] ?? null;
-
-        if (null === $label) {
-            return [$key, ''];
-        }
-
-        if (\is_string($label)) {
-            $label = [null, $label];
-        }
-
-        $label[1] = \sprintf($label[1], $this->id);
-
-        if (!isset($label[0])) {
-            $label[0] = $GLOBALS['TL_LANG']['DCA'][$key][0] ?? $label[1];
-        }
-
-        return $label;
     }
 }

--- a/faq-bundle/contao/languages/en/tl_faq.xlf
+++ b/faq-bundle/contao/languages/en/tl_faq.xlf
@@ -86,9 +86,6 @@
       <trans-unit id="tl_faq.publish_legend">
         <source>Publish settings</source>
       </trans-unit>
-      <trans-unit id="tl_faq.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_faq.new.1">
         <source>Create a new question</source>
       </trans-unit>

--- a/faq-bundle/contao/languages/en/tl_faq_category.xlf
+++ b/faq-bundle/contao/languages/en/tl_faq_category.xlf
@@ -29,9 +29,6 @@
       <trans-unit id="tl_faq_category.title_legend">
         <source>Title and redirect</source>
       </trans-unit>
-      <trans-unit id="tl_faq_category.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_faq_category.new.1">
         <source>Create a new category</source>
       </trans-unit>

--- a/news-bundle/contao/languages/en/tl_news.xlf
+++ b/news-bundle/contao/languages/en/tl_news.xlf
@@ -206,9 +206,6 @@
       <trans-unit id="tl_news.publish_legend">
         <source>Publish settings</source>
       </trans-unit>
-      <trans-unit id="tl_news.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_news.new.1">
         <source>Create a new news item</source>
       </trans-unit>

--- a/news-bundle/contao/languages/en/tl_news_archive.xlf
+++ b/news-bundle/contao/languages/en/tl_news_archive.xlf
@@ -44,9 +44,6 @@
       <trans-unit id="tl_news_archive.feeds.1">
         <source>Manage news feeds</source>
       </trans-unit>
-      <trans-unit id="tl_news_archive.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_news_archive.new.1">
         <source>Create a new news archive</source>
       </trans-unit>

--- a/newsletter-bundle/contao/languages/en/tl_newsletter.xlf
+++ b/newsletter-bundle/contao/languages/en/tl_newsletter.xlf
@@ -167,9 +167,6 @@
       <trans-unit id="tl_newsletter.send.1">
         <source>Send newsletter ID %s</source>
       </trans-unit>
-      <trans-unit id="tl_newsletter.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_newsletter.new.1">
         <source>Create a new newsletter</source>
       </trans-unit>

--- a/newsletter-bundle/contao/languages/en/tl_newsletter_channel.xlf
+++ b/newsletter-bundle/contao/languages/en/tl_newsletter_channel.xlf
@@ -53,9 +53,6 @@
       <trans-unit id="tl_newsletter_channel.sender_legend">
         <source>Sender settings</source>
       </trans-unit>
-      <trans-unit id="tl_newsletter_channel.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_newsletter_channel.new.1">
         <source>Create a new channel</source>
       </trans-unit>

--- a/newsletter-bundle/contao/languages/en/tl_newsletter_recipients.xlf
+++ b/newsletter-bundle/contao/languages/en/tl_newsletter_recipients.xlf
@@ -53,9 +53,6 @@
       <trans-unit id="tl_newsletter_recipients.import.1">
         <source>Import recipients from a CSV file</source>
       </trans-unit>
-      <trans-unit id="tl_newsletter_recipients.new.0">
-        <source>New</source>
-      </trans-unit>
       <trans-unit id="tl_newsletter_recipients.new.1">
         <source>Create a new recipient</source>
       </trans-unit>


### PR DESCRIPTION
I noticed that `tl_article` does not have a translation for the `New` global operation. And therefore noticed we're not falling back to the global `DCA.new.0` translation. Now we do and require a lot less translations 😎 