### PR TITLE
Add a PHPStan return type for `StringUtil::deserialize`

### DIFF
--- a/core-bundle/contao/library/Contao/StringUtil.php
+++ b/core-bundle/contao/library/Contao/StringUtil.php
@@ -1009,7 +1009,7 @@ class StringUtil
 	 * @param mixed   $varValue      The serialized string
 	 * @param boolean $blnForceArray True to always return an array
 	 *
-	 * @return mixed The unserialized array or the unprocessed input value
+	 * @return ($blnForceArray is true ? array : mixed) The unserialized array or the unprocessed input value
 	 */
 	public static function deserialize($varValue, $blnForceArray=false)
 	{


### PR DESCRIPTION
This should help IDEs better understand the return type