### PR TITLE
Output the global data for additional head/body content in layout pages

### DIFF
--- a/core-bundle/contao/templates/twig/page/regular.html.twig
+++ b/core-bundle/contao/templates/twig/page/regular.html.twig
@@ -27,7 +27,11 @@
     {% endblock %}
 
     {% block end_of_body %}
-        {{ response_context.jsonLdScripts|default|raw }}
+        {% for element in response_context.end_of_body %}
+            {{ element|raw }}
+        {% endfor %}
+
+        {{ response_context.json_ld_sripts|default|raw }}
     {% endblock %}
 {% endblock %}
 
@@ -43,4 +47,10 @@
     {% if page['enableCanonical'] %}
         <link rel="canonical" href="{{ head_bag.canonicalUriForRequest(app.request) }}">
     {% endif %}
+
+    {% block end_of_head %}
+        {% for element in response_context.end_of_head %}
+            {{ element|raw }}
+        {% endfor %}
+    {% endblock %}
 {% endblock %}

--- a/core-bundle/src/Controller/Page/AbstractLayoutPageController.php
+++ b/core-bundle/src/Controller/Page/AbstractLayoutPageController.php
@@ -108,16 +108,24 @@ abstract class AbstractLayoutPageController extends AbstractController
 
             public function __get(string $key): mixed
             {
-                if ($this->data instanceof \Closure) {
-                    $this->data = ($this->data)();
-                }
-
-                return $this->data[$key] ?? null;
+                return $this->toArray()[$key] ?? null;
             }
 
             public function __isset(string $key): bool
             {
                 return null !== $this->__get($key);
+            }
+
+            /**
+             * @interal
+             */
+            public function toArray(): array
+            {
+                if ($this->data instanceof \Closure) {
+                    $this->data = ($this->data)();
+                }
+
+                return $this->data;
             }
         });
 
@@ -158,7 +166,9 @@ abstract class AbstractLayoutPageController extends AbstractController
     {
         return [
             'head' => $responseContext->get(HtmlHeadBag::class),
-            'jsonLdScripts' => $responseContext->isInitialized(JsonLdManager::class)
+            'end_of_head' => [...$GLOBALS['TL_STYLE_SHEETS'] ?? [], ...$GLOBALS['TL_HEAD'] ?? []],
+            'end_of_body' => $GLOBALS['TL_BODY'] ?? [],
+            'json_ld_scripts' => $responseContext->isInitialized(JsonLdManager::class)
                 ? $responseContext->get(JsonLdManager::class)->collectFinalScriptFromGraphs()
                 : null,
         ];

--- a/core-bundle/tests/Controller/Page/AbstractLayoutPageControllerTest.php
+++ b/core-bundle/tests/Controller/Page/AbstractLayoutPageControllerTest.php
@@ -42,6 +42,7 @@ class AbstractLayoutPageControllerTest extends TestCase
             $GLOBALS['TL_HEAD'],
             $GLOBALS['TL_BODY'],
             $GLOBALS['TL_STYLE_SHEETS'],
+            $GLOBALS['TL_CSS'],
         );
 
         $this->resetStaticProperties([System::class]);
@@ -67,6 +68,7 @@ class AbstractLayoutPageControllerTest extends TestCase
         $GLOBALS['TL_HEAD'][] = '<meta content="additional-tag">';
         $GLOBALS['TL_BODY'][] = '<script>/* additional script */</script>';
         $GLOBALS['TL_STYLE_SHEETS'][] = '<link rel="stylesheet" href="additional_stylesheet.css">';
+        $GLOBALS['TL_CSS'][] = 'additional_stylesheet_filename.css|123';
 
         $response = $layoutPageController(new Request());
 
@@ -90,6 +92,7 @@ class AbstractLayoutPageControllerTest extends TestCase
                 'response_context' => [
                     'head' => [],
                     'end_of_head' => [
+                        '<link rel="stylesheet" href="/additional_stylesheet_filename.css?v=202cb962">',
                         '<link rel="stylesheet" href="additional_stylesheet.css">',
                         '<meta content="additional-tag">',
                     ],

--- a/core-bundle/tests/Fixtures/src/Controller/Page/LayoutPageController.php
+++ b/core-bundle/tests/Fixtures/src/Controller/Page/LayoutPageController.php
@@ -42,7 +42,7 @@ class LayoutPageController extends AbstractLayoutPageController
         $data = $template->getData();
 
         // The response context is evaluated lazily on access
-        $data['response_context'] = $template->getData()['response_context']->toArray();
+        $data['response_context'] = iterator_to_array($template->getData()['response_context']->all());
 
         return new JsonResponse([...$data, 'templateName' => $template->getName()]);
     }

--- a/core-bundle/tests/Fixtures/src/Controller/Page/LayoutPageController.php
+++ b/core-bundle/tests/Fixtures/src/Controller/Page/LayoutPageController.php
@@ -23,8 +23,27 @@ use Symfony\Component\HttpFoundation\Response;
 #[AsPage]
 class LayoutPageController extends AbstractLayoutPageController
 {
+    /**
+     * @template T
+     *
+     * @param class-string<T> $serviceId
+     *
+     * @return T
+     */
+    public function getResponseContextService(string $serviceId)
+    {
+        $page = $this->container->get('contao.routing.page_finder')->getCurrentPage();
+
+        return parent::getResponseContext($page)->get($serviceId);
+    }
+
     protected function getResponse(LayoutTemplate $template, LayoutModel $model, Request $request): Response
     {
-        return new JsonResponse([...$template->getData(), 'templateName' => $template->getName()]);
+        $data = $template->getData();
+
+        // The response context is evaluated lazily on access
+        $data['response_context'] = $template->getData()['response_context']->toArray();
+
+        return new JsonResponse([...$data, 'templateName' => $template->getName()]);
     }
 }


### PR DESCRIPTION
Fixes #8632 

This makes sure data from `$GLOBALS['TL_BODY']`,  `$GLOBALS['TL_HEAD']` and `$GLOBALS['TL_STYLE_SHEETS']` is still being output for modern layouts.