### PR TITLE
Fix the record fallback label

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -49,9 +49,16 @@ class FallbackRecordLabelListener
             $event->setLabel(trim(StringUtil::decodeEntities(strip_tags((string) $label))));
         } else {
             $messageDomain = "contao_$table";
-            $labelKey = $this->translator->getCatalogue()->has("$table.edit", $messageDomain) ? "$table.edit" : 'DCA.edit';
 
-            $event->setLabel($this->translator->trans($labelKey, [$event->getData()['id']], $messageDomain));
+            if ($this->translator->getCatalogue()->has("$table.edit.1", $messageDomain)) {
+                $label = $this->translator->trans("$table.edit.1", [$event->getData()['id']], $messageDomain);
+            } elseif ($this->translator->getCatalogue()->has("$table.edit", $messageDomain)) {
+                $label = $this->translator->trans("$table.edit", [$event->getData()['id']], $messageDomain);
+            } else {
+                $label = $this->translator->trans('DCA.edit.1', [$event->getData()['id']], 'contao_default');
+            }
+
+            $event->setLabel($label);
         }
     }
 }

--- a/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
@@ -48,7 +48,7 @@ class FallbackRecordLabelListenerTest extends TestCase
         $catalogue = $this->createMock(MessageCatalogueInterface::class);
         $catalogue
             ->method('has')
-            ->with('tl_foo.edit', 'contao_tl_foo')
+            ->with('tl_foo.edit.1', 'contao_tl_foo')
             ->willReturn(true)
         ;
 
@@ -62,7 +62,7 @@ class FallbackRecordLabelListenerTest extends TestCase
         $translator
             ->expects($this->once())
             ->method('trans')
-            ->with('tl_foo.edit', [123], 'contao_tl_foo')
+            ->with('tl_foo.edit.1', [123], 'contao_tl_foo')
             ->willReturn('Edit 123')
         ;
 


### PR DESCRIPTION
The labels have been renamed in https://github.com/contao/contao/pull/8576. But pretty sure the `DCA.edit` fallback didn't work before either.