### PR TITLE
Allow to create a user without a request

### DIFF
--- a/core-bundle/contao/library/Contao/User.php
+++ b/core-bundle/contao/library/Contao/User.php
@@ -329,11 +329,6 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 
 	public static function loadUserByIdentifier(string $identifier): self|null
 	{
-		if (!System::getContainer()->get('request_stack')->getCurrentRequest())
-		{
-			return null;
-		}
-
 		$user = new static();
 
 		// Load the user object


### PR DESCRIPTION
The request check seems to be a leftover from https://github.com/contao/contao/pull/4343 that does not make much sense to me. 

I tried to use Symfony `isGrantedForUser` (https://github.com/symfony/symfony/pull/48142) but that requires a `UserInterface`. If I have the `MemberModel`, I would nee this method regardless of having a request or not.