### PR TITLE
Remove a superfluous `"` in the `data-action` attribute of the `be_main` template

### DIFF
--- a/core-bundle/contao/templates/backend/be_main.html5
+++ b/core-bundle/contao/templates/backend/be_main.html5
@@ -14,7 +14,7 @@ $this->bodyAttributes = $this
     ->addClass('be_main')
     ->addClass('popup', $this->isPopup)
     ->set('data-controller', 'contao--tooltips')
-    ->set('data-action', '"touchstart@document->contao--tooltips#touchStart')
+    ->set('data-action', 'touchstart@document->contao--tooltips#touchStart')
     ->mergeWith($this->bodyAttributes)
 ;
 


### PR DESCRIPTION
There is a superfluous `"` which causes the listener to be bound on the `"touchstart` event, which obviously does not exist.
This problem only affects 5.6.
Actually I don't even notice a difference and don't know exactly what problems this causes, but it's definitely wrong 😅 