### PR TITLE
Fall back to the label if an operation has no title

### DIFF
--- a/core-bundle/contao/templates/twig/backend/data_container/operations.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/operations.html.twig
@@ -52,7 +52,7 @@
                     {% if operation.method != 'POST' %}<input type="hidden" name="_method" value="{{ operation.method }}">{% endif %}
                     <input type="hidden" name="REQUEST_TOKEN" value="{{ contao.request_token }}">
                     <button type="submit"{{ operation_attributes }}>
-                        {% if operation.icon|default %}{{ backend_icon(operation.icon, (menu or showLabels) ? '' : operation.title|default, operation.iconAttributes|default(null)) }}{% endif %}
+                        {% if operation.icon|default %}{{ backend_icon(operation.icon, (menu or showLabels) ? '' : operation.title|default(operation.label|default), operation.iconAttributes|default(null)) }}{% endif %}
                         {% if menu or showLabels %}{{ operation.label|default }}{% endif %}
                     </button>
                 </form>
@@ -61,14 +61,14 @@
                     .set('href', operation.href)
                 %}
                 <a{{ operation_attributes }}>
-                    {% if operation.icon|default %}{{ backend_icon(operation.icon, (menu or showLabels) ? '' : operation.title|default, operation.iconAttributes|default(null)) }}{% endif %}
+                    {% if operation.icon|default %}{{ backend_icon(operation.icon, (menu or showLabels) ? '' : operation.title|default(operation.label|default), operation.iconAttributes|default(null)) }}{% endif %}
                     {% if menu or showLabels %}{{ operation.label|default }}{% endif %}
                 </a>
             {% endif %}
         </li>
     {% elseif operation.icon|default and not menu %}
         <li{% if addSeparator %} class="separator"{% endif %}>
-            {{ backend_icon(operation.icon, operation.title|default, operation.iconAttributes|default(null)) }}
+            {{ backend_icon(operation.icon, (menu or showLabels) ? '' : operation.title|default(operation.label|default), operation.iconAttributes|default(null)) }}
             {% if menu or showLabels %}{{ operation.label|default }}{% endif %}
         </li>
     {% endif %}


### PR DESCRIPTION
Every operation should have a label, but not necessarily a title. If we are not a menu (do not show the label), we should use the label as a fallback for the title.