### PR TITLE
Only set the request format when rendering a Turbo stream template

### DIFF
--- a/core-bundle/src/Controller/AbstractBackendController.php
+++ b/core-bundle/src/Controller/AbstractBackendController.php
@@ -66,16 +66,16 @@ abstract class AbstractBackendController extends AbstractController
 
         $request = $this->getCurrentRequest();
 
-        if (\in_array('text/vnd.turbo-stream.html', $request->getAcceptableContentTypes(), true)) {
+        if (str_ends_with($view, '.stream.html.twig')) {
+            if (!\in_array('text/vnd.turbo-stream.html', $request->getAcceptableContentTypes(), true)) {
+                throw new \LogicException('The current route was not requested with "text/vnd.turbo-stream.html" in the "Accept" header but still tried to render a Turbo stream template. Protect the route with "condition: "\'text/vnd.turbo-stream.html\' in request.getAcceptableContentTypes()" or render a regular HTML response.');
+            }
+
+            $includeChromeContext ??= false;
+
             // Setting the request format will add the correct ContentType header and make
             // sure Symfony renders error pages correctly.
             $request->setRequestFormat('turbo_stream');
-
-            $includeChromeContext ??= false;
-        }
-
-        if ($request->headers->has('turbo-frame')) {
-            $includeChromeContext ??= false;
         }
 
         if ($includeChromeContext ?? true) {

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -108,17 +108,17 @@ class AbstractBackendControllerTest extends TestCase
         System::setContainer($container);
         $controller->setContainer($container);
 
-        $this->assertSame('<custom_be_main>', $controller->fooAction()->getContent());
+        $this->assertSame('<result>', $controller->fooAction()->getContent());
     }
 
     #[DataProvider('provideRequests')]
-    public function testHandlesTurboRequests(Request $request, bool|null $includeChromeContext, array $expectedContext, string $expectedRequestFormat = 'html', int $expectedStatus = Response::HTTP_OK, Response|null $response = null): void
+    public function testHandlesTurboRequests(Request $request, string $view, bool|null $includeChromeContext, array $expectedContext, string $expectedRequestFormat = 'html', int $expectedStatus = Response::HTTP_OK, Response|null $response = null): void
     {
         $controller = new class() extends AbstractBackendController {
-            public function fooAction(bool|null $includeChromeContext, Response|null $response = null): Response
+            public function fooAction(string $view, bool|null $includeChromeContext, Response|null $response = null): Response
             {
                 return $this->render(
-                    'custom_be.html.twig',
+                    $view,
                     ['version' => 'my version'],
                     $response,
                     includeChromeContext: $includeChromeContext,
@@ -148,9 +148,9 @@ class AbstractBackendControllerTest extends TestCase
 
         System::setContainer($container);
         $controller->setContainer($container);
-        $response = $controller->fooAction($includeChromeContext, $response);
+        $response = $controller->fooAction($view, $includeChromeContext, $response);
 
-        $this->assertSame('<custom_be_main>', $response->getContent());
+        $this->assertSame('<result>', $response->getContent());
         $this->assertSame($expectedRequestFormat, $request->getRequestFormat());
         $this->assertSame($expectedStatus, $response->getStatusCode());
     }
@@ -176,73 +176,32 @@ class AbstractBackendControllerTest extends TestCase
             'version' => 'my version',
         ];
 
-        $turboFrameRequest = new Request(server: ['HTTP_HOST' => 'localhost']);
-        $turboFrameRequest->headers->set('Turbo-Frame', 'id');
-
-        yield 'default turbo frame' => [
-            $turboFrameRequest,
-            null,
-            $customContext,
-        ];
-
-        yield 'turbo frame with chrome' => [
-            $turboFrameRequest,
-            true,
-            [...$customContext, ...$defaultContext],
-        ];
-
-        yield 'default turbo frame explicitly without chrome' => [
-            $turboFrameRequest,
-            false,
-            $customContext,
-        ];
-
-        $turboStreamRequest = new Request(server: ['HTTP_HOST' => 'localhost']);
-        $turboStreamRequest->headers->set('Accept', 'text/vnd.turbo-stream.html; charset=utf-8');
-
-        yield 'default turbo stream' => [
-            $turboStreamRequest,
-            null,
-            $customContext,
-            'turbo_stream',
-        ];
-
-        yield 'turbo stream with chrome' => [
-            $turboStreamRequest,
-            true,
-            [...$customContext, ...$defaultContext],
-            'turbo_stream',
-        ];
-
-        yield 'turbo stream explicitly without chrome' => [
-            $turboStreamRequest,
-            false,
-            $customContext,
-            'turbo_stream',
-        ];
-
         $plainRequest = new Request(server: ['HTTP_HOST' => 'localhost']);
 
         yield 'plain request' => [
             $plainRequest,
+            'custom_be.html.twig',
             null,
             [...$customContext, ...$defaultContext],
         ];
 
         yield 'plain request explicitly with chrome' => [
             $plainRequest,
+            'custom_be.html.twig',
             true,
             [...$customContext, ...$defaultContext],
         ];
 
         yield 'plain request without chrome' => [
             $plainRequest,
+            'custom_be.html.twig',
             false,
             $customContext,
         ];
 
         yield 'request with widget error' => [
             new Request(attributes: ['_contao_widget_error' => true], server: ['HTTP_HOST' => 'localhost']),
+            'custom_be.html.twig',
             false,
             $customContext,
             'html',
@@ -251,12 +210,62 @@ class AbstractBackendControllerTest extends TestCase
 
         yield 'request with widget error and 500 response' => [
             new Request(attributes: ['_contao_widget_error' => true], server: ['HTTP_HOST' => 'localhost']),
+            'custom_be.html.twig',
             false,
             $customContext,
             'html',
             Response::HTTP_INTERNAL_SERVER_ERROR,
             new Response(status: Response::HTTP_INTERNAL_SERVER_ERROR),
         ];
+
+        $requestAcceptingTurboStreams = new Request(server: ['HTTP_HOST' => 'localhost']);
+        $requestAcceptingTurboStreams->headers->set('Accept', 'text/vnd.turbo-stream.html; charset=utf-8');
+
+        yield 'regular request accepting turbo stream' => [
+            $requestAcceptingTurboStreams,
+            'custom_be.html.twig',
+            null,
+            [...$customContext, ...$defaultContext],
+        ];
+
+        yield 'turbo stream with chrome' => [
+            $requestAcceptingTurboStreams,
+            'update.stream.html.twig',
+            true,
+            [...$customContext, ...$defaultContext],
+            'turbo_stream',
+        ];
+
+        yield 'turbo stream explicitly without chrome' => [
+            $requestAcceptingTurboStreams,
+            'update.stream.html.twig',
+            false,
+            $customContext,
+            'turbo_stream',
+        ];
+    }
+
+    public function testThrowsAnExceptionWhenRenderingAStreamWithoutBeingAccepted(): void
+    {
+        $controller = new class() extends AbstractBackendController {
+            public function fooAction(string $view, bool|null $includeChromeContext, Response|null $response = null): Response
+            {
+                return $this->render(
+                    $view,
+                    ['version' => 'my version'],
+                    $response,
+                    includeChromeContext: $includeChromeContext,
+                );
+            }
+        };
+
+        $plainRequest = new Request(server: ['HTTP_HOST' => 'localhost']);
+
+        $container = $this->getContainerWithDefaultConfiguration([], $plainRequest);
+        $controller->setContainer($container);
+
+        $this->expectException(\LogicException::class);
+        $controller->fooAction('update.stream.html.twig', null, null);
     }
 
     public function testGetSessionBag(): void
@@ -311,7 +320,8 @@ class AbstractBackendControllerTest extends TestCase
                     $map = [
                         '@Contao/backend/chrome/main_menu.html.twig' => '<menu>',
                         '@Contao/backend/chrome/header_menu.html.twig' => '<header_menu>',
-                        'custom_be.html.twig' => '<custom_be_main>',
+                        'custom_be.html.twig' => '<result>',
+                        'update.stream.html.twig' => '<result>',
                     ];
 
                     return $map[$template];


### PR DESCRIPTION
Fixes #8215

Coproduction with @fritzmg :slightly_smiling_face: 

We're now checking if the rendered template ends with `.stream.html.twig` and only set the request format in that case.

On top, we throw an exception if you try to render such a template but the request was not done by Turbo (or rather does not contain `text/vnd.turbo-stream.html` in the `Accept` header). This makes sure such a response is never seen in the browser/by a search indexer/…