### PR TITLE
Remove the `ClipboardManager` class constant

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -6812,7 +6812,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 	protected function getClipboardPermission(string $mode, int $id, array|null $new = null): array
 	{
-		if (ClipboardManager::MODE_CREATE === $mode)
+		if ('create' === $mode)
 		{
 			$parent = array('pid' => $id);
 


### PR DESCRIPTION
The `ClipboardManager` class has only been added in Contao 5.5 or 5.6. So this must be fixed in 5.3 but changed again on upstream merge.

see https://github.com/contao/contao/pull/8572