### PR TITLE
Move two levels up with the save and go back button

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2159,19 +2159,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				Message::reset();
 
-				if (!$this->ptable)
-				{
-					$this->redirect(System::getContainer()->get('router')->generate('contao_backend') . '?do=' . Input::get('do'));
-				}
-				// TODO: try to abstract this
-				elseif ($this->ptable == 'tl_page' && $this->strTable == 'tl_article')
-				{
-					$this->redirect($this->getReferer(false, $this->strTable));
-				}
-				else
-				{
-					$this->redirect($this->getReferer(false, $this->ptable));
-				}
+				$this->redirect($this->getReferer(false, null, 2));
 			}
 			elseif (Input::post('saveNcreate') !== null)
 			{

--- a/core-bundle/contao/library/Contao/System.php
+++ b/core-bundle/contao/library/Contao/System.php
@@ -304,7 +304,7 @@ abstract class System
 	 *
 	 * @param boolean $blnEncodeAmpersands If true, ampersands will be encoded
 	 * @param string  $strTable            An optional table name
-	 * @param string  $intLevel            How many levels to go up the trail
+	 * @param int     $intLevel            How many levels to go up the trail
 	 *
 	 * @return string The referer URL
 	 */

--- a/core-bundle/contao/library/Contao/System.php
+++ b/core-bundle/contao/library/Contao/System.php
@@ -304,10 +304,11 @@ abstract class System
 	 *
 	 * @param boolean $blnEncodeAmpersands If true, ampersands will be encoded
 	 * @param string  $strTable            An optional table name
+	 * @param string  $intLevel            How many levels to go up the trail
 	 *
 	 * @return string The referer URL
 	 */
-	public static function getReferer($blnEncodeAmpersands=false, $strTable=null)
+	public static function getReferer($blnEncodeAmpersands=false, $strTable=null, $intLevel=1)
 	{
 		$container = static::getContainer();
 		$return = null;
@@ -328,9 +329,9 @@ abstract class System
 			{
 				$trail = $container->get('contao.data_container.dca_url_analyzer')->getTrail();
 
-				if ($trail[\count($trail) - 2]['url'] ?? null)
+				if ($trail[\count($trail) - $intLevel - 1]['url'] ?? null)
 				{
-					$return = $trail[\count($trail) - 2]['url'];
+					$return = $trail[\count($trail) - $intLevel - 1]['url'];
 				}
 				elseif (Input::get('do') && Input::get('act'))
 				{

--- a/core-bundle/src/Twig/FragmentTemplate.php
+++ b/core-bundle/src/Twig/FragmentTemplate.php
@@ -338,7 +338,7 @@ final class FragmentTemplate extends Template
     /**
      * @internal
      */
-    public static function getReferer($blnEncodeAmpersands = false, $strTable = null): never
+    public static function getReferer($blnEncodeAmpersands = false, $strTable = null, $intLevel=1): never
     {
         self::throwOnAccess();
     }

--- a/core-bundle/src/Twig/FragmentTemplate.php
+++ b/core-bundle/src/Twig/FragmentTemplate.php
@@ -338,7 +338,7 @@ final class FragmentTemplate extends Template
     /**
      * @internal
      */
-    public static function getReferer($blnEncodeAmpersands = false, $strTable = null, $intLevel=1): never
+    public static function getReferer($blnEncodeAmpersands = false, $strTable = null, $intLevel = 1): never
     {
         self::throwOnAccess();
     }


### PR DESCRIPTION
Alternative to #8827

Save and back now moves two levels up (in the breadcrumb path)

@netzarbeiter is that the desired behavior?

Does that make sense if you edit a deeply nested content element?

Or should “save and go back” instead always go to the topmost level of the current module?