### PR TITLE
Automatically prefix time based backup intervals

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -803,7 +803,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(5)
                 ->end()
                 ->arrayNode('keep_intervals')
-                    ->info('The latest backup plus the oldest of every configured interval will be kept. Intervals have to be specified as documented in https://www.php.net/manual/en/dateinterval.construct.php without the P prefix.')
+                    ->info('The latest backup plus the oldest of every configured interval will be kept. Intervals have to be specified as documented in https://www.php.net/manual/en/dateinterval.construct.php without the P or T prefix.')
                     ->defaultValue(['1D', '7D', '14D', '1M'])
                     ->validate()
                         ->ifTrue(

--- a/core-bundle/src/Doctrine/Backup/RetentionPolicy.php
+++ b/core-bundle/src/Doctrine/Backup/RetentionPolicy.php
@@ -73,7 +73,13 @@ final class RetentionPolicy implements RetentionPolicyInterface
         $intervalsNew = [];
 
         foreach ($keepIntervals as $interval) {
-            $intervalsNew[$interval] = new \DateInterval('P'.$interval);
+            $prefix = 'P';
+
+            if (\in_array(substr($interval, -1), ['H', 'M', 'S'], true) && !str_starts_with($interval, 'T')) {
+                $prefix .= 'T';
+            }
+
+            $intervalsNew[$interval] = new \DateInterval($prefix.$interval);
         }
 
         uasort($intervalsNew, static fn (\DateInterval $a, \DateInterval $b) => self::compareDateIntervals($a, $b));


### PR DESCRIPTION
For our `contao.backup.keep_intervals` we use the syntax used by `DateInterval` - except you must not use the `P` prefix. However, if you want to use any of the time-based intervals (`H`, `M`, `S`) you still have to use the `T` prefix. So this currently does not work:

```yaml
contao:
    backup:
        keep_intervals: [12H, 1D]
```

Only this will work:

```yaml
contao:
    backup:
        keep_intervals: [T12H, 1D]
```

This PR adjusts `RetentionPolicy::validateAndSortIntervals()` so that the `T` prefix is also automatically used for the time-based intervals.