### PR TITLE
Check for main request in the `PreviewToolbarListener`

### DIFF
--- a/core-bundle/src/EventListener/PreviewToolbarListener.php
+++ b/core-bundle/src/EventListener/PreviewToolbarListener.php
@@ -49,6 +49,10 @@ class PreviewToolbarListener
 
     public function __invoke(ResponseEvent $event): void
     {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
         $request = $event->getRequest();
         $response = $event->getResponse();
 


### PR DESCRIPTION
Small optimisation: our `PreviewToolbarListener` is currently missing an early out for sub requests of fragments. We only need to inject the toolbar into the HTML of the main request.