### PR TITLE
Fix the invalid permission check in `tl_content`

### DIFF
--- a/core-bundle/src/DataContainer/DynamicPtableTrait.php
+++ b/core-bundle/src/DataContainer/DynamicPtableTrait.php
@@ -30,20 +30,16 @@ trait DynamicPtableTrait
     {
         // Limit to a nesting level of 10
         $records = $connection->fetchAllAssociative(
-            "SELECT id, @pid:=pid AS pid, ptable FROM $table WHERE id=:id".str_repeat(" UNION SELECT id, @pid:=pid AS pid, ptable FROM $table WHERE id=@pid AND ptable=:ptable", 9),
+            "SELECT id, @pid:=pid AS pid, ptable FROM $table WHERE id=:id AND ptable = :ptable".str_repeat(" UNION SELECT id, @pid:=pid AS pid, ptable FROM $table WHERE id=@pid AND ptable=:ptable", 9),
             ['id' => $id, 'ptable' => $table],
         );
 
+        // If we have no results, the given $id is the child of a record where ptable!=$table
+        // (e.g. only one element nested). Use this to find the parent below.
         if (!$records) {
-            throw new \RuntimeException(\sprintf('Parent record of %s.%s not found', $table, $id));
-        }
-
-        $record = end($records);
-
-        // If the given $id is the child of a record where ptable!=$table (e.g. only one
-        // element nested), $records will only have one result, and we can directly use it.
-        if ($record['ptable'] !== $table) {
-            return [$record['ptable'], (int) $record['pid']];
+            $record = ['ptable' => $table, 'pid' => $id];
+        } else {
+            $record = end($records);
         }
 
         // Trigger recursion in case our query returned exactly 10 records in which case
@@ -52,8 +48,8 @@ trait DynamicPtableTrait
             return $this->getParentTableAndId($connection, $table, (int) $record['pid']);
         }
 
-        // If we have more than 1 but less than 10 results, the last result in our array
-        // must be the first nested element, and its parent is what we are looking for.
+        // The nesting query always has ptable==$table, but we are looking for
+        // first the parent element that where ptable!=$table.
         $record = $connection->fetchAssociative(
             "SELECT id, pid, ptable FROM $table WHERE id=?",
             [$record['pid']],

--- a/core-bundle/src/DataContainer/DynamicPtableTrait.php
+++ b/core-bundle/src/DataContainer/DynamicPtableTrait.php
@@ -48,8 +48,8 @@ trait DynamicPtableTrait
             return $this->getParentTableAndId($connection, $table, (int) $record['pid']);
         }
 
-        // The nesting query always has ptable==$table, but we are looking for
-        // first the parent element that where ptable!=$table.
+        // The nesting query always has ptable==$table, but we are looking for first the
+        // parent element that where ptable!=$table.
         $record = $connection->fetchAssociative(
             "SELECT id, pid, ptable FROM $table WHERE id=?",
             [$record['pid']],


### PR DESCRIPTION
fixes https://github.com/contao/contao/issues/8674

The issue is that we do not check for the parent table of the current record, only for the UNION query. If the first record has a different ptable, the recursive relation check will continue to find content elements that are related to the pid of the first record. The `tl_content` database in the dump looks like this:

<table>
<tr>
<th>id</th>
<th>pid</th>
<th>ptable</th>
<th>type</th>
</tr>
<tr>
<td>1</td>
<td>1</td>
<td>tl_article</td>
<td>element_group</td>
</tr>
<tr>
<td>2</td>
<td>1</td>
<td>tl_content</td>
<td>text</td>
</tr>
<tr>
<td>3</td>
<td>2</td>
<td> tl_article </td>
<td>element_group</td>
</tr>
<tr>
<td>4</td>
<td>3</td>
<td>tl_content</td>
<td>text</td>
</tr>
</table>

The recursive query will load a result for `id=3` and recursive to `pid` of that record (PID 2), which will incorrectly return result ID 1, which will then incorrectly check permission on the parent of ID 1 (the article with ID 1).
By checking that the original record also has `ptable=$table`, we will not load any record from the database and only check for the parent of our current record.