### PR TITLE
Correctly load the DCA labels for excluded fields

### DIFF
--- a/core-bundle/contao/dca/tl_user_group.php
+++ b/core-bundle/contao/dca/tl_user_group.php
@@ -398,6 +398,11 @@ class tl_user_group extends Backend
 
 					if (DataContainer::isFieldExcluded($k, $kk))
 					{
+						if (!$vv['label'])
+						{
+							$vv['label'] = &$GLOBALS['TL_LANG'][$k][$kk];
+						}
+
 						$arrReturn[$k][StringUtil::specialchars($k . '::' . $kk)] = isset($vv['label'][0]) ? $vv['label'][0] . ' <span class="label-info">[' . $kk . ']</span>' : $kk;
 					}
 				}


### PR DESCRIPTION
<img width="2486" height="298" alt="Bildschirmfoto 2025-08-05 um 10 57 53" src="https://github.com/user-attachments/assets/9769de48-229c-4eda-abd8-74617ccc15f9" />

Custom fields (without defined label) are not translated in the user group edit view.
