### PR TITLE
Fix undefined array key `$parentPath` within `$allUuidsByPath`

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -537,7 +537,7 @@ class Dbafs implements DbafsInterface, ResetInterface
                 return null;
             }
 
-            return $allUuidsByPath[$parentPath];
+            return $allUuidsByPath[$parentPath] ?? null;
         };
 
         $allLastModifiedUpdatesByPath = [];


### PR DESCRIPTION
### Description

I could not reproduce this in 5.3 but it comes very apparent when trying to drag folders in #8548 with debug mode enabled 🤔 .
