### PR TITLE
Additionally check the `disablePermissionsChecks` flag for back end modules

### DIFF
--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -131,23 +131,13 @@ class BackendAccessVoter extends Voter implements ResetInterface
 
         // Additionally check for 'disablePermissionChecks' flag for modules
         if ('modules' === $field) {
-            $moduleAccess = null;
-
             foreach ($subject as $module) {
                 foreach ($GLOBALS['BE_MOD'] as $modules) {
-                    foreach ($modules as $name => $config) {
-                        if ($name === $module) {
-                            $moduleAccess = ($config['disablePermissionChecks'] ?? false) || \in_array($module, $user->$field, true);
-                        }
-
-                        if (false === $moduleAccess) {
-                            return false;
-                        }
+                    if ($modules[$module]['disablePermissionChecks'] ?? false) {
+                        return true;
                     }
                 }
             }
-
-            return (bool) $moduleAccess;
         }
 
         return false;

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -131,25 +131,23 @@ class BackendAccessVoter extends Voter implements ResetInterface
 
         // Additionally check for 'disablePermissionChecks' flag for modules
         if ('modules' === $field) {
-            $hasModuleAccess = null;
+            $moduleAccess = null;
 
             foreach ($subject as $module) {
                 foreach ($GLOBALS['BE_MOD'] as $modules) {
                     foreach ($modules as $name => $config) {
                         if ($name === $module) {
-                            $hasModuleAccess = $config['disablePermissionChecks'] ?? false;
+                            $moduleAccess = ($config['disablePermissionChecks'] ?? false) || \in_array($module, $user->$field);
                         }
 
-                        if (false === $hasModuleAccess) {
-                            break 3;
+                        if (false === $moduleAccess) {
+                            return false;
                         }
                     }
                 }
             }
 
-            if (true === $hasModuleAccess) {
-                return true;
-            }
+            return (bool) $moduleAccess;
         }
 
         return false;

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -137,7 +137,7 @@ class BackendAccessVoter extends Voter implements ResetInterface
                 foreach ($GLOBALS['BE_MOD'] as $modules) {
                     foreach ($modules as $name => $config) {
                         if ($name === $module) {
-                            $moduleAccess = ($config['disablePermissionChecks'] ?? false) || \in_array($module, $user->$field);
+                            $moduleAccess = ($config['disablePermissionChecks'] ?? false) || \in_array($module, $user->$field, true);
                         }
 
                         if (false === $moduleAccess) {

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -129,7 +129,7 @@ class BackendAccessVoter extends Voter implements ResetInterface
             return !empty($this->pagemountsCache[$user->id]) && array_intersect($subject, $this->pagemountsCache[$user->id]);
         }
 
-        // Additionally check for 'disablePermissionChecks' flag for modules
+        // Additionally check the "disablePermissionChecks" flag for modules
         if ('modules' === $field) {
             foreach ($subject as $module) {
                 foreach ($GLOBALS['BE_MOD'] as $modules) {

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -129,6 +129,29 @@ class BackendAccessVoter extends Voter implements ResetInterface
             return !empty($this->pagemountsCache[$user->id]) && array_intersect($subject, $this->pagemountsCache[$user->id]);
         }
 
+        // Additionally check for 'disablePermissionChecks' flag for modules
+        if ('modules' === $field) {
+            $hasModuleAccess = null;
+
+            foreach ($subject as $module) {
+                foreach ($GLOBALS['BE_MOD'] as $modules) {
+                    foreach ($modules as $name => $config) {
+                        if ($name === $module) {
+                            $hasModuleAccess = $config['disablePermissionChecks'] ?? false;
+                        }
+
+                        if (false === $hasModuleAccess) {
+                            break 3;
+                        }
+                    }
+                }
+            }
+
+            if (true === $hasModuleAccess) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
@@ -33,6 +33,13 @@ class BackendAccessVoterTest extends TestCase
         $this->voter = new BackendAccessVoter($this->mockContaoFramework());
     }
 
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_MOD']);
+
+        parent::tearDown();
+    }
+
     public function testAbstainsIfTheAttributeIsContaoUser(): void
     {
         $token = $this->createMock(TokenInterface::class);
@@ -649,6 +656,55 @@ class BackendAccessVoterTest extends TestCase
             ['g6'],
             1,
             1,
+            VoterInterface::ACCESS_GRANTED,
+        ];
+    }
+
+    /**
+     * @dataProvider getBackendModulePermissions
+     */
+    public function testBackendModulePermissions(array $allowedModules, string $requestedModule, array $config, int $expected): void
+    {
+        $user = $this->mockClassWithProperties(BackendUser::class, ['id' => 1, 'modules' => $allowedModules]);
+
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+
+        $GLOBALS['BE_MOD'] = $config;
+
+        $this->assertSame($expected, $this->voter->vote($token, $requestedModule, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE]));
+    }
+
+    public static function getBackendModulePermissions(): iterable
+    {
+        yield 'Denies access if module is not allowed for user' => [
+            ['foo'],
+            'bar',
+            [],
+            VoterInterface::ACCESS_DENIED,
+        ];
+
+        yield 'Allows access if module is allowed for user' => [
+            ['foo'],
+            'foo',
+            [],
+            VoterInterface::ACCESS_GRANTED,
+        ];
+
+        yield 'Allows access if module does not need permission checks' => [
+            ['foo'],
+            'ipsum',
+            [
+                'lorem' => [
+                    'ipsum' => [
+                        'disablePermissionChecks' => true,
+                    ],
+                ],
+            ],
             VoterInterface::ACCESS_GRANTED,
         ];
     }


### PR DESCRIPTION
Fixes #8753

This adds a check for `disablePermissionChecks` in our `BackendAccessVoter` which will also have an effect on the `TableAccessVoter` when it checks for the back end module access.