### PR TITLE
Only duplicate fragment services if needed

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -36,11 +36,6 @@ class RegisterFragmentsPass implements CompilerPassInterface
 {
     use PriorityTaggedServiceTrait;
 
-    /**
-     * @var array<int, string>
-     */
-    private array $seenTagAndTypes = [];
-
     public function __construct(
         private readonly string|null $tag,
         private readonly string|null $globalsKey = null,
@@ -72,6 +67,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
         $templates = [];
         $registry = $container->findDefinition('contao.fragment.registry');
         $compositor = $container->findDefinition('contao.fragment.compositor');
+        $seenTagAndTypes = [];
 
         foreach ($this->findAndSortTaggedServices($tag, $container) as $reference) {
             // If a controller has multiple methods for different fragment types (e.g. a
@@ -106,12 +102,12 @@ class RegisterFragmentsPass implements CompilerPassInterface
                 }
 
                 // Can only have one service per tag and type (highest priority wins)
-                if (\in_array($identifier, $this->seenTagAndTypes, true)) {
+                if (\in_array($identifier, $seenTagAndTypes, true)) {
                     $controllerDefinition->clearTag($tag);
                     continue;
                 }
 
-                $this->seenTagAndTypes[] = $identifier;
+                $seenTagAndTypes[] = $identifier;
 
                 $controllerDefinition->setPublic(true);
                 $config = $this->getFragmentConfig($container, new Reference($serviceId), $attributes);

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -96,9 +96,11 @@ class RegisterFragmentsPass implements CompilerPassInterface
                     $serviceId = 'contao.fragment._'.$identifier;
                     $controllerDefinition = new ChildDefinition((string) $reference);
                     $controllerDefinition->setTags($definition->getTags());
+                    $controllerReference = new Reference($serviceId);
+                    $container->setDefinition($serviceId, $controllerDefinition);
                 } else {
-                    $serviceId = (string) $reference;
                     $controllerDefinition = $definition;
+                    $controllerReference = $reference;
                 }
 
                 // Can only have one service per tag and type (highest priority wins)
@@ -110,14 +112,14 @@ class RegisterFragmentsPass implements CompilerPassInterface
                 $seenTagAndTypes[] = $identifier;
 
                 $controllerDefinition->setPublic(true);
-                $config = $this->getFragmentConfig($container, new Reference($serviceId), $attributes);
+                $config = $this->getFragmentConfig($container, $controllerReference, $attributes);
 
                 $attributes['priority'] ??= 0;
                 $attributes['template'] ??= substr($tag, 7).'/'.$attributes['type'];
                 $templates[$attributes['type']] = $attributes['template'];
 
                 if (is_a($definition->getClass(), FragmentPreHandlerInterface::class, true)) {
-                    $preHandlers[$identifier] = new Reference($serviceId);
+                    $preHandlers[$identifier] = $controllerReference;
                 }
 
                 if (is_a($definition->getClass(), FragmentOptionsAwareInterface::class, true)) {
@@ -133,8 +135,6 @@ class RegisterFragmentsPass implements CompilerPassInterface
                 if (isset($attributes['nestedFragments'])) {
                     $compositor->addMethodCall('add', [$identifier, $attributes['nestedFragments']]);
                 }
-
-                $container->setDefinition($serviceId, $controllerDefinition);
 
                 if ($this->globalsKey && $this->proxyClass) {
                     if (!isset($attributes['category'])) {

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
@@ -56,9 +56,7 @@ class RegisterFragmentsPassTest extends TestCase
         $methodCalls = $container->getDefinition('contao.fragment.registry')->getMethodCalls();
         [$element, $module] = $methodCalls;
 
-        /*
-         * Test Content Element
-         */
+        // Test a content element
         $this->assertSame('add', $element[0]);
         $this->assertSame('contao.content_element.text', $element[1][0]);
         $this->assertMatchesRegularExpression('/^contao.fragment._config_/', (string) $element[1][1]);
@@ -66,9 +64,7 @@ class RegisterFragmentsPassTest extends TestCase
         $arguments = $container->getDefinition((string) $element[1][1])->getArguments();
         $this->assertSame('forward', $arguments[1]);
 
-        /*
-         * Test Frontend Module
-         */
+        // Test a front end module
         $this->assertSame('add', $module[0]);
         $this->assertSame('contao.frontend_module.login', $module[1][0]);
         $this->assertMatchesRegularExpression('/^contao.fragment._config_/', (string) $module[1][1]);

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class RegisterFragmentsPassTest extends TestCase
 {
-    public function testCreatesChildDefinitionForFragments(): void
+    public function testCreatesChildDefinitionForFragmentsWithOnlyOneTag(): void
     {
         $elementController = new Definition('App\Fragments\Text');
         $elementController->addTag('contao.content_element');
@@ -66,10 +66,6 @@ class RegisterFragmentsPassTest extends TestCase
         $arguments = $container->getDefinition((string) $element[1][1])->getArguments();
         $this->assertSame('forward', $arguments[1]);
 
-        $definition = $container->getDefinition($arguments[0]);
-        $this->assertInstanceOf(ChildDefinition::class, $definition);
-        $this->assertSame('app.fragments.content_controller', $definition->getParent());
-
         /*
          * Test Frontend Module
          */
@@ -78,6 +74,78 @@ class RegisterFragmentsPassTest extends TestCase
         $this->assertMatchesRegularExpression('/^contao.fragment._config_/', (string) $module[1][1]);
 
         $arguments = $container->getDefinition((string) $module[1][1])->getArguments();
+        $this->assertSame('esi', $arguments[1]);
+    }
+
+    public function testCreatesChildDefinitionForFragmentsWithMultipleTags(): void
+    {
+        $elementController = new Definition('App\Fragments\Text');
+        $elementController->addTag('contao.content_element', ['type' => 'text_1']);
+        $elementController->addTag('contao.content_element', ['type' => 'text_2']);
+
+        $moduleController = new Definition('App\Fragments\LoginController');
+        $moduleController->addTag('contao.frontend_module', ['type' => 'login_1', 'renderer' => 'esi']);
+        $moduleController->addTag('contao.frontend_module', ['type' => 'login_2', 'renderer' => 'esi']);
+
+        $container = $this->getContainerWithFragmentServices();
+        $container->setDefinition('app.fragments.content_controller', $elementController);
+        $container->setDefinition('app.fragments.module_controller', $moduleController);
+
+        (new ResolveClassPass())->process($container);
+
+        $pass = new RegisterFragmentsPass(ContentElementReference::TAG_NAME);
+        $pass->process($container);
+
+        $pass = new RegisterFragmentsPass(FrontendModuleReference::TAG_NAME);
+        $pass->process($container);
+
+        $methodCalls = $container->getDefinition('contao.fragment.registry')->getMethodCalls();
+        [$element1, $element2, $module1, $module2] = $methodCalls;
+
+        /*
+         * Test Content Elements
+         */
+        $this->assertSame('add', $element1[0]);
+        $this->assertSame('contao.content_element.text_1', $element1[1][0]);
+        $this->assertMatchesRegularExpression('/^contao.fragment._config_/', (string) $element1[1][1]);
+
+        $arguments = $container->getDefinition((string) $element1[1][1])->getArguments();
+        $this->assertSame('forward', $arguments[1]);
+
+        $definition = $container->getDefinition($arguments[0]);
+        $this->assertInstanceOf(ChildDefinition::class, $definition);
+        $this->assertSame('app.fragments.content_controller', $definition->getParent());
+
+        $this->assertSame('add', $element2[0]);
+        $this->assertSame('contao.content_element.text_2', $element2[1][0]);
+        $this->assertMatchesRegularExpression('/^contao.fragment._config_/', (string) $element2[1][1]);
+
+        $arguments = $container->getDefinition((string) $element2[1][1])->getArguments();
+        $this->assertSame('forward', $arguments[1]);
+
+        $definition = $container->getDefinition($arguments[0]);
+        $this->assertInstanceOf(ChildDefinition::class, $definition);
+        $this->assertSame('app.fragments.content_controller', $definition->getParent());
+
+        /*
+         * Test Frontend Modules
+         */
+        $this->assertSame('add', $module1[0]);
+        $this->assertSame('contao.frontend_module.login_1', $module1[1][0]);
+        $this->assertMatchesRegularExpression('/^contao.fragment._config_/', (string) $module1[1][1]);
+
+        $arguments = $container->getDefinition((string) $module1[1][1])->getArguments();
+        $this->assertSame('esi', $arguments[1]);
+
+        $definition = $container->getDefinition($arguments[0]);
+        $this->assertInstanceOf(ChildDefinition::class, $definition);
+        $this->assertSame('app.fragments.module_controller', $definition->getParent());
+
+        $this->assertSame('add', $module2[0]);
+        $this->assertSame('contao.frontend_module.login_2', $module2[1][0]);
+        $this->assertMatchesRegularExpression('/^contao.fragment._config_/', (string) $module2[1][1]);
+
+        $arguments = $container->getDefinition((string) $module2[1][1])->getArguments();
         $this->assertSame('esi', $arguments[1]);
 
         $definition = $container->getDefinition($arguments[0]);
@@ -111,7 +179,7 @@ class RegisterFragmentsPassTest extends TestCase
 
         $arguments = $container->getDefinition((string) $methodCalls[0][1][1])->getArguments();
 
-        $this->assertSame('contao.fragment._contao.content_element.foo::bar', $arguments[0]);
+        $this->assertSame('app.fragments.content_controller::bar', $arguments[0]);
         $this->assertSame('esi', $arguments[1]);
     }
 
@@ -131,10 +199,8 @@ class RegisterFragmentsPassTest extends TestCase
         $pass = new RegisterFragmentsPass(ContentElementReference::TAG_NAME);
         $pass->process($container);
 
-        $definition = $container->findDefinition('contao.fragment._contao.content_element.text');
-
-        $this->assertInstanceOf(ChildDefinition::class, $definition);
-        $this->assertSame('app.fragments.content_controller.enhanced_text', $definition->getParent());
+        $this->assertSame([], $container->getDefinition('app.fragments.content_controller.text')->getTags());
+        $this->assertSame(['contao.content_element' => [['type' => 'text']]], $container->getDefinition('app.fragments.content_controller.enhanced_text')->getTags());
     }
 
     public function testMakesFragmentServicesPublic(): void
@@ -153,11 +219,7 @@ class RegisterFragmentsPassTest extends TestCase
         $pass = new RegisterFragmentsPass(ContentElementReference::TAG_NAME);
         $pass->process($container);
 
-        $definition = $container->findDefinition('contao.fragment._contao.content_element.text');
-
-        $this->assertInstanceOf(ChildDefinition::class, $definition);
-        $this->assertSame('app.fragments.content_controller', $definition->getParent());
-        $this->assertTrue($definition->isPublic());
+        $this->assertTrue($container->findDefinition('app.fragments.content_controller')->isPublic());
     }
 
     public function testAddsContainerCallIfClassExtendsSymfonyAbstractController(): void
@@ -173,7 +235,7 @@ class RegisterFragmentsPassTest extends TestCase
         $pass = new RegisterFragmentsPass(FrontendModuleReference::TAG_NAME);
         $pass->process($container);
 
-        $definition = $container->findDefinition('contao.fragment._contao.frontend_module.two_factor');
+        $definition = $container->findDefinition('app.fragments.two_factor');
         $calls = $definition->getMethodCalls();
 
         $this->assertCount(2, $calls);
@@ -182,11 +244,12 @@ class RegisterFragmentsPassTest extends TestCase
         $this->assertSame(ContainerInterface::class, (string) $calls[1][1][0]);
     }
 
-    public function testCopiesTagsToChildDefinition(): void
+    public function testCopiesTagsToChildDefinitions(): void
     {
         $contentController = new Definition('App\Fragments\Text');
         $contentController->setPublic(false);
-        $contentController->addTag('contao.content_element');
+        $contentController->addTag('contao.content_element', ['type' => 'text_1']);
+        $contentController->addTag('contao.content_element', ['type' => 'text_2']);
         $contentController->addTag('foo.bar');
 
         $container = $this->getContainerWithFragmentServices();
@@ -197,7 +260,13 @@ class RegisterFragmentsPassTest extends TestCase
         $pass = new RegisterFragmentsPass(ContentElementReference::TAG_NAME);
         $pass->process($container);
 
-        $definition = $container->findDefinition('contao.fragment._contao.content_element.text');
+        $definition = $container->findDefinition('contao.fragment._contao.content_element.text_1');
+
+        $this->assertInstanceOf(ChildDefinition::class, $definition);
+        $this->assertSame('app.fragments.content_controller', $definition->getParent());
+        $this->assertSame(['foo.bar' => [[]]], $definition->getTags());
+
+        $definition = $container->findDefinition('contao.fragment._contao.content_element.text_2');
 
         $this->assertInstanceOf(ChildDefinition::class, $definition);
         $this->assertSame('app.fragments.content_controller', $definition->getParent());
@@ -222,7 +291,7 @@ class RegisterFragmentsPassTest extends TestCase
         $this->assertArrayHasKey('contao.content_element.fragment_pre_handler_interface', $arguments[0]);
 
         $this->assertSame(
-            'contao.fragment._contao.content_element.fragment_pre_handler_interface',
+            'app.fragments.content_controller',
             (string) $arguments[0]['contao.content_element.fragment_pre_handler_interface'],
         );
     }


### PR DESCRIPTION
Improves https://github.com/contao/contao/issues/8255.

We now only duplicate the service if it has multiple `AsContentElement` or `AsFrontendModule` attributes. This means that in case you only add one of them, there will also only be one service (and if you have a `AsHook` attribute, this one will be called only once).

However, as soon as you try to do this with e.g. two `AsContentElement` tags, you will have 3 calls for the hook (1 on the original service and 2 on the duplicated children).