### PR TITLE
Fix moving multiple items via the clipboard

### DIFF
--- a/core-bundle/src/DataContainer/ClipboardManager.php
+++ b/core-bundle/src/DataContainer/ClipboardManager.php
@@ -139,7 +139,10 @@ class ClipboardManager
             return false;
         }
 
-        if ((string) $id === (string) $clipboard['id'] || (\is_array($clipboard['id']) && \in_array($id, $clipboard['id'], false))) {
+        if (
+            (\is_array($clipboard['id']) && \in_array($id, $clipboard['id'], false))
+            || (!\is_array($clipboard['id']) && (string) $id === (string) $clipboard['id'])
+        ) {
             return true;
         }
 


### PR DESCRIPTION
`ClipboardManager` has been added in Contoa 5.5. The first if-condition fails if `$clipboard['id']` is an array (as checked for in the second condition).