### PR TITLE
Fix an SQL error when disabling subscribed members

### DIFF
--- a/newsletter-bundle/contao/classes/Newsletter.php
+++ b/newsletter-bundle/contao/classes/Newsletter.php
@@ -964,7 +964,7 @@ class Newsletter extends Backend
 				{
 					$db
 						->prepare("UPDATE tl_newsletter_recipients SET active=? WHERE email=?")
-						->execute(Input::post('disable') ? '' : 1, $objUser->email);
+						->execute(Input::post('disable') ? 0 : 1, $objUser->email);
 
 					$objUser->disable = Input::post('disable');
 				}


### PR DESCRIPTION
If you set a member that is subscribed to a newsletter to disabled, the following error will occur:

```
PDOException:
SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `c53`.`tl_newsletter_recipients`.`active` at row 1

  at vendor\doctrine\dbal\src\Driver\PDO\Statement.php:130
  at PDOStatement->execute()
     (vendor\doctrine\dbal\src\Driver\PDO\Statement.php:130)
  at Doctrine\DBAL\Driver\PDO\Statement->execute()
     (vendor\doctrine\dbal\src\Driver\Middleware\AbstractStatementMiddleware.php:69)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute()
     (vendor\doctrine\dbal\src\Logging\Statement.php:98)
  at Doctrine\DBAL\Logging\Statement->execute()
     (vendor\doctrine\dbal\src\Driver\Middleware\AbstractStatementMiddleware.php:69)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute()
     (vendor\symfony\doctrine-bridge\Middleware\Debug\DBAL3\Statement.php:70)
  at Symfony\Bridge\Doctrine\Middleware\Debug\DBAL3\Statement->execute()
     (vendor\doctrine\dbal\src\Connection.php:1104)
  at Doctrine\DBAL\Connection->executeQuery()
     (vendor\contao\contao\core-bundle\contao\library\Contao\Database\Statement.php:261)
  at Contao\Database\Statement->query()
     (vendor\contao\contao\core-bundle\contao\library\Contao\Database\Statement.php:218)
  at Contao\Database\Statement->execute()
     (vendor\contao\contao\newsletter-bundle\contao\classes\Newsletter.php:967)
  at Contao\Newsletter->updateAccount()
     (vendor\contao\contao\core-bundle\contao\drivers\DC_Table.php:225)
```