### PR TITLE
Fix the template module class

### DIFF
--- a/core-bundle/contao/templates/twig/frontend_module/template.html.twig
+++ b/core-bundle/contao/templates/twig/frontend_module/template.html.twig
@@ -1,1 +1,12 @@
-{% extends "@Contao/content_element/template.html.twig" %}
+{% extends "@Contao/frontend_module/_base.html.twig" %}
+
+{% block content %}
+    {% if keys|default %}
+        <dl>
+            {% for key, value in keys %}
+                <dt>{{ key }}</dt>
+                <dd>{{ value }}</dd>
+            {% endfor %}
+        </dl>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Added in https://github.com/contao/contao/pull/5310

The module template extends a content element template, which leads to a template class of `content-template` instead of `module-template`.

I'm not sure we need to fix this, it would change the markup for existing users. But I thought we should at least discuss this.
An alternative option would be to just add the `module-template` class so it would have both `content-template module-template`.