### PR TITLE
Add the `referrerpolicy` attribute to the `_video.html.twig` template

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/_video.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/_video.html.twig
@@ -17,7 +17,7 @@
                 {{ block('splash_screen_component') }}
             {% else %}
                 {% block iframe %}
-                    {% set iframe_attrs = attrs({width, height, src: source.url, allowfullscreen: true})
+                    {% set iframe_attrs = attrs({width, height, src: source.url, allowfullscreen: true, referrerpolicy: 'strict-origin-when-cross-origin'})
                         .mergeWith(iframe_attrs|default)
                     %}
                     {% do csp_source('frame-src', iframe_attrs.src) %}

--- a/core-bundle/tests/Controller/ContentElement/VideoControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/VideoControllerTest.php
@@ -50,6 +50,7 @@ class VideoControllerTest extends ContentElementTestCase
                         height="360"
                         src="https://www.youtube-nocookie.com/embed/12345678?fs=0&amp;iv_load_policy=3&amp;loop=1&amp;start=15&amp;end=60"
                         allowfullscreen
+                        referrerpolicy="strict-origin-when-cross-origin"
                         allow="autoplay; encrypted-media; picture-in-picture; fullscreen"></iframe>
                     <figcaption>Some caption</figcaption>
                 </figure>
@@ -95,7 +96,8 @@ class VideoControllerTest extends ContentElementTestCase
                             width="1600"
                             height="900"
                             src="https://player.vimeo.com/video/12345678?h=123abc&amp;autoplay=1&amp;portrait=0&amp;color=f47c00#t=30s"
-                            allowfullscreen></iframe>
+                            allowfullscreen
+                            referrerpolicy="strict-origin-when-cross-origin"></iframe>
                     </template>
                 </button>
                 </figure>


### PR DESCRIPTION
Adding "referrerpolicy" attribute to iframe tag with  a value of "strict-origin-when-cross-origin"

Fixes #8887
