### PR TITLE
Correctly handle non-array DCA operation labels

### DIFF
--- a/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
@@ -253,7 +253,7 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
         }
 
         if (!isset($label[0])) {
-            if (\is_array($GLOBALS['TL_LANG']['DCA'][$key]) && isset($GLOBALS['TL_LANG']['DCA'][$key][0])) {
+            if (\is_array($GLOBALS['TL_LANG']['DCA'][$key] ?? null) && isset($GLOBALS['TL_LANG']['DCA'][$key][0])) {
                 $label[0] = $GLOBALS['TL_LANG']['DCA'][$key][0];
             } else {
                 $label[0] = $label[1];

--- a/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
@@ -253,7 +253,11 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
         }
 
         if (!isset($label[0])) {
-            $label[0] = $GLOBALS['TL_LANG']['DCA'][$key][0] ?? $label[1];
+            if (\is_array($GLOBALS['TL_LANG']['DCA'][$key]) && isset($GLOBALS['TL_LANG']['DCA'][$key][0])) {
+                $label[0] = $GLOBALS['TL_LANG']['DCA'][$key][0];
+            } else {
+                $label[0] = $label[1];
+            }
         }
 
         return $label;


### PR DESCRIPTION
If `$GLOBALS['TL_LANG']['DCA'][$key]` is not an array, it currently takes the first letter of the label as title. Can be noticed in the context menu on the header of mode 4 (content elemnts) when something is in the clipboard.

<img width="1664" height="224" alt="Bildschirmfoto 2025-08-28 um 08 45 40" src="https://github.com/user-attachments/assets/e25a69fc-8b1f-4101-abb6-9c2c78834ad8" />
