### PR TITLE
Ignore empty styles in `HtmlAttributes::addStyle()`

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -515,6 +515,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
                 $property = trim(substr($match[0], 0, -1), " \n\r\t\v\f");
                 $value = trim(substr($declaration, \strlen($match[0])), " \n\r\t\v\f");
                 $propertyDecoded = $this->decodeStyleProperty($match[1]);
+
                 $result[$propertyDecoded][] = match (true) {
                     '' === $value && !str_starts_with($propertyDecoded, '--') => '',
                     default => "$property: $value;",

--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -222,7 +222,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
      *
      * If a falsy $condition is specified, the method is a no-op.
      *
-     * @param string|array<int|string, string> $styles
+     * @param string|list<string>|array<string, string|int|float|bool|null> $styles
      */
     public function addStyle(array|string $styles, mixed $condition = true): self
     {
@@ -230,43 +230,28 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
             return $this;
         }
 
+        $stylesToRemove = [];
+
         if (\is_array($styles)) {
             foreach ($styles as $prop => $value) {
                 if (\is_string($prop)) {
-                    $styles[$prop] = "$prop:$value";
+                    if ('' === (string) $value) {
+                        $stylesToRemove[] = $prop;
+                        unset($styles[$prop]);
+                    } else {
+                        $styles[$prop] = "$prop:$value";
+                    }
                 }
             }
 
             $styles = implode(';', $styles);
+        }
+
+        if ($stylesToRemove) {
+            $this->removeStyle($stylesToRemove);
         }
 
         $mergedStyles = [...$this->parseStyles($this->attributes['style'] ?? ''), ...$this->parseStyles($styles)];
-
-        $this->attributes['style'] = $this->serializeStyles($mergedStyles);
-
-        if (empty($this->attributes['style'])) {
-            unset($this->attributes['style']);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Adds the style if the styles value is truthy.
-     */
-    public function addStyleIfExists(array|string $styles): self
-    {
-        if (\is_array($styles)) {
-            foreach ($styles as $prop => $value) {
-                if (\is_string($prop)) {
-                    $styles[$prop] = "$prop:$value";
-                }
-            }
-
-            $styles = implode(';', $styles);
-        }
-
-        $mergedStyles = [...$this->parseStyles($this->attributes['style'] ?? ''), ...$this->parseStyles($styles, true)];
 
         $this->attributes['style'] = $this->serializeStyles($mergedStyles);
 
@@ -475,7 +460,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
     /**
      * @return array<string, list<string>>
      */
-    private function parseStyles(string $styles, bool $skipEmpty = false): array
+    private function parseStyles(string $styles): array
     {
         // Regular expression to match declarations according to
         // https://www.w3.org/TR/css-syntax-3/#declaration-list-diagram
@@ -529,9 +514,11 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
                 // Spacing according to https://www.w3.org/TR/cssom-1/#serialize-a-css-declaration
                 $property = trim(substr($match[0], 0, -1), " \n\r\t\v\f");
                 $value = trim(substr($declaration, \strlen($match[0])), " \n\r\t\v\f");
-                if (!$skipEmpty || '' !== $value) {
-                    $result[$this->decodeStyleProperty($match[1])][] = "$property: $value;";
-                }
+                $propertyDecoded = $this->decodeStyleProperty($match[1]);
+                $result[$propertyDecoded][] = match (true) {
+                    '' === $value && !str_starts_with($propertyDecoded, '--') => '',
+                    default => "$property: $value;",
+                };
             }
         }
 
@@ -564,6 +551,6 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
     {
         // Serialize styles according to
         // https://www.w3.org/TR/cssom-1/#serialize-a-css-declaration-block
-        return implode(' ', array_merge(...array_values($styles)));
+        return implode(' ', array_filter(array_merge(...array_values($styles))));
     }
 }

--- a/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
+++ b/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
@@ -169,6 +169,7 @@ final class GlobalStateWatcher implements AfterTestHook, BeforeTestHook
                 'Symfony\Component\HttpClient\Response\MockResponse',
                 'Symfony\Component\Mime\Address',
                 'Symfony\Component\Mime\MimeTypes\\',
+                'Symfony\Component\Process\Process',
                 'Symfony\Component\String\\',
                 'Symfony\Component\VarDumper\\',
                 'Symfony\Component\Yaml\\',

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -576,30 +576,47 @@ class HtmlAttributesTest extends TestCase
 
         $this->assertSame([], iterator_to_array($attributes));
 
-        $attributes->addStyleIfExists('foo:');
-        $attributes->addStyleIfExists('foo:;');
-        $attributes->addStyleIfExists('foo: ;');
-        $attributes->addStyleIfExists(['foo' => null]);
-        $attributes->addStyleIfExists(['foo' => false]);
-        $attributes->addStyleIfExists(['foo' => '']);
-        $attributes->addStyleIfExists(['foo' => ';']);
+        $attributes->addStyle('foo1:');
+        $attributes->addStyle('foo2:;');
+        $attributes->addStyle('foo3: ;');
+        $attributes->addStyle(['foo4' => null]);
+        $attributes->addStyle(['foo5' => false]);
+        $attributes->addStyle(['foo6' => '']);
+        $attributes->addStyle(['foo7' => ';']);
 
         $this->assertSame([], iterator_to_array($attributes));
 
-        $attributes->addStyle('foo:');
-        $attributes->addStyleIfExists('foo:');
+        $attributes->addStyle('a: 0;');
+        $attributes->addStyle('b: "";');
+        $attributes->addStyle('c: false;');
+        $attributes->addStyle(['d' => true]);
+        $attributes->addStyle(['e' => 0]);
+        $attributes->addStyle(['f' => '""']);
+        $attributes->addStyle(['g' => '1']);
+        $attributes->addStyle(['g' => null]);
 
-        $this->assertSame(['style' => 'foo: ;'], iterator_to_array($attributes));
+        $this->assertSame(['style' => 'a: 0; b: ""; c: false; d: 1; e: 0; f: "";'], iterator_to_array($attributes));
 
-        $attributes->addStyleIfExists('a: 0;');
-        $attributes->addStyleIfExists('b: "";');
-        $attributes->addStyleIfExists('c: false;');
-        $attributes->addStyleIfExists(['d' => true]);
-        $attributes->addStyleIfExists(['e' => 0]);
-        $attributes->addStyleIfExists(['f' => '""']);
-        $attributes->addStyleIfExists(['f' => null]);
+        $attributes->set('style', '--a:;');
+        $attributes->addStyle('--b:;');
+        $attributes->addStyle(['--c:']);
+        $attributes->addStyle(['--d' => ' ']);
+        $attributes->addStyle(['--e' => '']);
+        $attributes->addStyle(['--f' => null]);
+        $attributes->addStyle(['--g' => false]);
 
-        $this->assertSame(['style' => 'foo: ; a: 0; b: ""; c: false; d: 1; e: 0; f: "";'], iterator_to_array($attributes));
+        $this->assertSame(
+            ['style' => '--a: ; --b: ; --c: ; --d: ;'],
+            iterator_to_array($attributes),
+            'Custom properties with empty values should not get stripped',
+        );
+
+        $attributes->addStyle(['--a' => '']);
+        $attributes->addStyle(['--b' => null]);
+        $attributes->addStyle(['--c' => false]);
+        $attributes->addStyle(['--d' => '']);
+
+        $this->assertSame([], iterator_to_array($attributes));
     }
 
     public function testDoesNotOutputEmptyStyleAttribute(): void
@@ -624,7 +641,6 @@ class HtmlAttributesTest extends TestCase
             ->set('style', 'color: red;')
             ->setIfExists('data-foo', null)
             ->addStyle('color: blue;')
-            ->addStyleIfExists(['color' => null])
         ;
 
         $this->assertSame(' class="block headline" style="color: blue;"', (string) $attributes);

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -575,6 +575,31 @@ class HtmlAttributesTest extends TestCase
         $attributes->removeStyle(['d'], condition: '1');
 
         $this->assertSame([], iterator_to_array($attributes));
+
+        $attributes->addStyleIfExists('foo:');
+        $attributes->addStyleIfExists('foo:;');
+        $attributes->addStyleIfExists('foo: ;');
+        $attributes->addStyleIfExists(['foo' => null]);
+        $attributes->addStyleIfExists(['foo' => false]);
+        $attributes->addStyleIfExists(['foo' => '']);
+        $attributes->addStyleIfExists(['foo' => ';']);
+
+        $this->assertSame([], iterator_to_array($attributes));
+
+        $attributes->addStyle('foo:');
+        $attributes->addStyleIfExists('foo:');
+
+        $this->assertSame(['style' => 'foo: ;'], iterator_to_array($attributes));
+
+        $attributes->addStyleIfExists('a: 0;');
+        $attributes->addStyleIfExists('b: "";');
+        $attributes->addStyleIfExists('c: false;');
+        $attributes->addStyleIfExists(['d' => true]);
+        $attributes->addStyleIfExists(['e' => 0]);
+        $attributes->addStyleIfExists(['f' => '""']);
+        $attributes->addStyleIfExists(['f' => null]);
+
+        $this->assertSame(['style' => 'foo: ; a: 0; b: ""; c: false; d: 1; e: 0; f: "";'], iterator_to_array($attributes));
     }
 
     public function testDoesNotOutputEmptyStyleAttribute(): void
@@ -598,9 +623,11 @@ class HtmlAttributesTest extends TestCase
             ->removeClass('foo')
             ->set('style', 'color: red;')
             ->setIfExists('data-foo', null)
+            ->addStyle('color: blue;')
+            ->addStyleIfExists(['color' => null])
         ;
 
-        $this->assertSame(' class="block headline" style="color: red;"', (string) $attributes);
+        $this->assertSame(' class="block headline" style="color: blue;"', (string) $attributes);
     }
 
     public function testEscapesAttributesWhenRenderingAsString(): void


### PR DESCRIPTION
I implemented #8677 in ab3f8e4503d588342308870a49b82ea8becb54cf, but during writing the tests I noticed that instead of adding a new method it might make more sense to just change how `HtmlAttributes::addStyle()` works.

I investigated how the DOM API handles empty styles, with the following result:

```js
style.setProperty('margin', '1px'); // 'margin: 1px;'
style.setProperty('margin', '0');   // 'margin: 0px;'
style.setProperty('margin', 0);     // 'margin: 0px;'
style.setProperty('margin', '');    // ''
style.setProperty('margin', null);  // ''
style.setProperty('--foo', '1px');  // '--foo: 1px;'
style.setProperty('--foo', '0');    // '--foo: 0;'
style.setProperty('--foo', 0);      // '--foo: 0;'
style.setProperty('--foo', '');     // ''
style.setProperty('--foo', null);   // ''
```

So I now updated our `HtmlAttributes::addStyle()` to work the same. This makes the following Twig code to work as expected:

```twig
{{ attrs()
    .addStyle({ 
        'margin': margin|default,
        '--foo': foo|default,
    }) 
    .addStyle('margin: #{margin|default};')
    .addStyle([
        'margin: #{margin|default};',
    ])
}}
```

The styles are only output now if the variables exist, meaning they do not compute to `''`, `null` or `false`. _(Note, that `0` is not considered empty here.)_

There is one special case though: custom properties. See:

```js
style.setProperty('--foo', null);   // ''
style.setProperty('--foo', '');     // ''
style.setProperty('--foo', ' ');    // '--foo: ;'
style = '--foo:;';                  // '--foo: ;'
```

I also integrated that into `HtmlAttributes::addStyle()` but that means in the following case:

```twig
{{ attrs()
    .addStyle({ '--foo': foo|default }) 
    .addStyle([ '--foo: #{foo|default};' ])
    .addStyle('--foo: #{foo|default};')
}}
```

that only the first `addStyle()` would be ignored, the other two would result in `--foo: ;` just like they do in JavaScript. But as this only happens for properties that start with `--` I think this is fine (and will probably not get noticed by anybody in the future ☺️).

@contao/developers do you agree that we change `addStyle()` accordingly instead of adding a new `addStyleIfExists()`?  
If so, should I backport this as a bugfix to 5.3?