### PR TITLE
Use a 16:9 aspect ratio in translations

### DIFF
--- a/core-bundle/contao/languages/en/tl_content.xlf
+++ b/core-bundle/contao/languages/en/tl_content.xlf
@@ -360,7 +360,7 @@
         <source>Player size</source>
       </trans-unit>
       <trans-unit id="tl_content.playerSize.1">
-        <source>Width and height of the media player in pixels (e.g. 640x480).</source>
+        <source>Width and height of the media player in pixels (e.g. 640x360).</source>
       </trans-unit>
       <trans-unit id="tl_content.playerOptions.0">
         <source>Player options</source>


### PR DESCRIPTION
Super minor issue - but I find the 4:3 aspect ratio in our video player size description somewhat outdated. But feel free to disregard and close if it's not worth the effort of then also changing this in all languages 🙃

Though this will then match the default size of our YouTube and Vimeo players.