### PR TITLE
Do not make the new Twig layouts the default

### DIFF
--- a/core-bundle/contao/dca/tl_layout.php
+++ b/core-bundle/contao/dca/tl_layout.php
@@ -103,10 +103,9 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 		'type' => array
 		(
 			'inputType'               => 'select',
-			'options'                 => array('modern', 'default'),
+			'options'                 => array('default', 'modern'),
 			'reference'               => &$GLOBALS['TL_LANG']['tl_layout'],
 			'eval'                    => array('tl_class'=>'w50', 'submitOnChange'=>true),
-			'default'                 => 'modern',
 			'sql'                     => array('type'=>'string', 'length'=>7, 'default'=>'default')
 		),
 		'rows' => array

--- a/core-bundle/contao/languages/en/tl_layout.xlf
+++ b/core-bundle/contao/languages/en/tl_layout.xlf
@@ -333,7 +333,7 @@
         <source>Twig layout with slots</source>
       </trans-unit>
       <trans-unit id="tl_layout.default">
-        <source>Legacy HTML5 layout</source>
+        <source>Default layout</source>
       </trans-unit>
       <trans-unit id="tl_layout.html5">
         <source>HTML</source>


### PR DESCRIPTION
Since the new Twig layouts are still experimental, we should not make them the default.

Also, we should not call the default layout _HTML5 layout_ because technically the new Twig layouts are HTML5, too. Therefore I have named it _Default layout_ now and once the Twig layouts are stable, we can rename it to _Legacy layout_.