### PR TITLE
Add a higher priority to the `BooleanFieldsMigration`

### DIFF
--- a/core-bundle/config/migrations.yaml
+++ b/core-bundle/config/migrations.yaml
@@ -39,6 +39,9 @@ services:
             - '@database_connection'
             - '@contao.framework'
             - '@contao.resource_finder'
+        tags:
+            # Use a higher priority for the boolean fields migration (#8707)
+            - { name: contao.migration, priority: 1 }
 
     contao.migration.version_500.empty_ptable:
         class: Contao\CoreBundle\Migration\Version500\EmptyPtableMigration


### PR DESCRIPTION
See https://github.com/contao/contao/pull/8707#issuecomment-3200654602 https://github.com/contao/contao/pull/8707#issuecomment-3202305153

Should be added as a bugfix to Contao 5.3 imho, in case other migrations from extensions or the `App` also want to query any boolean fields with `= 1`.

Tested the change also in Contao 5.6 with a Contao 4.13 database 👍 
