### PR TITLE
Add the event dates to the calendar feed titles again

### DIFF
--- a/calendar-bundle/src/EventListener/CalendarFeedListener.php
+++ b/calendar-bundle/src/EventListener/CalendarFeedListener.php
@@ -80,8 +80,14 @@ class CalendarFeedListener
     {
         $calendarEvent = $systemEvent->getEvent();
 
+        if ($calendarEvent['time']) {
+            $title = \sprintf('%s (%s) %s', $calendarEvent['date'], $calendarEvent['time'], $calendarEvent['title']);
+        } else {
+            $title = \sprintf('%s %s', $calendarEvent['date'], $calendarEvent['title']);
+        }
+
         $item = new Item();
-        $item->setTitle(html_entity_decode($calendarEvent['title'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, $this->charset));
+        $item->setTitle(html_entity_decode($title, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, $this->charset));
         $item->setLastModified((new \DateTime())->setTimestamp($calendarEvent['begin']));
         $item->setLink($this->urlGenerator->generate($calendarEvent['model'], [], UrlGeneratorInterface::ABSOLUTE_URL));
         $item->setContent($this->getContent($calendarEvent, $item, $systemEvent));

--- a/calendar-bundle/tests/EventListener/CalendarFeedListenerTest.php
+++ b/calendar-bundle/tests/EventListener/CalendarFeedListenerTest.php
@@ -252,6 +252,8 @@ class CalendarFeedListenerTest extends ContaoTestCase
         $eventData = $eventModel->row();
         $eventData['model'] = $eventModel;
         $eventData['begin'] = $eventModel->startTime;
+        $eventData['date'] = date('Y-m-d', $eventModel->startTime);
+        $eventData['time'] = '';
 
         $event = new TransformEventForFeedEvent($eventData, $feed, $pageModel, $request, $baseUrl);
 
@@ -266,7 +268,7 @@ class CalendarFeedListenerTest extends ContaoTestCase
 
         $item = $event->getItem();
 
-        $this->assertSame($title[1], $item->getTitle());
+        $this->assertSame(date('Y-m-d', $eventModel->startTime).' '.$title[1], $item->getTitle());
         $this->assertSame(1656578758, $item->getLastModified()->getTimestamp());
         $this->assertSame('https://example.org/news/example-title', $item->getLink());
         $this->assertSame('1cfcaaf3-79b2-515d-89aa-819773585f11', $item->getPublicId());


### PR DESCRIPTION
The old feed implementation put titles like these into the feed:

* 2025-07-22 Lorem ipsum
* 2025-07-22–2025-07-24 Lorem ipsum multi day
* 2025-07-22 (10:00) Lorem ipsum start time
* 2025-07-22 (10:00–12:00) Lorem ipsum start and end time

i.e. encoding the date and start and end date/times. The new implementation did not do that - this PR fixes that.