### PR TITLE
Add `&amp;` to URL if referrer contains `?` otherwise add `?`

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2442,8 +2442,13 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		if ((string) $currentRecord['tstamp'] === '0')
 		{
-            $strBackUrl = preg_replace('/([?&])revise=\d*/', '$1revise=' . $this->strTable . '.' . ((int) $this->intId), $strBackUrl);
-            $strBackUrl .= strstr($strBackUrl, 'revise=') ?: (strpos($strBackUrl,'?') ? '&' : '?') . 'revise=' . $this->strTable . '.' . ((int) $this->intId);
+			$delimiter = (strpos($strBackUrl, '?') !== false) ? '&amp;' : '?';
+			$strBackUrl = preg_replace(
+				'/&(?:amp;)?revise=[^&]+|$/',
+				$delimiter . 'revise=' . $this->strTable . '.' . (int) $this->intId,
+				$strBackUrl,
+				1
+			);
 		}
 
 		// Begin the form (-> DO NOT CHANGE THIS ORDER -> this way the onsubmit attribute of the form can be changed by a field)

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2442,7 +2442,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		if ((string) $currentRecord['tstamp'] === '0')
 		{
-			$strBackUrl = preg_replace('/&(?:amp;)?revise=[^&]+|$/', '&amp;revise=' . $this->strTable . '.' . ((int) $this->intId), $strBackUrl, 1);
+			$strBackUrl = preg_replace('/&(?:amp;)?revise=[^&]+|$/', (str_contains($strBackUrl, '?') ? '&amp;' : '?') . 'revise=' . $this->strTable . '.' . ((int)$this->intId), $strBackUrl, 1);
 		}
 
 		// Begin the form (-> DO NOT CHANGE THIS ORDER -> this way the onsubmit attribute of the form can be changed by a field)

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2442,7 +2442,8 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		if ((string) $currentRecord['tstamp'] === '0')
 		{
-			$strBackUrl = preg_replace('/&(?:amp;)?revise=[^&]+|$/', (str_contains($strBackUrl, '?') ? '&amp;' : '?') . 'revise=' . $this->strTable . '.' . ((int)$this->intId), $strBackUrl, 1);
+            $strBackUrl = preg_replace('/([?&])revise=\d*/', '$1revise=' . $this->strTable . '.' . ((int) $this->intId), $strBackUrl);
+            $strBackUrl .= strstr($strBackUrl, 'revise=') ?: (strpos($strBackUrl,'?') ? '&' : '?') . 'revise=' . $this->strTable . '.' . ((int) $this->intId);
 		}
 
 		// Begin the form (-> DO NOT CHANGE THIS ORDER -> this way the onsubmit attribute of the form can be changed by a field)


### PR DESCRIPTION
When using backend controllers e.g. for custom listings and linking to DC_TABLE actions then the back url starts with an "amp;" which causes the route to not be found. 

https://domain.de/contao/backend-end-route&revise=table.4

<!--
Bugfixes should be based on the 5.3 branch and features on the 5.x branch.
Select the correct branch in the "base:" drop-down menu above.

Pull requests for Contao 4.13 are no longer merged upstream into Contao 5!
If you want to fix a bug in Contao 4.13, please create a pull request for
Contao 5.3 first and then a separate backport pull request for Contao 4.13.
-->
