### PR TITLE
Switch to `php-feed-io/feed-io`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "contao/image": "^1.2",
         "contao/imagine-svg": "^1.0",
         "contao/manager-plugin": "^2.6.2",
-        "debril/feed-io": "^6.0",
+        "php-feed-io/feed-io": "^6.0",
         "doctrine/collections": "^2.1",
         "doctrine/dbal": "^3.6",
         "doctrine/doctrine-bundle": "^2.8",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -68,7 +68,7 @@
         "doctrine/orm": "^2.17",
         "doctrine/persistence": "^3.2",
         "dragonmantank/cron-expression": "^2.3",
-        "debril/feed-io": "^6.0",
+        "php-feed-io/feed-io": "^6.0",
         "enshrined/svg-sanitize": "^0.21",
         "friendsofsymfony/http-cache": "^2.15.1",
         "friendsofsymfony/http-cache-bundle": "^2.6",

--- a/news-bundle/composer.json
+++ b/news-bundle/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^8.1",
         "contao/core-bundle": "self.version",
-        "debril/feed-io": "^6.0",
+        "php-feed-io/feed-io": "^6.0",
         "friendsofsymfony/http-cache": "^2.4",
         "symfony/config": "^6.4",
         "symfony/dependency-injection": "^6.4",


### PR DESCRIPTION
Fixes #8569

`debril/feed-io` is now officially abandoned.
