### PR TITLE
Remove the deprecation from `Input::stripTags()`

### DIFF
--- a/core-bundle/contao/library/Contao/Input.php
+++ b/core-bundle/contao/library/Contao/Input.php
@@ -553,11 +553,6 @@ class Input
 	 */
 	public static function stripTags($varValue, $strAllowedTags='', $allowedAttributes='')
 	{
-		if ($strAllowedTags === '' || $allowedAttributes === '')
-		{
-			trigger_deprecation('contao/core-bundle', '5.0', 'Using %s() without setting allowed tags and allowed attributes has been deprecated and will no longer work in Contao 6.', __METHOD__);
-		}
-
 		if (!$varValue)
 		{
 			return $varValue;

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -129,7 +129,6 @@ class InputTest extends TestCase
 
         $this->assertSame($source, Input::postUnsafeRaw('key'));
 
-        $this->expectDeprecation('%sstripTags() without setting allowed tags and allowed attributes has been deprecated%s');
         $this->assertSame($expected, Input::postHtml('key', true));
         $this->assertSame($expectedEncoded, Input::postHtml('key'));
     }
@@ -156,8 +155,6 @@ class InputTest extends TestCase
 
         $this->assertSame($expected, Input::post('decoded', true));
         $this->assertSame($expectedEncoded, Input::post('encoded'));
-
-        $this->expectDeprecation('%sstripTags() without setting allowed tags and allowed attributes has been deprecated%s');
 
         $this->assertSame($expected, Input::postHtml('decoded', true));
         $this->assertSame($expectedEncoded, Input::postHtml('encoded'));
@@ -697,14 +694,10 @@ class InputTest extends TestCase
     }
 
     /**
-     * @group legacy
-     *
      * @dataProvider stripTagsNoTagsAllowedProvider
      */
     public function testStripTagsNoTagsAllowed(string $source, string $expected): void
     {
-        $this->expectDeprecation('%sstripTags() without setting allowed tags and allowed attributes has been deprecated%s');
-
         $this->assertSame($expected, Input::stripTags($source));
     }
 
@@ -736,9 +729,6 @@ class InputTest extends TestCase
         $this->assertSame($html, Input::stripTags($html, '<span>', serialize([['key' => '*', 'value' => '*']])));
     }
 
-    /**
-     * @group legacy
-     */
     public function testStripTagsNoAttributesAllowed(): void
     {
         $html = "<dIv class=gets-normalized bar-foo-something = 'keep'><spAN class=gets-normalized bar-foo-something = 'keep'>foo</SPan></DiV><notallowed></notallowed>";
@@ -749,17 +739,11 @@ class InputTest extends TestCase
         $this->assertSame($expected, Input::stripTags($html, '<div><span>', serialize([])));
         $this->assertSame($expected, Input::stripTags($html, '<div><span>', serialize(null)));
 
-        $this->expectDeprecation('%sstripTags() without setting allowed tags and allowed attributes has been deprecated%s');
         $this->assertSame($expected, Input::stripTags($html, '<div><span>'));
     }
 
-    /**
-     * @group legacy
-     */
     public function testStripTagsScriptAllowed(): void
     {
-        $this->expectDeprecation('%sstripTags() without setting allowed tags and allowed attributes has been deprecated%s');
-
         $this->assertSame(
             '<script>alert(foo > bar);</script>foo &#62; bar',
             Input::stripTags('<script>alert(foo > bar);</script>foo > bar', '<div><span><script>'),


### PR DESCRIPTION
The depreaction is from 8e9edfb376bea50e205edf3857d5b008d97af70e and originally read `Using stripTags() with $strAllowedTags but without $strAllowedAttributes has been deprecated and will no longer work in Contao 5.0.` which was because `$strAllowedAttributes` was newly added and defaulted to the `Config::get('allowedAttributes')`. 

This is no longer the case and calling `stripTags($foo)` without extra configuration just strips all tags and allows no attributes so this usage is perfectly valid.