### PR TITLE
Reset `$blnDetailsLoaded` in `PageModel` when setting a new row

### DIFF
--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -345,6 +345,14 @@ class PageModel extends Model
 		self::$suffixes = null;
 	}
 
+	public function setRow(array $arrData)
+	{
+		// Reset $blnDetailsLoaded (#8516)
+		$this->blnDetailsLoaded = false;
+
+		return parent::setRow($arrData);
+	}
+
 	/**
 	 * Find a published page by its ID
 	 *


### PR DESCRIPTION
Fixes #8516 

If you have a website root with an URL prefix and you execute something like this:

```php
$page = PageModel::findById(…);

// outputs "/en/foobar"
echo $this->contentUrlGenerator->generate($page);

$page = $page->cloneOriginal();

// outputs "/foobar"
echo $this->contentUrlGenerator->generate($page);
```

the second URL generation will be wrong, because the URL suffix is now missing. This is because `cloneOriginal()` completely resets the row of the record to its original state - but then `->loadDetails()` (which would be executed during URL generation) won't load the details anymore, because `$this->blnDetailsLoaded` will remain `true`.

This PR fixes that by resetting `$blnDetailsLoaded` whenever `setRow()` is executed, i.e. whenever the data of the record is overwritten. This happens during `cloneOriginal()` and `refresh()` for example.