### PR TITLE
Do not render empty labels in widgets

### DIFF
--- a/core-bundle/contao/templates/backend/be_widget.html5
+++ b/core-bundle/contao/templates/backend/be_widget.html5
@@ -1,6 +1,5 @@
 
-<?php $label = $this->generateLabel(); ?>
-  <?php if (!empty($label)): ?>
-  <h3><?= $this->generateLabel().$this->xlabel ?></h3>
+  <?php if ($label = $this->generateLabel()): ?>
+  <h3><?= $label.$this->xlabel ?></h3>
   <?php endif ?>
   <?= $this->generateWithError(true) ?>

--- a/core-bundle/contao/templates/backend/be_widget.html5
+++ b/core-bundle/contao/templates/backend/be_widget.html5
@@ -1,5 +1,5 @@
 
   <?php if ($label = $this->generateLabel()): ?>
-  <h3><?= $label.$this->xlabel ?></h3>
+    <h3><?= $label.$this->xlabel ?></h3>
   <?php endif ?>
   <?= $this->generateWithError(true) ?>

--- a/core-bundle/contao/templates/backend/be_widget.html5
+++ b/core-bundle/contao/templates/backend/be_widget.html5
@@ -1,3 +1,4 @@
+
 <?php $label = $this->generateLabel(); ?>
   <?php if (!empty($label)): ?>
   <h3><?= $this->generateLabel().$this->xlabel ?></h3>

--- a/core-bundle/contao/templates/backend/be_widget.html5
+++ b/core-bundle/contao/templates/backend/be_widget.html5
@@ -1,3 +1,5 @@
-
+<?php $label = $this->generateLabel(); ?>
+  <?php if (!empty($label)): ?>
   <h3><?= $this->generateLabel().$this->xlabel ?></h3>
+  <?php endif ?>
   <?= $this->generateWithError(true) ?>


### PR DESCRIPTION
### Description

Using `be_widget` as a template also renders empty labels ''.
Kinda need this as a prerequisite for:

* https://github.com/contao/contao/pull/8781
* https://github.com/contao/contao/pull/8658/