### PR TITLE
Allow version 2 of `guzzlehttp/promises`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "enshrined/svg-sanitize": "^0.21",
         "friendsofsymfony/http-cache": "^2.15.1",
         "friendsofsymfony/http-cache-bundle": "^2.6",
-        "guzzlehttp/promises": "^1.5",
+        "guzzlehttp/promises": "^1.5 || ^2.0",
         "imagine/imagine": "^1.2.4",
         "knplabs/knp-menu": "^3.1",
         "knplabs/knp-menu-bundle": "^3.0",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -72,7 +72,7 @@
         "enshrined/svg-sanitize": "^0.21",
         "friendsofsymfony/http-cache": "^2.15.1",
         "friendsofsymfony/http-cache-bundle": "^2.6",
-        "guzzlehttp/promises": "^1.5",
+        "guzzlehttp/promises": "^1.5 || ^2.0",
         "imagine/imagine": "^1.2.4",
         "knplabs/knp-menu": "^3.1",
         "knplabs/knp-menu-bundle": "^3.0",


### PR DESCRIPTION
Fixes #8188

Enables support for PHP 8.4

<img width="836" height="392" alt="Bildschirmfoto 2025-08-12 um 08 46 39" src="https://github.com/user-attachments/assets/2ca18ba3-cd17-45d6-a6d9-63002197e824" />

https://github.com/guzzle/promises#version-guidance