### PR TITLE
Remove `aria-hidden` on drag handles

### DIFF
--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -146,7 +146,7 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 			'drag' => array
 			(
 				'icon'                => 'drag.svg',
-				'attributes'          => 'class="drag-handle" aria-hidden="true"',
+				'attributes'          => 'class="drag-handle"',
 				'primary'             => true,
 				'button_callback'     => array('tl_files', 'dragFile')
 			)

--- a/core-bundle/contao/dca/tl_form_field.php
+++ b/core-bundle/contao/dca/tl_form_field.php
@@ -550,7 +550,7 @@ class tl_form_field extends Backend
 		if (!Input::get('act') && System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::DC_PREFIX . 'tl_form_field', new UpdateAction('tl_form_field', $arrRow)))
 		{
 			$labelCut = $GLOBALS['TL_LANG']['tl_form_field']['cut'] ?? $GLOBALS['TL_LANG']['DCA']['cut'];
-			$dragHandle = '<button type="button" class="drag-handle" aria-hidden="true">' . Image::getHtml('drag.svg', sprintf(is_array($labelCut) ? $labelCut[1] : $labelCut, $arrRow['id'])) . '</button>';
+			$dragHandle = '<button type="button" class="drag-handle">' . Image::getHtml('drag.svg', sprintf(is_array($labelCut) ? $labelCut[1] : $labelCut, $arrRow['id'])) . '</button>';
 		}
 
 		$strType = '

--- a/core-bundle/contao/dca/tl_templates.php
+++ b/core-bundle/contao/dca/tl_templates.php
@@ -103,7 +103,7 @@ $GLOBALS['TL_DCA']['tl_templates'] = array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_files']['cut'],
 				'icon'                => 'drag.svg',
-				'attributes'          => 'class="drag-handle" aria-hidden="true"',
+				'attributes'          => 'class="drag-handle"',
 				'primary'             => true,
 				'button_callback'     => array('tl_templates', 'dragFile')
 			)

--- a/core-bundle/contao/templates/twig/backend/widget/checkbox_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/checkbox_wizard.html.twig
@@ -41,7 +41,6 @@
                 {% set drag_handle_attributes = attrs()
                     .set('type', 'button')
                     .set('data-action', 'keydown->contao--sortable#move')
-                    .set('aria-hidden', 'true')
                     .addClass('drag-handle')
                 %}
                 <button{{ drag_handle_attributes}}>{{ backend_icon('drag.svg', 'MSC.move'|trans) }}</button>

--- a/core-bundle/contao/templates/twig/backend/widget/key_value_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/key_value_wizard.html.twig
@@ -22,7 +22,6 @@
                     {% set drag_handle_attributes = attrs()
                         .set('type', 'button')
                         .set('data-action', 'keydown->contao--sortable#move')
-                        .set('aria-hidden', 'true')
                         .addClass('drag-handle')
                     %}
                     <button{{ drag_handle_attributes}}>{{ backend_icon('drag.svg', 'MSC.move'|trans) }}</button>

--- a/core-bundle/contao/templates/twig/backend/widget/list_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/list_wizard.html.twig
@@ -17,7 +17,6 @@
             {% set drag_handle_attributes = attrs()
                 .set('type', 'button')
                 .set('data-action', 'keydown->contao--sortable#move')
-                .set('aria-hidden', 'true')
                 .addClass('drag-handle')
             %}
             <button{{ drag_handle_attributes}}>{{ backend_icon('drag.svg', 'MSC.move'|trans) }}</button>

--- a/core-bundle/contao/templates/twig/backend/widget/module_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/module_wizard.html.twig
@@ -22,7 +22,6 @@
                     {% set drag_handle_attributes = attrs()
                         .set('type', 'button')
                         .set('data-action', 'keydown->contao--sortable#move')
-                        .set('aria-hidden', 'true')
                         .addClass('drag-handle')
                     %}
                     <button{{ drag_handle_attributes}}>{{ backend_icon('drag.svg', 'MSC.move'|trans) }}</button>

--- a/core-bundle/contao/templates/twig/backend/widget/option_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/option_wizard.html.twig
@@ -24,7 +24,6 @@
                     {% set drag_handle_attributes = attrs()
                         .set('type', 'button')
                         .set('data-action', 'keydown->contao--sortable#move')
-                        .set('aria-hidden', 'true')
                         .addClass('drag-handle')
                     %}
                     <button{{ drag_handle_attributes}}>{{ backend_icon('drag.svg', 'MSC.move'|trans) }}</button>

--- a/core-bundle/contao/templates/twig/backend/widget/section_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/section_wizard.html.twig
@@ -24,7 +24,6 @@
                     {% set drag_handle_attributes = attrs()
                         .set('type', 'button')
                         .set('data-action', 'keydown->contao--sortable#move')
-                        .set('aria-hidden', 'true')
                         .addClass('drag-handle')
                     %}
                     <button{{ drag_handle_attributes}}>{{ backend_icon('drag.svg', 'MSC.move'|trans) }}</button>

--- a/core-bundle/contao/widgets/TableWizard.php
+++ b/core-bundle/contao/widgets/TableWizard.php
@@ -130,7 +130,7 @@ class TableWizard extends Widget
 			{
 				if ($button == 'rdrag')
 				{
-					$return .= ' <button type="button" class="drag-handle" aria-hidden="true">' . Image::getHtml('drag.svg', $GLOBALS['TL_LANG']['MSC']['move']) . '</button>';
+					$return .= ' <button type="button" class="drag-handle">' . Image::getHtml('drag.svg', $GLOBALS['TL_LANG']['MSC']['move']) . '</button>';
 				}
 				else
 				{

--- a/faq-bundle/contao/dca/tl_faq.php
+++ b/faq-bundle/contao/dca/tl_faq.php
@@ -365,7 +365,7 @@ class tl_faq extends Backend
 		if (!Input::get('act') && System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::DC_PREFIX . 'tl_faq', new UpdateAction('tl_faq', $arrRow)))
 		{
 			$labelCut = $GLOBALS['TL_LANG']['tl_faq']['cut'] ?? $GLOBALS['TL_LANG']['DCA']['cut'];
-			$dragHandle = '<button type="button" class="drag-handle" aria-hidden="true">' . Image::getHtml('drag.svg', sprintf(is_array($labelCut) ? $labelCut[1] : $labelCut, $arrRow['id'])) . '</button>';
+			$dragHandle = '<button type="button" class="drag-handle">' . Image::getHtml('drag.svg', sprintf(is_array($labelCut) ? $labelCut[1] : $labelCut, $arrRow['id'])) . '</button>';
 		}
 
 		return '


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/8453

I would suggest to fix this in 5.6+ only since there will be a lot of upstream conflicts and its more like a "accessibility optimization" to me (similar to https://github.com/contao/contao/pull/8613).