### PR TITLE
Deprecate `Contao\Feed` and `Contao\FeedItem`

### DIFF
--- a/core-bundle/contao/library/Contao/Feed.php
+++ b/core-bundle/contao/library/Contao/Feed.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6.', Feed::class);
+
 /**
  * Creates RSS or Atom feeds
  *

--- a/core-bundle/contao/library/Contao/FeedItem.php
+++ b/core-bundle/contao/library/Contao/FeedItem.php
@@ -12,6 +12,8 @@ namespace Contao;
 
 use Symfony\Component\Filesystem\Path;
 
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6.', FeedItem::class);
+
 /**
  * Creates items to be appended to RSS or Atom feeds
  *


### PR DESCRIPTION
One thing that I forgot - with https://github.com/contao/contao/pull/8390 the last usage of `Contao\Feed` and `Contao\FeedItem` within Contao has been deprecated. Thus we can also deprecate those in favor of [`php-feed-io/feed-io`](https://packagist.org/packages/php-feed-io/feed-io).