### PR TITLE
Update `paragonie/constant_time_encoding`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "nelmio/security-bundle": "^3.0",
         "nikic/php-parser": "^4.9",
         "nyholm/psr7": "^1.2",
-        "paragonie/constant_time_encoding": "^2.2",
+        "paragonie/constant_time_encoding": "^2.8 || ^3.1",
         "phpspec/php-diff": "^1.0",
         "phpunit/phpunit": "^9.5.19",
         "psr/cache": "^3.0",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -88,7 +88,7 @@
         "nelmio/security-bundle": "^3.0",
         "nikic/php-parser": "^4.9",
         "nyholm/psr7": "^1.2",
-        "paragonie/constant_time_encoding": "^2.2",
+        "paragonie/constant_time_encoding": "^2.8 || ^3.1",
         "phpspec/php-diff": "^1.0",
         "psr/cache": "^3.0",
         "psr/container": "^2.0",


### PR DESCRIPTION
Support PHP 8.4+, get better performance.

<!--
Bugfixes should be based on the 5.3 branch and features on the 5.x branch.
Select the correct branch in the "base:" drop-down menu above.

Pull requests for Contao 4.13 are no longer merged upstream into Contao 5!
If you want to fix a bug in Contao 4.13, please create a pull request for
Contao 5.3 first and then a separate backport pull request for Contao 4.13.
-->
