### PR TITLE
Use the attributes callback to initialize the layout template widget

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/ThemeLayoutListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ThemeLayoutListener.php
@@ -55,16 +55,17 @@ class ThemeLayoutListener
         return $value;
     }
 
-    #[AsCallback(table: 'tl_layout', target: 'fields.type.load')]
-    public function adjustFieldsForLegacyType(string $value, DataContainer $dc): string
+    #[AsCallback(table: 'tl_layout', target: 'fields.template.attributes')]
+    public function adjustFieldsForLegacyType(array $attributes, DataContainer $dc): array
     {
+        unset($attributes['unknownOption']);
+
         if ($this->isLegacy($dc)) {
-            $templateField = &$GLOBALS['TL_DCA']['tl_layout']['fields']['template'];
-            $templateField['eval']['mandatory'] = false;
-            $templateField['eval']['submitOnChange'] = false;
+            $attributes['mandatory'] = false;
+            $attributes['submitOnChange'] = false;
         }
 
-        return $value;
+        return $attributes;
     }
 
     private function isLegacy(DataContainer $dc): bool

--- a/core-bundle/src/EventListener/DataContainer/ThemeLayoutListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ThemeLayoutListener.php
@@ -58,14 +58,28 @@ class ThemeLayoutListener
     #[AsCallback(table: 'tl_layout', target: 'fields.template.attributes')]
     public function adjustFieldsForLegacyType(array $attributes, DataContainer $dc): array
     {
-        unset($attributes['unknownOption']);
-
         if ($this->isLegacy($dc)) {
             $attributes['mandatory'] = false;
             $attributes['submitOnChange'] = false;
         }
 
         return $attributes;
+    }
+
+    #[AsCallback(table: 'tl_layout', target: 'config.onbeforesubmit')]
+    public function resetTemplateForType(array $values, DataContainer $dc): array
+    {
+        if (!isset($values['type'])) {
+            return $values;
+        }
+
+        $current = $dc->getCurrentRecord();
+
+        if ($current['type'] !== $values['type']) {
+            $values['template'] = '';
+        }
+
+        return $values;
     }
 
     private function isLegacy(DataContainer $dc): bool


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/8683

unsetting the `unknownOption` will force a new selection because the field is invalid by default.