### PR TITLE
Remove a superfluous `"` in the data-action attribute of the `be_main` template

### DIFF
--- a/core-bundle/contao/templates/backend/be_main.html5
+++ b/core-bundle/contao/templates/backend/be_main.html5
@@ -14,7 +14,7 @@ $this->bodyAttributes = $this
     ->addClass('be_main')
     ->addClass('popup', $this->isPopup)
     ->set('data-controller', 'contao--tooltips contao--toggle-state')
-    ->set('data-action', '"touchstart@document->contao--tooltips#touchStart keydown.esc@document->contao--toggle-state#close')
+    ->set('data-action', 'touchstart@document->contao--tooltips#touchStart keydown.esc@document->contao--toggle-state#close')
     ->set('data-contao--toggle-state-active-class', 'active')
     ->mergeWith($this->bodyAttributes)
 ;


### PR DESCRIPTION
### Description

Thanks to @Toflar for pointing that out.

This is a regression caused by https://github.com/contao/contao/pull/8618/files#diff-d5b9d2c96b5f5a0060c70d34a59de8bc2e9246872aa47d95e4e6af47f6daac5eR17 which has been fixed by https://github.com/contao/contao/pull/8612