### PR TITLE
Backup the response context

### DIFF
--- a/core-bundle/contao/controllers/FrontendIndex.php
+++ b/core-bundle/contao/controllers/FrontendIndex.php
@@ -54,7 +54,8 @@ class FrontendIndex extends Frontend
 			$GLOBALS['TL_MOOTOOLS'] ?? array(),
 			$GLOBALS['TL_JQUERY'] ?? array(),
 			$GLOBALS['TL_USER_CSS'] ?? array(),
-			$GLOBALS['TL_FRAMEWORK_CSS'] ?? array()
+			$GLOBALS['TL_FRAMEWORK_CSS'] ?? array(),
+			System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext()
 		);
 
 		try
@@ -75,8 +76,11 @@ class FrontendIndex extends Frontend
 				$GLOBALS['TL_MOOTOOLS'],
 				$GLOBALS['TL_JQUERY'],
 				$GLOBALS['TL_USER_CSS'],
-				$GLOBALS['TL_FRAMEWORK_CSS']
+				$GLOBALS['TL_FRAMEWORK_CSS'],
+				$responseContext
 			) = $arrBackup;
+
+			System::getContainer()->get('contao.routing.response_context_accessor')->setResponseContext($responseContext);
 
 			throw $e;
 		}


### PR DESCRIPTION
While working on https://github.com/contao/contao/issues/8705 I noticed that since we now allow a predefined response context (see https://github.com/contao/contao/pull/7781), we should be affected by the same issues as described in https://github.com/contao/core/issues/7659. 

If anything is added to the response context by the current page, but e.g. a `UnusedArgumentsException` is thrown, that content will/might leak to the error page.