### PR TITLE
Only vote on `pid` and `ptable` for parent mode

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -6812,7 +6812,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 	protected function getClipboardPermission(string $mode, int $id, array|null $new = null): array
 	{
-		if ('create' === $mode)
+		if ('create' === $mode && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_PARENT)
 		{
 			$parent = array('pid' => $id);
 


### PR DESCRIPTION
Fixes #8671

The `pid` (and `ptable`) should only be passed in parent mode. All other modes do not have a known parent record for the global `create` action.