### PR TITLE
Fix the infinite loop on `encore dev --watch`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const Encore = require('@symfony/webpack-encore');
 const ImageMinimizerPlugin = require('image-minimizer-webpack-plugin');
-const path = require('node:path');
 
 // Core bundle assets
 Encore
@@ -104,7 +103,7 @@ Encore
     })
     .configureWatchOptions(watchOptions => {
         // Since we overwrite the sources, we need to prevent an endless loop.
-        watchOptions.ignored = [path.resolve('./core-bundle/contao/themes/flexible/icons')];
+        watchOptions.ignored = ['**/core-bundle/contao/themes/flexible/icons'];
     })
 ;
 


### PR DESCRIPTION
Fixes an infinite loop caused by the `/icons` folder not being properly excluded on e. g. Windows

This was introduced in https://github.com/contao/contao/pull/8094