### PR TITLE
Fix the `undefined method named "shouldPreload"` error

### DIFF
--- a/core-bundle/contao/pages/PageRegular.php
+++ b/core-bundle/contao/pages/PageRegular.php
@@ -261,10 +261,9 @@ class PageRegular extends Frontend
 
 		foreach ($arrModules as $arrModule)
 		{
-			/** @var class-string<Module> $strClass */
 			$strClass = Module::findClass($arrMapper[$arrModule['mod']]->type ?? '');
 
-			if (!$strClass || !$strClass::shouldPreload($arrMapper[$arrModule['mod']]->type ?? '', $objPage, $request))
+			if (!is_a($strClass, Module::class, true) || !$strClass::shouldPreload($arrMapper[$arrModule['mod']]->type ?? '', $objPage, $request))
 			{
 				continue;
 			}
@@ -292,10 +291,9 @@ class PageRegular extends Frontend
 
 		foreach ($objResult->fetchAllAssoc() as list('id' => $intId, 'type' => $strType, 'column' => $strColumn))
 		{
-			/** @var class-string<Module> $strClass */
 			$strClass = Module::findClass($strType);
 
-			if (!$strClass || !$strClass::shouldPreload($strType, $objPage, $request))
+			if (!is_a($strClass, Module::class, true) || !$strClass::shouldPreload($strType, $objPage, $request))
 			{
 				continue;
 			}


### PR DESCRIPTION
Fixes errors like `Attempted to call an undefined method named "shouldPreload" of class "Contao\Form".`