### PR TITLE
Add the missing autowiring alias for `FileDownloadHelper`

### DIFF
--- a/core-bundle/config/controller.yaml
+++ b/core-bundle/config/controller.yaml
@@ -78,11 +78,6 @@ services:
         arguments:
             - '@security.helper'
             - '@contao.filesystem.virtual.files'
-        tags:
-            - controller.service_arguments
-            - { name: container.service_subscriber, id: contao.filesystem.file_download_helper }
-            - { name: container.service_subscriber, id: contao.image.preview_factory }
-            - { name: container.service_subscriber, id: contao.image.studio }
 
     Contao\CoreBundle\Controller\ContentElement\ElementGroupController: ~
 

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1306,6 +1306,7 @@ services:
     Contao\CoreBundle\Csrf\ContaoCsrfTokenManager: '@contao.csrf.token_manager'
     Contao\CoreBundle\DataContainer\DcaUrlAnalyzer: '@contao.data_container.dca_url_analyzer'
     Contao\CoreBundle\Doctrine\Backup\DumperInterface: '@contao.doctrine.backup.dumper'
+    Contao\CoreBundle\Filesystem\FileDownloadHelper: '@contao.filesystem.file_download_helper'
     Contao\CoreBundle\Framework\ContaoFramework: '@contao.framework'
     Contao\CoreBundle\Image\ImageFactoryInterface: '@contao.image.factory'
     Contao\CoreBundle\Image\ImageSizes: '@contao.image.sizes'


### PR DESCRIPTION
Fixes #8596

If you have a content element like this:

```php
// src/Controller/ContentElement/ExampleElementController.php
namespace App\Controller\ContentElement;

use Contao\ContentModel;
use Contao\CoreBundle\Controller\ContentElement\AbstractDownloadContentElementController;
use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
use Contao\CoreBundle\Filesystem\FilesystemItemIterator;
use Contao\CoreBundle\Filesystem\VirtualFilesystemInterface;
use Contao\CoreBundle\Twig\FragmentTemplate;
use Symfony\Component\HttpFoundation\Request;
use Symfony\Component\HttpFoundation\Response;

#[AsContentElement(category: 'downloads')]
class ExampleElementController extends AbstractDownloadContentElementController
{
    public function __construct(
        private readonly VirtualFilesystemInterface $filesStorage,
    ) {
    }

    protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response
    {
        return $template->getResponse();
    }

    protected function getVirtualFilesystem(): VirtualFilesystemInterface
    {
        return $this->filesStorage;
    }

    protected function getFilesystemItems(Request $request, ContentModel $model): FilesystemItemIterator
    {
        return new FilesystemItemIterator([]);
    }
}
```

The following error will occur:

```
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException:
The service "contao.filesystem.file_download_helper" in the container provided to "App\Controller\ContentElement\ExampleElementController" has a dependency on a non-existent service "Contao\CoreBundle\Filesystem\FileDownloadHelper".

  at vendor\symfony\dependency-injection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass.php:119
```

This is because in our `AbstractDownloadContentElementController` we subscribe to `Contao\CoreBundle\Filesystem\FileDownloadHelper`:

https://github.com/contao/contao/blob/d8fbc988f40431da64724586fa2d0d9e860c6729/core-bundle/src/Controller/ContentElement/AbstractDownloadContentElementController.php#L46-L50

But such a service does not exist and thus the error occurs. For the Core's own download content elements this is fixed by adding `container.service_subscriber` service tags.

https://github.com/contao/contao/blob/d8fbc988f40431da64724586fa2d0d9e860c6729/core-bundle/config/controller.yaml#L77-L85

This PR fixes the issue by adding an autowiring alias for the `FileDownloadHelper`. This PR also removes the service tags from the `DownloadsController` as they are not necessary (or not necessary anymore).