### PR TITLE
Ensure a correct cron job return value

### DIFF
--- a/core-bundle/src/Cron/CronJob.php
+++ b/core-bundle/src/Cron/CronJob.php
@@ -46,16 +46,12 @@ class CronJob
         } else {
             $result = $this->service->{$this->method}($scope);
         }
-    
-        if ($result === null || $result instanceof PromiseInterface) {
+
+        if (null === $result || $result instanceof PromiseInterface) {
             return $result;
         }
-    
-        throw new \UnexpectedValueException(sprintf(
-            'Invalid return value from "%s": expected null or PromiseInterface, got %s',
-            $this->name,
-            get_debug_type($result)
-        ));
+
+        throw new \UnexpectedValueException(\sprintf('Invalid return value from "%s": expected null or PromiseInterface, got %s', $this->name, get_debug_type($result)));
     }
 
     public function getService(): object

--- a/core-bundle/src/Cron/CronJob.php
+++ b/core-bundle/src/Cron/CronJob.php
@@ -42,10 +42,20 @@ class CronJob
     public function __invoke(string $scope): PromiseInterface|null
     {
         if (\is_callable($this->service)) {
-            return ($this->service)($scope);
+            $result = ($this->service)($scope);
+        } else {
+            $result = $this->service->{$this->method}($scope);
         }
-
-        return $this->service->{$this->method}($scope);
+    
+        if ($result === null || $result instanceof PromiseInterface) {
+            return $result;
+        }
+    
+        throw new \RuntimeException(sprintf(
+            'Invalid return value from "%s": expected null or PromiseInterface, got %s',
+            $this->name,
+            get_debug_type($result)
+        ));
     }
 
     public function getService(): object

--- a/core-bundle/src/Cron/CronJob.php
+++ b/core-bundle/src/Cron/CronJob.php
@@ -51,7 +51,7 @@ class CronJob
             return $result;
         }
     
-        throw new \RuntimeException(sprintf(
+        throw new \UnexpectedValueException(sprintf(
             'Invalid return value from "%s": expected null or PromiseInterface, got %s',
             $this->name,
             get_debug_type($result)

--- a/core-bundle/tests/Cron/CronJobTest.php
+++ b/core-bundle/tests/Cron/CronJobTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Cron;
 
+use Contao\CoreBundle\Cron\Cron;
 use Contao\CoreBundle\Cron\CronJob;
 use Contao\CoreBundle\Fixtures\Cron\TestCronJob;
 use Contao\CoreBundle\Tests\TestCase;
@@ -23,5 +24,14 @@ class CronJobTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         new CronJob(new TestCronJob(), '@hourly');
+    }
+
+    public function testUnexpectedReturnValue(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid return value from "Contao\CoreBundle\Fixtures\Cron\TestCronJob::wrongReturnValue": expected null or PromiseInterface, got int');
+
+        $cronJob = new CronJob(new TestCronJob(), '@daily', 'wrongReturnValue');
+        $cronJob(Cron::SCOPE_CLI);
     }
 }

--- a/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
+++ b/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
@@ -56,4 +56,9 @@ class TestCronJob
     {
         return new Promise(static function (): never { throw new CronExecutionSkippedException(); });
     }
+
+    public function wrongReturnValue(): int
+    {
+        return 42;
+    }
 }


### PR DESCRIPTION
Throw a UnexpectedValueException if return value is neither null nor PromiseInterface

<!--
Bugfixes should be based on the 5.3 branch and features on the 5.x branch.
Select the correct branch in the "base:" drop-down menu above.

Pull requests for Contao 4.13 are no longer merged upstream into Contao 5!
If you want to fix a bug in Contao 4.13, please create a pull request for
Contao 5.3 first and then a separate backport pull request for Contao 4.13.
-->
