### PR TITLE
Do not double-encode the operation title

### DIFF
--- a/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
@@ -225,7 +225,7 @@ class DataContainerOperationsBuilder extends AbstractDataContainerOperationsBuil
                 'onclick',
                 \sprintf(
                     "Backend.openModalIframe({title:'%s', url:'%s'});return false",
-                    StringUtil::specialchars($config['title']),
+                    $config['title'],
                     $href.(str_contains($href, '?') ? '&' : '?').'popup=1',
                 ),
             );


### PR DESCRIPTION
The output is already encoded by the Twig template.