### PR TITLE
Remove the close button from non-gallery `fileTree` widgets

### DIFF
--- a/core-bundle/contao/widgets/FileTree.php
+++ b/core-bundle/contao/widgets/FileTree.php
@@ -422,15 +422,9 @@ class FileTree extends Widget
 			$buffer = Image::getHtml('placeholder.svg', $strInfo, 'data-contao--tooltips-target="tooltip"');
 		}
 
-		$closeIcon = Image::getHtml('close');
-
 		if ($blnRemovable)
 		{
-			$buffer .= \sprintf('<button type="button" class="tl_red" data-action="contao--input-map#removeElement" data-contao--input-map-closest-param="li">%s</button>', $closeIcon);
-		}
-		else
-		{
-			$buffer .= \sprintf('<button type="button" disabled>%s</button>', $closeIcon);
+			$buffer .= \sprintf('<button type="button" class="tl_red" data-action="contao--input-map#removeElement" data-contao--input-map-closest-param="li">%s</button>', Image::getHtml('close'));
 		}
 
 		return $buffer;


### PR DESCRIPTION
Fixes #8585