### PR TITLE
Keep the ref parameter for Turbo requests

### DIFF
--- a/core-bundle/src/EventListener/RefererIdListener.php
+++ b/core-bundle/src/EventListener/RefererIdListener.php
@@ -46,7 +46,7 @@ class RefererIdListener
         $request = $event->getRequest();
 
         if (null === $this->token) {
-            if ($request->isXmlHttpRequest() && $request->query->has('ref')) {
+            if (($request->isXmlHttpRequest() || $request->headers->has('x-turbo-request-id')) && $request->query->has('ref')) {
                 $this->token = $request->query->get('ref');
             } else {
                 $this->token = $this->tokenGenerator->generateToken();

--- a/core-bundle/tests/EventListener/RefererIdListenerTest.php
+++ b/core-bundle/tests/EventListener/RefererIdListenerTest.php
@@ -104,6 +104,23 @@ class RefererIdListenerTest extends TestCase
         $this->assertSame('foobar', $request->attributes->get('_contao_referer_id'));
     }
 
+    public function testKeepsTheTokenForTurboRequests(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
+        $request->headers->set('x-turbo-request-id', '79a877bc-e328-4854-9225-0807256c4d70');
+        $request->query->set('ref', 'foobar');
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $listener = new RefererIdListener($this->mockTokenGenerator(), $this->mockScopeMatcher());
+        $listener($event);
+
+        $this->assertTrue($request->attributes->has('_contao_referer_id'));
+        $this->assertSame('foobar', $request->attributes->get('_contao_referer_id'));
+    }
+
     private function mockTokenGenerator(): TokenGeneratorInterface&MockObject
     {
         $tokenGenerator = $this->createMock(TokenGeneratorInterface::class);


### PR DESCRIPTION
For Turbo requests we want to keep the `ref` identical for the same tab.