### PR TITLE
Map the backup object to file names

### DIFF
--- a/core-bundle/src/Command/Backup/BackupRestoreCommand.php
+++ b/core-bundle/src/Command/Backup/BackupRestoreCommand.php
@@ -54,8 +54,8 @@ class BackupRestoreCommand extends AbstractBackupCommand
 
         if ([] !== $backups) {
             $choices = array_map(
-                fn(Backup $option) => $option->getFilename(),
-                $backups
+                static fn (Backup $option) => $option->getFilename(),
+                $backups,
             );
 
             $question = new ChoiceQuestion('Select a backup (press <return> to use the latest one)', array_values($choices), 0);

--- a/core-bundle/src/Command/Backup/BackupRestoreCommand.php
+++ b/core-bundle/src/Command/Backup/BackupRestoreCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Command\Backup;
 
+use Contao\CoreBundle\Doctrine\Backup\Backup;
 use Contao\CoreBundle\Doctrine\Backup\BackupManagerException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -52,10 +53,15 @@ class BackupRestoreCommand extends AbstractBackupCommand
         $backups = $this->backupManager->listBackups();
 
         if ([] !== $backups) {
-            $question = new ChoiceQuestion('Select a backup (press <return> to use the latest one)', array_values($backups), 0);
+            $choices = array_map(
+                fn(Backup $option) => $option->getFilename(),
+                $backups
+            );
+
+            $question = new ChoiceQuestion('Select a backup (press <return> to use the latest one)', array_values($choices), 0);
             $option = $this->io->askQuestion($question);
 
-            $this->backupName = $option->getFilename();
+            $this->backupName = $option;
         }
     }
 


### PR DESCRIPTION
### Description

Fixes the failing PHPstan test.

Whilst this did work before, we only ever need the file name of the backups.
<img width="649" height="125" alt="image" src="https://github.com/user-attachments/assets/da5e7d30-632b-416b-9c47-2450d9b614ae" />


