### PR TITLE
Bump `bacon-qr-code` to version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ext-zlib": "*",
         "composer-runtime-api": "^2.0.14",
         "ausi/slug-generator": "^1.1",
-        "bacon/bacon-qr-code": "^2.0",
+        "bacon/bacon-qr-code": "^3.0",
         "cmsig/seal": "^0.12",
         "cmsig/seal-loupe-adapter": "^0.12",
         "cmsig/seal-symfony-bundle": "^0.12",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -40,7 +40,7 @@
         "ext-zlib": "*",
         "composer-runtime-api": "^2.0.14",
         "ausi/slug-generator": "^1.1",
-        "bacon/bacon-qr-code": "^2.0",
+        "bacon/bacon-qr-code": "^3.0",
         "cmsig/seal": "^0.12",
         "cmsig/seal-symfony-bundle": "^0.12",
         "contao-components/ace": "^1.8",

--- a/core-bundle/tests/Security/TwoFactor/AuthenticatorTest.php
+++ b/core-bundle/tests/Security/TwoFactor/AuthenticatorTest.php
@@ -138,7 +138,7 @@ class AuthenticatorTest extends TestCase
         $authenticator = new Authenticator($clock);
         $svg = $authenticator->getQrCode($user, $request);
 
-        $this->assertSame(5897, \strlen($svg));
+        $this->assertSame(5905, \strlen($svg));
         $this->assertSame(0, strpos($svg, $beginSvg));
     }
 


### PR DESCRIPTION
### Description

Our tests were throwing 2 deprecation warnings (implicit nullable parameter) in the bcaon/bacon-qr-code component which have been fixed in the new major release.

The only breakable change according to their Release notes is requiring PHP ^8.1. I've successfully tested the QR-Code as well.