### PR TITLE
Make a job optional for the back end search reindex

### DIFF
--- a/core-bundle/contao/classes/RebuildBackendSearchIndex.php
+++ b/core-bundle/contao/classes/RebuildBackendSearchIndex.php
@@ -56,7 +56,7 @@ class RebuildBackendSearchIndex extends Backend implements MaintenanceModuleInte
 		{
 			// Drop the entire index as the schema might have changed after an update, etc.
 			$backendSearch->clear();
-			$backendSearch->reindex(new ReindexConfig());
+			$backendSearch->reindex((new ReindexConfig())->withRequireJob(true));
 
 			Message::addConfirmation($GLOBALS['TL_LANG']['tl_maintenance']['backend_search']['confirmation'], self::class);
 

--- a/core-bundle/src/Search/Backend/BackendSearch.php
+++ b/core-bundle/src/Search/Backend/BackendSearch.php
@@ -84,20 +84,20 @@ class BackendSearch
     }
 
     /**
-     * @return string The job ID for the job framework
+     * @return string|null The job ID for the job framework if any
      */
-    public function reindex(ReindexConfig $config, bool $async = true): string
+    public function reindex(ReindexConfig $config, bool $async = true): string|null
     {
         $job = $config->getJobId() ? $this->jobs->getByUuid($config->getJobId()) : null;
 
-        // Create the job if not done already
-        if (!$job) {
+        // Create the job if required
+        if (!$job && $config->requiresJob()) {
             $job = $this->jobs->createJob(self::REINDEX_JOB_TYPE);
             $config = $config->withJobId($job->getUuid());
         }
 
         // Validate the job type just in case it was not created from this method
-        if (self::REINDEX_JOB_TYPE !== $job->getType()) {
+        if ($job && self::REINDEX_JOB_TYPE !== $job->getType()) {
             throw new \InvalidArgumentException(\sprintf('Provided a custom job type "%s" but must be "%s".', $job->getType(), self::REINDEX_JOB_TYPE));
         }
 
@@ -115,7 +115,9 @@ class BackendSearch
                     $config = $config->limitToDocumentIds($documentIdGroup);
 
                     // Create child jobs here, so we can track progress across multiple messages
-                    $config = $config->withJobId($this->jobs->createChildJob($job)->getUuid());
+                    if ($job) {
+                        $config = $config->withJobId($this->jobs->createChildJob($job)->getUuid());
+                    }
 
                     $this->messageBus->dispatch(new ReindexMessage($config));
                 }
@@ -125,7 +127,9 @@ class BackendSearch
         }
 
         // Mark job as pending now
-        $this->jobs->persist($job->markPending());
+        if ($job) {
+            $this->jobs->persist($job->markPending());
+        }
 
         // Seal does not delete unused documents, it just re-indexes. So if some
         // identifier here does no longer exist, it would never get removed. Hence, we
@@ -136,7 +140,9 @@ class BackendSearch
         $this->engine->reindex([$this->reindexProvider], SealUtil::internalReindexConfigToSealReindexConfig($config));
 
         // Mark job as completed
-        $this->jobs->persist($job->markCompleted());
+        if ($job) {
+            $this->jobs->persist($job->markCompleted());
+        }
 
         return $config->getJobId();
     }

--- a/core-bundle/src/Search/Backend/ReindexConfig.php
+++ b/core-bundle/src/Search/Backend/ReindexConfig.php
@@ -15,6 +15,8 @@ final class ReindexConfig
 
     private string|null $jobId = null;
 
+    private bool $requireJob = false;
+
     public function __construct()
     {
         $this->limitedDocumentIds = new GroupedDocumentIds();
@@ -54,6 +56,19 @@ final class ReindexConfig
         return $clone;
     }
 
+    public function withRequireJob(bool $requireJob): self
+    {
+        $clone = clone $this;
+        $clone->requireJob = $requireJob;
+
+        return $clone;
+    }
+
+    public function requiresJob(): bool
+    {
+        return $this->requireJob;
+    }
+
     public function getJobId(): string|null
     {
         return $this->jobId;
@@ -70,6 +85,7 @@ final class ReindexConfig
             'updatedSince' => $this->updateSince?->format(\DateTimeInterface::ATOM),
             'limitedDocumentIds' => $this->limitedDocumentIds->toArray(),
             'jobId' => $this->jobId,
+            'requireJob' => $this->requireJob,
         ];
     }
 
@@ -83,6 +99,10 @@ final class ReindexConfig
 
         if (isset($array['jobId'])) {
             $config = $config->withJobId($array['jobId']);
+        }
+
+        if (isset($array['requireJob'])) {
+            $config = $config->withRequireJob($array['requireJob']);
         }
 
         return $config->limitToDocumentIds(GroupedDocumentIds::fromArray($array['limitedDocumentIds']));

--- a/core-bundle/tests/Search/Backend/BackendSearchTest.php
+++ b/core-bundle/tests/Search/Backend/BackendSearchTest.php
@@ -137,6 +137,7 @@ class BackendSearchTest extends TestCase
     public function testReindexAsync(): void
     {
         $reindexConfig = (new ReindexConfig())
+            ->withRequireJob(true)
             ->limitToDocumentIds(new GroupedDocumentIds(['foo' => ['bar']]))
             ->limitToDocumentsNewerThan(new \DateTimeImmutable('2024-01-01T00:00:00+00:00'))
         ;

--- a/core-bundle/tests/Search/Backend/ReindexConfigTest.php
+++ b/core-bundle/tests/Search/Backend/ReindexConfigTest.php
@@ -38,4 +38,13 @@ class ReindexConfigTest extends TestCase
         $config = $config->limitToDocumentIds(new GroupedDocumentIds(['foo' => ['42']]));
         $this->assertSame(['foo' => ['42']], $config->getLimitedDocumentIds()->toArray());
     }
+
+    public function testRequiresJob(): void
+    {
+        $config = new ReindexConfig();
+        $this->assertFalse($config->requiresJob());
+
+        $config = $config->withRequireJob(true);
+        $this->assertTrue($config->requiresJob());
+    }
 }


### PR DESCRIPTION
Currently, you'll see all backend search re-index jobs in the new jobs framework which will be a lot.
Basically, every edit of any content triggers a re-index which is correct because the contents might have changed. So updating the search index is correct but showing those jobs in the jobs framework is of no real benefit because things will happen mostly instantaneous (indexing/updating the index with e.g. one content element will be super quick, why bother showing any progress in the jobs framework).

Let's limit this to the ones executed in the backend maintenance mode only because those are the ones that take a while.

I've decided to add a new feature on the `ReindexConfig` as otherwise every dev would have to inject both, the `BackendSearch` as well as the `Jobs` service in order to trigger re-indexing **with** a job. Like this, it's not needed and the DX is better as you can just do `withRequireJob(true)` and the `BackendSearch` will then create it for you.
