### PR TITLE
Fix a wrong Swiper option

### DIFF
--- a/core-bundle/src/Controller/ContentElement/SwiperController.php
+++ b/core-bundle/src/Controller/ContentElement/SwiperController.php
@@ -25,7 +25,7 @@ class SwiperController extends AbstractContentElementController
     {
         $sliderSettings = [
             'speed' => (float) $model->sliderSpeed,
-            'offset' => $model->sliderStartSlide,
+            'initialSlide' => $model->sliderStartSlide,
             'loop' => $model->sliderContinuous,
         ];
 

--- a/core-bundle/tests/Controller/ContentElement/SwiperControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/SwiperControllerTest.php
@@ -49,7 +49,7 @@ class SwiperControllerTest extends ContentElementTestCase
 
         $expectedJson = htmlspecialchars(json_encode([
             'speed' => 300,
-            'offset' => 0,
+            'initialSlide' => 0,
             'loop' => true,
             'autoplay' => [
                 'delay' => 1000,


### PR DESCRIPTION
The `offset` option doesn't exist in Swiper, changed it to `initialSlide`