### PR TITLE
Fix the title tag in Twig layouts

### DIFF
--- a/core-bundle/contao/templates/twig/page/_html_boilerplate.html.twig
+++ b/core-bundle/contao/templates/twig/page/_html_boilerplate.html.twig
@@ -5,7 +5,7 @@
             <meta charset="UTF-8">
             <meta name="generator" content="Contao Open Source CMS">
             {% block title %}
-                {% if title is defined and title is not empty %}
+                {% if title|default %}
                     <title>{{ title }}</title>
                 {% endif %}
             {% endblock %}

--- a/core-bundle/contao/templates/twig/page/_html_boilerplate.html.twig
+++ b/core-bundle/contao/templates/twig/page/_html_boilerplate.html.twig
@@ -4,9 +4,11 @@
         {% block head %}
             <meta charset="UTF-8">
             <meta name="generator" content="Contao Open Source CMS">
-            {% if title is defined %}
-                <title>{{ title }}</title>
-            {% endif %}
+            {% block title %}
+                {% if title is defined %}
+                    <title>{{ title }}</title>
+                {% endif %}
+            {% endblock %}
         {% endblock %}
     </head>
     <body{{ body_attributes|default }}>

--- a/core-bundle/contao/templates/twig/page/_html_boilerplate.html.twig
+++ b/core-bundle/contao/templates/twig/page/_html_boilerplate.html.twig
@@ -5,7 +5,7 @@
             <meta charset="UTF-8">
             <meta name="generator" content="Contao Open Source CMS">
             {% block title %}
-                {% if title is defined %}
+                {% if title is defined and title is not empty %}
                     <title>{{ title }}</title>
                 {% endif %}
             {% endblock %}

--- a/core-bundle/contao/templates/twig/page/regular.html.twig
+++ b/core-bundle/contao/templates/twig/page/regular.html.twig
@@ -13,9 +13,11 @@
 %}
 
 {% block title %}
-    {% if head.title|default %}
-        <title>{{ head.title }}{% if contao.page.rootPageTitle|default %} - {{ contao.page.rootPageTitle }}{% endif %}</title>
+    {% set title = head.title|default %}
+    {% if title and contao.page.rootPageTitle|default %}
+        {% set title = title ~ ' - ' ~ contao.page.rootPageTitle %}
     {% endif %}
+    {{ parent() }}
 {% endblock %}
 
 {% block body %}

--- a/core-bundle/contao/templates/twig/page/regular.html.twig
+++ b/core-bundle/contao/templates/twig/page/regular.html.twig
@@ -12,6 +12,12 @@
     .mergeWith(body_attributes|default)
 %}
 
+{% block title %}
+    {% if head.title|default %}
+        <title>{{ head.title }}{% if contao.page.rootPageTitle|default %} - {{ contao.page.rootPageTitle }}{% endif %}</title>
+    {% endif %}
+{% endblock %}
+
 {% block body %}
     {% block body_content %}
         {% slot header %}


### PR DESCRIPTION
Fixes #8679

This adds a new `block` to our `_html_boilerplate` so that we can only adjust the `<title>`. For our Contao pages we want to restore the original _Page name - Root page name_ title style, which this PR adds to the `regular.html.twig`.

The new block then allows you to adjust the title style to your needs, e.g. if you want to have a `|` as the separator:

```twig
{# templates/page/regular.html.twig #}
{% extends "@Contao/page/regular.html.twig" %}

{% block title %}
    {% set title = head.title|default %}
    {% if title and contao.page.rootPageTitle|default %}
        {% set title = title ~ ' | ' ~ contao.page.rootPageTitle %}
    {% endif %}
    {{ parent() }}
{% endblock %}
```

The title is taken from the `HtmlHeadBag` which the `AbstractPageLayoutController` passes to the template in the `head` variable.
