### PR TITLE
Reduce the jobs polling interval to 5 seconds

### DIFF
--- a/core-bundle/contao/templates/twig/backend/jobs/_menu_item.html.twig
+++ b/core-bundle/contao/templates/twig/backend/jobs/_menu_item.html.twig
@@ -3,7 +3,7 @@
 {% set controller_attributes = attrs()
     .set('data-controller', 'contao--jobs')
     .set('data-contao--jobs-pending-jobs-url-value', path('_contao_jobs_pending.stream'))
-    .set('data-contao--jobs-default-interval-value', 1000)
+    .set('data-contao--jobs-default-interval-value', 5000)
     .set('data-contao--jobs-maximum-interval-value', 60000)
     .set('data-contao--jobs-enabled-value', has_pending_jobs)
     .set('data-contao--jobs-all-jobs-processed-message-value', 'jobs.all_jobs_processed'|trans({}, 'contao_jobs'))


### PR DESCRIPTION
As discussed, 1 second seems a bit too aggressive for a default.