### PR TITLE
Fix the `datetime` types in the Doctrine entities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "contao/manager-plugin": "^2.6.2",
         "php-feed-io/feed-io": "^6.0",
         "doctrine/collections": "^2.1",
-        "doctrine/dbal": "^3.6.2 || ^4.3",
+        "doctrine/dbal": "^3.7 || ^4.3",
         "doctrine/doctrine-bundle": "^2.8",
         "doctrine/orm": "^2.17 || ^3.0",
         "doctrine/persistence": "^3.2",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -65,7 +65,7 @@
         "contao/image": "^1.2",
         "contao/imagine-svg": "^1.0",
         "doctrine/collections": "^2.1",
-        "doctrine/dbal": "^3.6.2 || ^4.3",
+        "doctrine/dbal": "^3.7 || ^4.3",
         "doctrine/doctrine-bundle": "^2.8",
         "doctrine/orm": "^2.17 || ^3.0",
         "doctrine/persistence": "^3.2",

--- a/core-bundle/src/Entity/Altcha.php
+++ b/core-bundle/src/Entity/Altcha.php
@@ -34,16 +34,21 @@ class Altcha
     #[Column(type: 'string', length: 64, nullable: false)]
     protected string $challenge;
 
-    #[Column(type: 'datetime')]
-    protected \DateTimeInterface $created;
+    #[Column(type: 'datetime_immutable')]
+    protected \DateTimeImmutable $created;
 
-    #[Column(type: 'datetime')]
-    protected \DateTimeInterface $expires;
+    #[Column(type: 'datetime_immutable')]
+    protected \DateTimeImmutable $expires;
 
     public function __construct(string $challenge, \DateTimeInterface $expires)
     {
         $this->challenge = $challenge;
-        $this->created = new \DateTime();
+        $this->created = new \DateTimeImmutable();
+
+        if (!$expires instanceof \DateTimeImmutable) {
+            $expires = \DateTimeImmutable::createFromInterface($expires);
+        }
+
         $this->expires = $expires;
     }
 
@@ -90,6 +95,10 @@ class Altcha
 
     public function setExpires(\DateTimeInterface $expires): self
     {
+        if (!$expires instanceof \DateTimeImmutable) {
+            $expires = \DateTimeImmutable::createFromInterface($expires);
+        }
+
         $this->created = $expires;
 
         return $this;

--- a/core-bundle/src/Entity/Altcha.php
+++ b/core-bundle/src/Entity/Altcha.php
@@ -83,6 +83,10 @@ class Altcha
 
     public function setCreated(\DateTimeInterface $created): self
     {
+        if (!$created instanceof \DateTimeImmutable) {
+            $created = \DateTimeImmutable::createFromInterface($created);
+        }
+
         $this->created = $created;
 
         return $this;

--- a/core-bundle/src/Entity/CronJob.php
+++ b/core-bundle/src/Entity/CronJob.php
@@ -33,18 +33,18 @@ class CronJob
     #[Column(type: 'string', length: 255, nullable: false)]
     protected string $name;
 
-    #[Column(type: 'datetime', nullable: false)]
-    protected \DateTime $lastRun;
+    #[Column(type: 'datetime_immutable', nullable: false)]
+    protected \DateTimeImmutable $lastRun;
 
     public function __construct(string $name, \DateTimeInterface|null $lastRun = null)
     {
         $this->name = $name;
 
-        if ($lastRun && !$lastRun instanceof \DateTime) {
-            $lastRun = \DateTime::createFromInterface($lastRun);
+        if ($lastRun && !$lastRun instanceof \DateTimeImmutable) {
+            $lastRun = \DateTimeImmutable::createFromInterface($lastRun);
         }
 
-        $this->lastRun = $lastRun ?? new \DateTime();
+        $this->lastRun = $lastRun ?? new \DateTimeImmutable();
     }
 
     public function getName(): string
@@ -54,8 +54,8 @@ class CronJob
 
     public function setLastRun(\DateTimeInterface $lastRun): self
     {
-        if (!$lastRun instanceof \DateTime) {
-            $lastRun = \DateTime::createFromInterface($lastRun);
+        if (!$lastRun instanceof \DateTimeImmutable) {
+            $lastRun = \DateTimeImmutable::createFromInterface($lastRun);
         }
 
         $this->lastRun = $lastRun;

--- a/core-bundle/src/Entity/TrustedDevice.php
+++ b/core-bundle/src/Entity/TrustedDevice.php
@@ -28,8 +28,8 @@ class TrustedDevice
     #[GeneratedValue(strategy: 'AUTO')]
     protected int|null $id = null;
 
-    #[Column(type: 'datetime')]
-    protected \DateTimeInterface $created;
+    #[Column(type: 'datetime_immutable')]
+    protected \DateTimeImmutable $created;
 
     #[Column(type: 'string', nullable: true)]
     protected string|null $userClass = null;
@@ -52,7 +52,7 @@ class TrustedDevice
     public function __construct(User $user)
     {
         $this->userId = $user->id;
-        $this->created = new \DateTime();
+        $this->created = new \DateTimeImmutable();
         $this->userClass = $user::class;
     }
 
@@ -75,6 +75,10 @@ class TrustedDevice
 
     public function setCreated(\DateTimeInterface $created): self
     {
+        if (!$created instanceof \DateTimeImmutable) {
+            $created = \DateTimeImmutable::createFromInterface($created);
+        }
+
         $this->created = $created;
 
         return $this;


### PR DESCRIPTION
Currently the following error occurs when sending a form with an altcha widget:

```
Doctrine\DBAL\Types\Exception\InvalidType:
Could not convert PHP value of type DateTime to type Doctrine\DBAL\Types\DateTimeImmutableType. Expected one of the following types: null, DateTimeImmutable.

  at vendor\doctrine\dbal\src\Types\Exception\InvalidType.php:49
  at Doctrine\DBAL\Types\Exception\InvalidType::new()
     (vendor\doctrine\dbal\src\Types\DateTimeImmutableType.php:43)
  at Doctrine\DBAL\Types\DateTimeImmutableType->convertToDatabaseValue()
     (vendor\doctrine\dbal\src\Statement.php:86)
  at Doctrine\DBAL\Statement->bindValue()
     (vendor\doctrine\orm\src\Persisters\Entity\BasicEntityPersister.php:251)
  at Doctrine\ORM\Persisters\Entity\BasicEntityPersister->executeInserts()
     (vendor\doctrine\orm\src\UnitOfWork.php:1059)
  at Doctrine\ORM\UnitOfWork->executeInserts()
     (vendor\doctrine\orm\src\UnitOfWork.php:402)
  at Doctrine\ORM\UnitOfWork->commit()
     (vendor\doctrine\orm\src\EntityManager.php:268)
  at Doctrine\ORM\EntityManager->flush()
     (vendor\contao\contao\core-bundle\src\Altcha\Altcha.php:104)
  at Contao\CoreBundle\Altcha\Altcha->validate()
     (vendor\contao\contao\core-bundle\contao\forms\FormAltcha.php:106)
  at Contao\FormAltcha->validator()
     (vendor\contao\contao\core-bundle\contao\library\Contao\Widget.php:736)
  at Contao\Widget->validate()
```

Using `\DateTimeImmutable` together with the `datetime` type [has been deprecated in `doctrine/dbal` `3.7`](https://www.doctrine-project.org/projects/doctrine-dbal/en/4.3/reference/types.html#datetime-immutable) and support for that was dropped in `4.0`. You need to use `\DateTime` together with `datetime` or `\DateTimeImmutable` together with `datetime_immutable`. Since we do not want to allow modifying the date member variables of our entities we should always use `datetime_immutable`.

> [!NOTE]
> For consistency, this also changes the types accordingly in our `CronJob` and `TrustedDevice` entities. We could backport this to 5.3, but I think there is little reason to do so.