### PR TITLE
Handle having no request in the scope matcher

### DIFF
--- a/core-bundle/src/Routing/ScopeMatcher.php
+++ b/core-bundle/src/Routing/ScopeMatcher.php
@@ -53,11 +53,23 @@ class ScopeMatcher
 
     public function isBackendRequest(Request|null $request = null): bool
     {
-        return $this->backendMatcher->matches($request ?? $this->requestStack->getCurrentRequest());
+        $request ??= $this->requestStack->getCurrentRequest();
+
+        if (!$request) {
+            return false;
+        }
+
+        return $this->backendMatcher->matches($request);
     }
 
     public function isFrontendRequest(Request|null $request = null): bool
     {
-        return $this->frontendMatcher->matches($request ?? $this->requestStack->getCurrentRequest());
+        $request ??= $this->requestStack->getCurrentRequest();
+
+        if (!$request) {
+            return false;
+        }
+
+        return $this->frontendMatcher->matches($request);
     }
 }

--- a/core-bundle/tests/Routing/ScopeMatcherTest.php
+++ b/core-bundle/tests/Routing/ScopeMatcherTest.php
@@ -17,6 +17,8 @@ use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -96,5 +98,18 @@ class ScopeMatcherTest extends TestCase
             false,
             false,
         ];
+    }
+
+    public function testReturnsFalseIfThereIsNoRequest(): void
+    {
+        $scopeMatcher = new ScopeMatcher(
+            $this->createMock(RequestMatcherInterface::class),
+            $this->createMock(RequestMatcherInterface::class),
+            new RequestStack(),
+        );
+
+        $this->assertFalse($scopeMatcher->isFrontendRequest());
+        $this->assertFalse($scopeMatcher->isBackendRequest());
+        $this->assertFalse($scopeMatcher->isContaoRequest());
     }
 }


### PR DESCRIPTION
In #6998 a fallback to the current request was added in our scope matcher, thereby widening the parameter type to be nullable. However, the case `$request === null` wasn't handled (which this PR is now adding). 