### PR TITLE
Replace insert tags in link titles in the hyperlink controller

### DIFF
--- a/core-bundle/src/Controller/ContentElement/HyperlinkController.php
+++ b/core-bundle/src/Controller/ContentElement/HyperlinkController.php
@@ -40,9 +40,12 @@ class HyperlinkController extends AbstractContentElementController
             $href = $request->getBasePath().'/'.$href;
         }
 
+        // Link title
+        $titleText = $this->insertTagParser->replaceInline($model->titleText ?? '');
+
         $linkAttributes = (new HtmlAttributes())
             ->set('href', $href)
-            ->setIfExists('title', $model->titleText)
+            ->setIfExists('title', $titleText)
             ->setIfExists('data-lightbox', $model->rel)
         ;
 


### PR DESCRIPTION
Replacing InsertTags in the link title of Hyperlinks did not work because the InsertTags were escaped before replacement. This fix applies replaceInline to the value from $model->titleText before passing it to HtmlAttributes.

```php
// Link title
$titleText = $this->insertTagParser->replaceInline($model->titleText ?? '');

$linkAttributes = (new HtmlAttributes())
    ->set('href', $href)
    ->setIfExists('title', $titleText)
    ->setIfExists('data-lightbox', $model->rel)
;
```

InsertTags are needed here, for example, to create multilingual titles using {{trans::*}}.