### PR TITLE
Do not hardcode the file preview

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -137,6 +137,14 @@ services:
         arguments:
             - '@translator'
 
+    contao.listener.data_container.file_image_preview:
+        class: Contao\CoreBundle\EventListener\DataContainer\FileImagePreviewListener
+        arguments:
+            - '@contao.framework'
+            - '@security.helper'
+            - '@contao.image.factory'
+            - '%kernel.project_dir%'
+
     contao.listener.data_container.frontend_module_permissions:
         class: Contao\CoreBundle\EventListener\DataContainer\FrontendModulePermissionsListener
         arguments:

--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -20,7 +20,6 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
-use Contao\Image\ResizeConfiguration;
 use Doctrine\DBAL\ArrayParameterType;
 
 /**

--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -733,59 +733,7 @@ abstract class DataContainer extends Backend
   </fieldset>';
 		}
 
-		$strPreview = '';
-
-		// Show a preview image (see #4948)
-		if ($this->strTable == 'tl_files' && $this->strField == 'name' && $this->objActiveRecord !== null && $this->objActiveRecord->type == 'file')
-		{
-			$objFile = new File($this->objActiveRecord->path);
-
-			if ($objFile->isImage)
-			{
-				if (!$objFile->isSvgImage || ($objFile->viewWidth && $objFile->viewHeight))
-				{
-					$container = System::getContainer();
-					$projectDir = $container->getParameter('kernel.project_dir');
-
-					try
-					{
-						$image = rawurldecode($container->get('contao.image.factory')->create($projectDir . '/' . $objFile->path, array(699, 524, ResizeConfiguration::MODE_BOX))->getUrl($projectDir));
-					}
-					catch (\Exception $e)
-					{
-						Message::addError($e->getMessage());
-						$image = Image::getPath('placeholder.svg');
-					}
-				}
-				else
-				{
-					$image = Image::getPath('placeholder.svg');
-				}
-
-				$objImage = new File($image);
-				$ctrl = 'ctrl_preview_' . substr(md5($image), 0, 8);
-
-				$strPreview = '
-<div id="' . $ctrl . '" class="tl_edit_preview">
-  <img src="' . $objImage->dataUri . '" width="' . $objImage->width . '" height="' . $objImage->height . '" alt="">
-</div>';
-
-				// Add the script to mark the important part
-				if (basename($image) !== 'placeholder.svg')
-				{
-					$strPreview .= '<script>Backend.editPreviewWizard($(\'' . $ctrl . '\'));</script>';
-
-					if (Config::get('showHelp'))
-					{
-						$strPreview .= '<p class="tl_help tl_tip">' . $GLOBALS['TL_LANG'][$this->strTable]['edit_preview_help'] . '</p>';
-					}
-
-					$strPreview = '<div class="widget">' . $strPreview . '</div>';
-				}
-			}
-		}
-
-		return $strPreview . '
+		return '
 <div' . (!empty($arrAttributes['tl_class']) ? ' class="' . trim($arrAttributes['tl_class']) . '"' : '') . '>' . $objWidget->parse() . $updateMode . (!$objWidget->hasErrors() ? $this->help($strHelpClass, $objWidget->description) : '') . '
 </div>';
 	}

--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -147,7 +147,7 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 	// Palettes
 	'palettes' => array
 	(
-		'default'                     => 'name,protected,syncExclude,importantPartX,importantPartY,importantPartWidth,importantPartHeight;meta'
+		'default'                     => 'preview,name,protected,syncExclude,importantPartX,importantPartY,importantPartWidth,importantPartHeight;meta'
 	),
 
 	// Fields
@@ -193,6 +193,10 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 		'found' => array
 		(
 			'sql'                     => array('type' => 'boolean', 'default' => true)
+		),
+		'preview' => array(
+			// input_field_callback
+			'exclude' => false,
 		),
 		'name' => array
 		(

--- a/core-bundle/contao/languages/en/tl_files.xlf
+++ b/core-bundle/contao/languages/en/tl_files.xlf
@@ -2,6 +2,12 @@
 <xliff version="1.1">
   <file datatype="php" original="contao/languages/en/tl_files.php" source-language="en">
     <body>
+      <trans-unit id="tl_files.preview.0">
+        <source>Image preview</source>
+      </trans-unit>
+      <trans-unit id="tl_files.preview.1">
+        <source>Mark the important part of the image with your mouse cursor.</source>
+      </trans-unit>
       <trans-unit id="tl_files.name.0">
         <source>Name</source>
       </trans-unit>
@@ -91,9 +97,6 @@
       </trans-unit>
       <trans-unit id="tl_files.editFile">
         <source>Edit file "%s"</source>
-      </trans-unit>
-      <trans-unit id="tl_files.edit_preview_help">
-        <source>Mark the important part of the image with your mouse cursor.</source>
       </trans-unit>
       <trans-unit id="tl_files.browseFiles">
         <source>Browse files</source>

--- a/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer;
+
+use Contao\Config;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Image\ImageFactoryInterface;
+use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\DataContainer;
+use Contao\File;
+use Contao\Image\ResizeConfiguration;
+use Symfony\Bundle\SecurityBundle\Security;
+
+#[AsCallback(table: 'tl_files', target: 'fields.preview.input_field')]
+class FileImagePreviewListener
+{
+    public function __construct(
+        private readonly ContaoFramework $framework,
+        private readonly Security $security,
+        private readonly ImageFactoryInterface $imageFactory,
+        private readonly string $projectDir,
+    ) {
+    }
+
+    public function __invoke(DataContainer $dc): string
+    {
+        $objFile = new File($dc->id);
+
+        if (!$objFile->isImage || ($objFile->isSvgImage && (!$objFile->viewWidth || !$objFile->viewHeight))) {
+            return '';
+        }
+
+        if (
+            !$this->security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, 'tl_files::importantPartX')
+            || !$this->security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, 'tl_files::importantPartY')
+            || !$this->security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, 'tl_files::importantPartWidth')
+            || !$this->security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, 'tl_files::importantPartHeight')
+        ) {
+            return '';
+        }
+
+        try {
+            $image = rawurldecode($this->imageFactory->create($this->projectDir . '/' . $objFile->path, array(699, 524, ResizeConfiguration::MODE_BOX))->getUrl($this->projectDir));
+        } catch (\Exception) {
+            return '';
+        }
+
+        $objImage = new File($image);
+        $ctrl = 'ctrl_preview_' . substr(md5($image), 0, 8);
+
+        $strPreview = '
+<div id="' . $ctrl . '" class="tl_edit_preview">
+<img src="' . $objImage->dataUri . '" width="' . $objImage->width . '" height="' . $objImage->height . '" alt="">
+</div>';
+
+        // Add the script to mark the important part
+        $strPreview .= '<script>Backend.editPreviewWizard($(\'' . $ctrl . '\'));</script>';
+
+        if ($this->framework->getAdapter(Config::class)->get('showHelp')) {
+            $strPreview .= '<p class="tl_help tl_tip">' . $GLOBALS['TL_LANG']['tl_files']['preview'][1] . '</p>';
+        }
+
+        $strPreview = '<div class="widget">' . $strPreview . '</div>';
+
+        return $strPreview;
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
@@ -20,6 +20,7 @@ use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\DataContainer;
 use Contao\File;
 use Contao\Image\ResizeConfiguration;
+use Contao\Message;
 use Symfony\Bundle\SecurityBundle\Security;
 
 #[AsCallback(table: 'tl_files', target: 'fields.preview.input_field')]
@@ -52,7 +53,9 @@ class FileImagePreviewListener
 
         try {
             $image = rawurldecode($this->imageFactory->create($this->projectDir.'/'.$objFile->path, [699, 524, ResizeConfiguration::MODE_BOX])->getUrl($this->projectDir));
-        } catch (\Exception) {
+        } catch (\Exception $e) {
+            Message::addError($e->getMessage());
+
             return '';
         }
 

--- a/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
@@ -51,27 +51,27 @@ class FileImagePreviewListener
         }
 
         try {
-            $image = rawurldecode($this->imageFactory->create($this->projectDir . '/' . $objFile->path, array(699, 524, ResizeConfiguration::MODE_BOX))->getUrl($this->projectDir));
+            $image = rawurldecode($this->imageFactory->create($this->projectDir.'/'.$objFile->path, [699, 524, ResizeConfiguration::MODE_BOX])->getUrl($this->projectDir));
         } catch (\Exception) {
             return '';
         }
 
         $objImage = new File($image);
-        $ctrl = 'ctrl_preview_' . substr(md5($image), 0, 8);
+        $ctrl = 'ctrl_preview_'.substr(md5($image), 0, 8);
 
         $strPreview = '
-<div id="' . $ctrl . '" class="tl_edit_preview">
-<img src="' . $objImage->dataUri . '" width="' . $objImage->width . '" height="' . $objImage->height . '" alt="">
+<div id="'.$ctrl.'" class="tl_edit_preview">
+<img src="'.$objImage->dataUri.'" width="'.$objImage->width.'" height="'.$objImage->height.'" alt="">
 </div>';
 
         // Add the script to mark the important part
-        $strPreview .= '<script>Backend.editPreviewWizard($(\'' . $ctrl . '\'));</script>';
+        $strPreview .= '<script>Backend.editPreviewWizard($(\''.$ctrl.'\'));</script>';
 
         if ($this->framework->getAdapter(Config::class)->get('showHelp')) {
-            $strPreview .= '<p class="tl_help tl_tip">' . $GLOBALS['TL_LANG']['tl_files']['preview'][1] . '</p>';
+            $strPreview .= '<p class="tl_help tl_tip">'.$GLOBALS['TL_LANG']['tl_files']['preview'][1].'</p>';
         }
 
-        $strPreview = '<div class="widget">' . $strPreview . '</div>';
+        $strPreview = '<div class="widget">'.$strPreview.'</div>';
 
         return $strPreview;
     }

--- a/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
@@ -65,14 +65,12 @@ class FileImagePreviewListener
 </div>';
 
         // Add the script to mark the important part
-        $strPreview .= '<script>Backend.editPreviewWizard($(\''.$ctrl.'\'));</script>';
+        $strPreview .= '<script>Backend.editPreviewWizard($(\''.$ctrl."'));</script>";
 
         if ($this->framework->getAdapter(Config::class)->get('showHelp')) {
             $strPreview .= '<p class="tl_help tl_tip">'.$GLOBALS['TL_LANG']['tl_files']['preview'][1].'</p>';
         }
 
-        $strPreview = '<div class="widget">'.$strPreview.'</div>';
-
-        return $strPreview;
+        return '<div class="widget">'.$strPreview.'</div>';
     }
 }


### PR DESCRIPTION
The file preview is currently shown if the user does not have access to all of the important part fields, which makes no sense. Additionally, it did render a `placeholder.svg` if the image could not be rendered, instead of just not showing a preview at all.

The additional advantage of the new DCA field is that you can manually choose to display the preview in edit-all mode or only show/edit the file name.