### PR TITLE
Initialize the clock in the 2FA authenticator

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1059,6 +1059,8 @@ services:
     contao.security.two_factor.authenticator:
         class: Contao\CoreBundle\Security\TwoFactor\Authenticator
         public: true
+        arguments:
+            - '@clock'
 
     contao.security.two_factor.backup_code_manager:
         class: Contao\CoreBundle\Security\TwoFactor\BackupCodeManager

--- a/core-bundle/src/Security/TwoFactor/Authenticator.php
+++ b/core-bundle/src/Security/TwoFactor/Authenticator.php
@@ -31,6 +31,8 @@ class Authenticator
      */
     public function validateCode(User $user, string $code, int|null $timestamp = null): bool
     {
+        $this->now();
+
         $totp = TOTP::create($this->getUpperUnpaddedSecretForUser($user), clock: $this->clock);
 
         return $totp->verify($code, $timestamp, 1);

--- a/core-bundle/src/Security/TwoFactor/Authenticator.php
+++ b/core-bundle/src/Security/TwoFactor/Authenticator.php
@@ -19,20 +19,20 @@ use BaconQrCode\Writer;
 use Contao\User;
 use OTPHP\TOTP;
 use ParagonIE\ConstantTime\Base32;
-use Symfony\Component\Clock\ClockAwareTrait;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\HttpFoundation\Request;
 
 class Authenticator
 {
-    use ClockAwareTrait;
+    public function __construct(private readonly Clock $clock)
+    {
+    }
 
     /**
      * Validates the code which was entered by the user.
      */
     public function validateCode(User $user, string $code, int|null $timestamp = null): bool
     {
-        $this->now();
-
         $totp = TOTP::create($this->getUpperUnpaddedSecretForUser($user), clock: $this->clock);
 
         return $totp->verify($code, $timestamp, 1);

--- a/core-bundle/src/Security/TwoFactor/Authenticator.php
+++ b/core-bundle/src/Security/TwoFactor/Authenticator.php
@@ -19,12 +19,12 @@ use BaconQrCode\Writer;
 use Contao\User;
 use OTPHP\TOTP;
 use ParagonIE\ConstantTime\Base32;
-use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class Authenticator
 {
-    public function __construct(private readonly Clock $clock)
+    public function __construct(private readonly ClockInterface $clock)
     {
     }
 

--- a/core-bundle/tests/Security/TwoFactor/AuthenticatorTest.php
+++ b/core-bundle/tests/Security/TwoFactor/AuthenticatorTest.php
@@ -44,8 +44,7 @@ class AuthenticatorTest extends TestCase
         $user = $this->mockClassWithProperties(BackendUser::class);
         $user->secret = $secret;
 
-        $authenticator = new Authenticator();
-        $authenticator->setClock($clock);
+        $authenticator = new Authenticator($clock);
 
         $this->assertTrue($authenticator->validateCode($user, $totp->now()));
         $this->assertFalse($authenticator->validateCode($user, 'foobar'));
@@ -64,8 +63,7 @@ class AuthenticatorTest extends TestCase
         $user = $this->mockClassWithProperties(BackendUser::class);
         $user->secret = $secret;
 
-        $authenticator = new Authenticator();
-        $authenticator->setClock($clock);
+        $authenticator = new Authenticator($clock);
 
         $this->assertTrue($authenticator->validateCode($user, $totp->at($now), $now));
         $this->assertTrue($authenticator->validateCode($user, $totp->at($beforeNow), $now));
@@ -75,6 +73,7 @@ class AuthenticatorTest extends TestCase
 
     public function testGeneratesTheProvisionUri(): void
     {
+        $clock = new MockClock('2025-08-12 08:24:00');
         $secret = $this->generateSecret(3);
 
         $user = $this->mockClassWithProperties(BackendUser::class);
@@ -93,7 +92,7 @@ class AuthenticatorTest extends TestCase
             ->willReturn('example.com')
         ;
 
-        $authenticator = new Authenticator();
+        $authenticator = new Authenticator($clock);
 
         $this->assertSame(
             \sprintf(
@@ -119,6 +118,7 @@ class AuthenticatorTest extends TestCase
             <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="180" height="180" viewBox="0 0 180 180"><rect x="0" y="0" width="180" height="180" fill="#fefefe"/>
             SVG;
 
+        $clock = new MockClock('2025-08-12 08:24:00');
         $user = $this->mockClassWithProperties(BackendUser::class);
         $user->secret = 'foobar';
 
@@ -135,7 +135,7 @@ class AuthenticatorTest extends TestCase
             ->willReturn('example.com')
         ;
 
-        $authenticator = new Authenticator();
+        $authenticator = new Authenticator($clock);
         $svg = $authenticator->getQrCode($user, $request);
 
         $this->assertSame(5897, \strlen($svg));


### PR DESCRIPTION
### Description

Unfortunately #8652 that made it into the latest bugfix releases does break Two-Factor-Auth so people can not login into the backend anymore after updating:

<img width="577" height="369" alt="image" src="https://github.com/user-attachments/assets/e9549009-be84-4829-9872-f9c491ad218c" />

<img width="1058" height="559" alt="image" src="https://github.com/user-attachments/assets/02bb9c19-855b-48dc-bb09-cbfa958e9a73" />

This PR sets the clock so it is initialized (see ClockAwareTrait for reference):
```php
trait ClockAwareTrait
{
    private readonly ClockInterface $clock;

    #[Required]
    public function setClock(ClockInterface $clock): void
    {
        $this->clock = $clock;
    }

    /**
     * @return DatePoint
     */
    protected function now(): \DateTimeImmutable
    {
        $now = ($this->clock ??= new Clock())->now();

        return $now instanceof DatePoint ? $now : DatePoint::createFromInterface($now);
    }
}
```