### PR TITLE
Do not preload reader modules if there are no articles in the layout

### DIFF
--- a/core-bundle/contao/pages/PageRegular.php
+++ b/core-bundle/contao/pages/PageRegular.php
@@ -287,7 +287,8 @@ class PageRegular extends Frontend
 			}
 		}
 
-		if (empty($arrArticleColumns)) {
+		if (empty($arrArticleColumns))
+		{
 			return $arrPreloaded;
 		}
 

--- a/core-bundle/contao/pages/PageRegular.php
+++ b/core-bundle/contao/pages/PageRegular.php
@@ -287,6 +287,10 @@ class PageRegular extends Frontend
 			}
 		}
 
+		if (empty($arrArticleColumns)) {
+			return $arrPreloaded;
+		}
+
 		$objResult = ContentModel::findModulesByArticleByPublishedPidAndColumns($objPage->id, $arrArticleColumns);
 
 		foreach ($objResult->fetchAllAssoc() as list('id' => $intId, 'type' => $strType, 'column' => $strColumn))


### PR DESCRIPTION
### Description

* Attempt to fix #8902 

See https://github.com/contao/contao/issues/8902#issuecomment-3352741925 for the explanation

/cc @ausi 

