### PR TITLE
Improve the root page error message

### DIFF
--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -1071,7 +1071,7 @@ class PageModel extends Model
 			{
 				System::getContainer()->get('monolog.logger.contao.error')->error('Page ID "' . $this->id . '" does not belong to a root page');
 
-				throw new NoRootPageFoundException('No root page found');
+				throw new NoRootPageFoundException('Page ID "' . $this->id . '" does not belong to a root page');
 			}
 		}
 


### PR DESCRIPTION
If the current exception is logged somewhere, we have no way of knowing what page caused the exception.