### PR TITLE
Fix a typo in `page/regular.html.twig`

### DIFF
--- a/core-bundle/contao/templates/twig/page/regular.html.twig
+++ b/core-bundle/contao/templates/twig/page/regular.html.twig
@@ -31,7 +31,7 @@
             {{ element|raw }}
         {% endfor %}
 
-        {{ response_context.json_ld_sripts|default|raw }}
+        {{ response_context.json_ld_scripts|default|raw }}
     {% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
Causes the JSON-LD not being output, as mentioned in #8659 
