### PR TITLE
Check undefined global `objPage`

### DIFF
--- a/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
+++ b/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
@@ -426,7 +426,7 @@ class LegacyInsertTag implements InsertTagResolverNestedResolvedInterface
             case 'page':
                 $property = $insertTag->getParameters()->get(0);
 
-                if ($GLOBALS['objPage']) {
+                if ($GLOBALS['objPage'] ?? null) {
                     if (!$GLOBALS['objPage']->parentPageTitle && 'parentPageTitle' === $property) {
                         $property = 'parentTitle';
                     } elseif (!$GLOBALS['objPage']->mainPageTitle && 'mainPageTitle' === $property) {
@@ -443,7 +443,7 @@ class LegacyInsertTag implements InsertTagResolverNestedResolvedInterface
                         'pageTitle' => htmlspecialchars($htmlHeadBag->getTitle(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5),
                         'description' => htmlspecialchars($htmlHeadBag->getMetaDescription(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5),
                     };
-                } elseif ($GLOBALS['objPage']) {
+                } elseif ($GLOBALS['objPage'] ?? null) {
                     // Do not use StringUtil::specialchars() here (see #4687)
                     if (!\in_array($property, ['title', 'parentTitle', 'mainTitle', 'rootTitle', 'pageTitle', 'parentPageTitle', 'mainPageTitle', 'rootPageTitle'], true)) {
                         $outputType = OutputType::text;


### PR DESCRIPTION
Using insert tags in templates and not having a specific `as_editor_view` causes php warnings, when the insert tag should be replaced with something from the `$objPage`.

PHP 8.4 only, discovered with sentry.io.

Edit: having `as_editor_view` does not help, the insert tag gets resolved anyway.