### PR TITLE
Hide drag operation from files menu

### DIFF
--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -148,7 +148,8 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 				'icon'                => 'drag.svg',
 				'attributes'          => 'class="drag-handle" aria-hidden="true"',
 				'primary'             => true,
-				'button_callback'     => array('tl_files', 'dragFile')
+				'showInMenu'          => false,
+				'button_callback'     => array('tl_files', 'dragFile'),
 			)
 		)
 	),

--- a/core-bundle/contao/templates/twig/backend/data_container/operations.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/operations.html.twig
@@ -24,7 +24,9 @@
                 </button>
                 <ul class="operations-menu" data-contao--operations-menu-target="submenu">
                     {% for operation in operations %}
-                        {{ _self.operation(operation, true, globalOperations) }}
+                        {% if operation.showInMenu|default != false %}
+                            {{ _self.operation(operation, true, globalOperations) }}
+                        {% endif %}
                     {% endfor %}
                 </ul>
             </li>

--- a/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
@@ -30,7 +30,7 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
     public const CREATE_PASTE_INTO = 'paste_into';
 
     /**
-     * @var list<array{html: string, primary?: bool}|array{separator: true}|array{
+     * @var list<array{html: string, primary?: bool, showInMenu?: bool}|array{separator: true}|array{
      *     label: string,
      *     title?: string,
      *     attributes?: HtmlAttributes,
@@ -39,6 +39,7 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
      *     href?: string,
      *     method?: string,
      *     primary?: bool|null,
+     *     showInMenu?: bool,
      * }>
      */
     protected array|null $operations = null;
@@ -48,7 +49,7 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
     }
 
     /**
-     * @param array{html: string, primary?: bool}|array{separator: true}|array{
+     * @param array{html: string, primary?: bool, showInMenu?: bool}|array{separator: true}|array{
      *     label: string,
      *     title?: string,
      *     attributes?: HtmlAttributes,
@@ -56,7 +57,8 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
      *     iconAttributes?: HtmlAttributes,
      *     href?: string,
      *     method?: string,
-     *     primary?: bool|null
+     *     primary?: bool|null,
+     *     showInMenu?: bool,
      * } $operation
      */
     public function prepend(array $operation, bool $parseHtml = false): self
@@ -73,7 +75,7 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
     }
 
     /**
-     * @param array{html: string, primary?: bool}|array{separator: true}|array{
+     * @param array{html: string, primary?: bool, showInMenu?: bool}|array{separator: true}|array{
      *     label: string,
      *     title?: string,
      *     attributes?: HtmlAttributes,
@@ -81,7 +83,8 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
      *     iconAttributes?: HtmlAttributes,
      *     href?: string,
      *     method?: string,
-     *     primary?: bool|null
+     *     primary?: bool|null,
+     *     showInMenu?: bool,
      * } $operation
      */
     public function append(array $operation, bool $parseHtml = false): self

--- a/core-bundle/src/DataContainer/DataContainerGlobalOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/DataContainerGlobalOperationsBuilder.php
@@ -179,6 +179,7 @@ class DataContainerGlobalOperationsBuilder extends AbstractDataContainerOperatio
             return [
                 'html' => $html,
                 'primary' => $config['primary'] ?? ('all' === $name ? true : null),
+                'showInMenu' => $config['showInMenu'] ?? true,
             ];
         }
 
@@ -195,6 +196,7 @@ class DataContainerGlobalOperationsBuilder extends AbstractDataContainerOperatio
             'attributes' => $config['attributes'],
             'icon' => $config['icon'] ?? null,
             'primary' => $config['primary'] ?? ('all' === $name ? true : null),
+            'showInMenu' => $config['showInMenu'] ?? true,
         ];
     }
 

--- a/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
@@ -183,6 +183,7 @@ class DataContainerOperationsBuilder extends AbstractDataContainerOperationsBuil
             return [
                 'html' => $html,
                 'primary' => $config['primary'] ?? null,
+                'showInMenu' => $config['showInMenu'] ?? true,
             ];
         }
 
@@ -215,6 +216,7 @@ class DataContainerOperationsBuilder extends AbstractDataContainerOperationsBuil
             'href' => $href,
             'method' => strtoupper($config['method'] ?? 'GET'),
             'primary' => $config['primary'] ?? null,
+            'showInMenu' => $config['showInMenu'] ?? true,
         ];
     }
 
@@ -323,6 +325,7 @@ class DataContainerOperationsBuilder extends AbstractDataContainerOperationsBuil
             'icon' => $state ? $icon : $_icon,
             'iconAttributes' => $iconAttributes,
             'primary' => $config['primary'] ?? null,
+            'showInMenu' => $config['showInMenu'] ?? true,
         ];
     }
 }


### PR DESCRIPTION
Extracted from reverted commit in https://github.com/contao/contao/pull/8372

The files drag&drop operation is currently visible in the operations menu, because it is a simple operation and we now support buttons (e.g. for POST forms).

<img width="649" height="214" alt="Bildschirmfoto 2025-07-10 um 14 52 14" src="https://github.com/user-attachments/assets/70c9e0fa-c3ca-4dad-bfe4-b63320a2d787" />

This PR is draft because we want to implement drag&drop on the left side of the tree, but keeping this commit for now if we can't find an alternative.