### PR TITLE
Change the newsletter recipient icon according to the start/stop date

### DIFF
--- a/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
@@ -16,6 +16,7 @@ use Contao\Date;
 use Contao\DC_Table;
 use Contao\Idna;
 use Contao\Image;
+use Contao\MemberModel;
 
 $GLOBALS['TL_DCA']['tl_newsletter_recipients'] = array
 (
@@ -209,6 +210,21 @@ class tl_newsletter_recipients extends Backend
 
 		$icon = Image::getPath('member');
 		$icond = Image::getPath('member_');
+
+		// Change icon according to start/stop of associated member (#951)
+		if ($member = MemberModel::findOneByEmail($row['email']))
+		{
+			$time = Date::floorToMinute();
+
+			if ($member->start && $time < $member->start)
+			{
+				$icon = $icond;
+			}
+			elseif ($member->stop && $time >= $member->stop)
+			{
+				$icon = $icond;
+			}
+		}
 
 		return sprintf(
 			'<div class="tl_content_left"><div class="list_icon" style="background-image:url(\'%s\')" data-icon="%s" data-icon-disabled="%s">%s</div></div>' . "\n",

--- a/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
@@ -17,7 +17,6 @@ use Contao\DC_Table;
 use Contao\Idna;
 use Contao\Image;
 use Contao\System;
-use Doctrine\DBAL\Connection;
 
 $GLOBALS['TL_DCA']['tl_newsletter_recipients'] = array
 (
@@ -134,7 +133,7 @@ class tl_newsletter_recipients extends Backend
 	 *
 	 * @var array<int, array<string, array<string, string>>
 	 */
-	private static $subscribedMembers = array();
+	private static array $subscribedMembers = array();
 
 	/**
 	 * Set the recipient status to "added manually" if they are moved to another channel
@@ -219,15 +218,15 @@ class tl_newsletter_recipients extends Backend
 		$icon = Image::getPath('member');
 		$icond = Image::getPath('member_');
 
-		// Change icon according to start/stop of associated member (#951)
+		// Change icon according to start/stop of the associated member (#951)
 		if (!isset(self::$subscribedMembers[$row['pid']]))
 		{
-			/** @var Connection $db */
-			$db = System::getContainer()->get('database_connection');
-			self::$subscribedMembers[$row['pid']] = $db->fetchAllAssociativeIndexed('SELECT r.email, m.start, m.stop FROM tl_newsletter_recipients r LEFT JOIN tl_member m ON r.email=m.email WHERE r.pid=?', array($row['pid']));
+			self::$subscribedMembers[$row['pid']] = System::getContainer()
+				->get('database_connection')
+				->fetchAllAssociativeIndexed('SELECT r.email, m.start, m.stop FROM tl_newsletter_recipients r LEFT JOIN tl_member m ON r.email=m.email WHERE r.pid=?', array($row['pid']));
 		}
 
-		if ($member = (self::$subscribedMembers[$row['pid']][$row['email']] ?? null))
+		if ($member = self::$subscribedMembers[$row['pid']][$row['email']] ?? null)
 		{
 			$time = Date::floorToMinute();
 


### PR DESCRIPTION
Fixes #951

This changes at least the member icon on the left according to the start/stop date, making it more clear, that the recipient is actually inactive, even though `tl_newsletter_recipient.active` is still enabled.

See also https://github.com/contao/contao/blob/fbc4d759bd7975722c25842503ac9c80c7fe5089/newsletter-bundle/contao/classes/Newsletter.php#L199 (note that `$objRecipients` is a `JOIN` with `tl_member` on `email`).