### PR TITLE
Check if the `Content-Type` header exists before using it in the `PreviewToolbarListener`

### DIFF
--- a/core-bundle/src/EventListener/PreviewToolbarListener.php
+++ b/core-bundle/src/EventListener/PreviewToolbarListener.php
@@ -73,7 +73,7 @@ class PreviewToolbarListener
         // Only inject the toolbar into HTML responses
         if (
             'html' !== $request->getRequestFormat()
-            || !str_contains((string) $response->headers->get('Content-Type'), 'text/html')
+            || ($response->headers->has('Content-Type') && !str_contains((string) $response->headers->get('Content-Type'), 'text/html'))
             || false !== stripos((string) $response->headers->get('Content-Disposition'), 'attachment;')
         ) {
             return;

--- a/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
@@ -70,7 +70,6 @@ class PreviewToolbarListenerTest extends TestCase
     public function testInjectsTheToolbarIntoTheResponse(): void
     {
         $response = new Response('<html><head></head><body></body></html>');
-        $response->headers->set('Content-Type', 'text/html; charset=utf-8');
 
         $event = new ResponseEvent(
             $this->createMock(HttpKernelInterface::class),


### PR DESCRIPTION
Fixes #8669

In Twig layouts the Content-Type header doesn't exist at this point, so the preview toolbar doesn't work.
Symfony uses [the same logic](https://github.com/symfony/web-profiler-bundle/blob/7.4/EventListener/WebDebugToolbarListener.php) for their debug toolbar.