### PR TITLE
Handle directories in the file image preview

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
@@ -22,7 +22,6 @@ use Contao\File;
 use Contao\Image\ResizeConfiguration;
 use Contao\Message;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\Filesystem\Filesystem;
 
 #[AsCallback(table: 'tl_files', target: 'fields.preview.input_field')]
 class FileImagePreviewListener

--- a/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FileImagePreviewListener.php
@@ -22,6 +22,7 @@ use Contao\File;
 use Contao\Image\ResizeConfiguration;
 use Contao\Message;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Filesystem\Filesystem;
 
 #[AsCallback(table: 'tl_files', target: 'fields.preview.input_field')]
 class FileImagePreviewListener
@@ -36,7 +37,11 @@ class FileImagePreviewListener
 
     public function __invoke(DataContainer $dc): string
     {
-        $objFile = new File($dc->id);
+        try {
+            $objFile = new File($dc->id);
+        } catch (\Exception) {
+            return '';
+        }
 
         if (!$objFile->isImage || ($objFile->isSvgImage && (!$objFile->viewWidth || !$objFile->viewHeight))) {
             return '';


### PR DESCRIPTION
#8819 introduced an error if the current record is a folder. The original code did check for `$dc->activeRecord->type`. Since `File` checks for the type anyway, this is the most safe check to catch and one less IO than checking the `is_dir` ourselves.