### PR TITLE
Correctly check permissions to create a new clipboard

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -6812,6 +6812,18 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 	protected function getClipboardPermission(string $mode, int $id, array|null $new = null): array
 	{
+		if (ClipboardManager::MODE_CREATE === $mode)
+		{
+			$parent = array('pid' => $id);
+
+			if (($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null) && $this->ptable)
+			{
+				$parent['ptable'] = $this->ptable;
+			}
+
+			$new = array_replace($parent, (array) $new);
+		}
+
 		$action = match ($mode)
 		{
 			'create' => new CreateAction($this->strTable, $new),


### PR DESCRIPTION
The clipboard check does not pass the current record information, if a new record is to be created with "paste new" (e.g. in content elements, where you get a paste button to select the position). This didn't affect `tl_content` right now, because no voter denies since there is no known `ptable`.

I noticed the problem in https://github.com/contao/contao/pull/8570 because a non-admin cannot create new form fields. Most likely also the case in 5.3 or at least 5.5.