### PR TITLE
Rename the `attr()` function to `attrs()`

### DIFF
--- a/core-bundle/contao/library/Contao/TemplateTrait.php
+++ b/core-bundle/contao/library/Contao/TemplateTrait.php
@@ -138,7 +138,7 @@ trait TemplateTrait
 	 */
 	public function attr(HtmlAttributes|iterable|string|null $attributes = null): HtmlAttributes
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use "attrs()" instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "$this->attr()" in templates is deprecated and will no longer work in Contao 6. Use "$this->attrs()" instead.');
 
 		return $this->attrs($attributes);
 	}

--- a/core-bundle/contao/library/Contao/TemplateTrait.php
+++ b/core-bundle/contao/library/Contao/TemplateTrait.php
@@ -132,8 +132,21 @@ trait TemplateTrait
 
 	/**
 	 * @param iterable<string, string|int|bool|\Stringable|null>|string|self|null $attributes
+	 *
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 *             use attrs() instead.
 	 */
 	public function attr(HtmlAttributes|iterable|string|null $attributes = null): HtmlAttributes
+	{
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use "attrs()" instead.', __METHOD__);
+
+		return $this->attrs($attributes);
+	}
+
+	/**
+	 * @param iterable<string, string|int|bool|\Stringable|null>|string|self|null $attributes
+	 */
+	public function attrs(HtmlAttributes|iterable|string|null $attributes = null): HtmlAttributes
 	{
 		return new HtmlAttributes($attributes);
 	}

--- a/core-bundle/tests/Twig/FragmentTemplateTest.php
+++ b/core-bundle/tests/Twig/FragmentTemplateTest.php
@@ -95,6 +95,7 @@ class FragmentTemplateTest extends TestCase
             'cspInlineStyles',
             'nonce',
             'attr',
+            'attrs',
         ];
 
         $parent = (new \ReflectionClass(FragmentTemplate::class))->getParentClass();


### PR DESCRIPTION
### Description

As mentioned by @fritzmg, the `attr` function should have been called `attrs` to match the twig function name.
Thus this PR:
* deprecates `attr()`
* implements `attrs()`
