### PR TITLE
Fix the `var/logs` symlink under Symfony 7.3+

### DIFF
--- a/core-bundle/src/Command/SymlinksCommand.php
+++ b/core-bundle/src/Command/SymlinksCommand.php
@@ -92,6 +92,7 @@ class SymlinksCommand extends Command
         $this->symlink('system/themes', Path::join($this->webDir, 'system/themes'));
 
         // Symlinks the logs directory
+        $fs->mkdir($this->logsDir); // see #8763
         $this->symlink($this->getRelativePath($this->logsDir), 'system/logs');
 
         // Symlink the highlight.php styles


### PR DESCRIPTION
Fixes #8763

* The PR now ensures that the `var/logs` folder is present, as Symfony 7.3 does not create it anymore (see [here](https://github.com/symfony/symfony/pull/58564)).
* The tests did not fail under Windows, because we still had `var/logs` in our `Fixtures` - which this PR now removes in order to more accurately reflect the state in Symfony 7.3 and higher.
