### PR TITLE
Support legacy templates in the Template studio

### DIFF
--- a/core-bundle/assets/styles/template-studio/common.pcss
+++ b/core-bundle/assets/styles/template-studio/common.pcss
@@ -126,17 +126,26 @@
         background-size: 10px 10px;
     }
 
-    .warning {
-        background-color: var(--error-bg);
-        color: var(--red);
+    .warning, .info {
         padding: 12px;
         margin: 6px 12px;
         border-radius: var(--border-radius);
         font-size: 0.8rem;
+        line-height: 1.3;
 
         svg {
             vertical-align: middle;
             padding-bottom: 2px;
+        }
+
+        &.warning {
+            background-color: var(--error-bg);
+            color: var(--red);
+        }
+
+        &.info {
+            background-color: var(--info-bg);
+            color: var(--blue);
         }
     }
 }

--- a/core-bundle/assets/styles/template-studio/editor-tab.pcss
+++ b/core-bundle/assets/styles/template-studio/editor-tab.pcss
@@ -64,7 +64,7 @@
             flex-shrink: 0;
         }
 
-        .warning {
+        .warning, .info {
             max-width: min(80%, 450px);
         }
     }

--- a/core-bundle/contao/languages/en/template_studio.xlf
+++ b/core-bundle/contao/languages/en/template_studio.xlf
@@ -101,6 +101,9 @@
       <trans-unit id="dialog.rename_variant">
         <source>Please define a new unique name for the variant template %s.</source>
       </trans-unit>
+      <trans-unit id="editor_tab.relation.legacy_pair">
+        <source>The %identifier% template is provided in two formats. When making adjustments, prefer the Twig variant to stay compatible with Contao 6.</source>
+      </trans-unit>
       <trans-unit id="editor_tab.relation.not_analyzable">
         <source>The template's relation cannot be analyzed because it contains errors.</source>
       </trans-unit>

--- a/core-bundle/contao/templates/twig/backend/template_studio/editor/_editor_tab.html.twig
+++ b/core-bundle/contao/templates/twig/backend/template_studio/editor/_editor_tab.html.twig
@@ -60,39 +60,54 @@
             {# Relation to next representation #}
             {% if not loop.last %}
                 <div class="relation">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"
-                         fill="none"
-                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M8 18L12 22L16 18"/>
-                        <path d="M12 2V22"/>
-                    </svg>
-                    {% if template.relation.not_analyzable %}
-                        <div class="warning">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
-                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                                 stroke-linejoin="round">
-                                <circle cx="12" cy="12" r="10"/>
-                                <line x1="12" x2="12" y1="8" y2="12"/>
-                                <line x1="12" x2="12.01" y1="16" y2="16"/>
-                            </svg>
-                            {{ 'editor_tab.relation.not_analyzable'|trans }}
-                        </div>
-                    {% elseif template.relation.warning %}
-                        <div class="warning">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
-                                 fill="none"
-                                 stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                                 stroke-linejoin="round">
-                                <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>
-                                <path d="M12 9v4"/>
-                                <path d="M12 17h.01"/>
-                            </svg>
-                            {% set message = 'editor_tab.relation.' ~ (template.is_component ? 'no_use_warning' : 'no_extend_warning') %}
-                            {% set previous_token -%}
-                                <span class="token">@Contao/{{ template.identifier }}.{{ template.extension }}</span>
+                    {% if template.relation.legacy_pair %}
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M12 2v20"/>
+                            <path d="m8 18 4 4 4-4"/>
+                            <path d="m8 6 4-4 4 4"/>
+                        </svg>
+                        <div class="info">
+                            {% set identifier_token -%}
+                                <span class="token">{{ template.identifier }}</span>
                             {%- endset %}
-                            {{ message|trans|replace({'%previous%': previous_token})|raw }}
+                            {{ 'editor_tab.relation.legacy_pair'|trans|replace({'%identifier%': identifier_token})|raw }}
                         </div>
+                    {% else %}
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"
+                             fill="none"
+                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M8 18L12 22L16 18"/>
+                            <path d="M12 2V22"/>
+                        </svg>
+                        {% if template.relation.not_analyzable %}
+                            <div class="warning">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+                                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                     stroke-linejoin="round">
+                                    <circle cx="12" cy="12" r="10"/>
+                                    <line x1="12" x2="12" y1="8" y2="12"/>
+                                    <line x1="12" x2="12.01" y1="16" y2="16"/>
+                                </svg>
+                                {{ 'editor_tab.relation.not_analyzable'|trans }}
+                            </div>
+                        {% elseif template.relation.warning %}
+                            <div class="warning">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+                                     fill="none"
+                                     stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                     stroke-linejoin="round">
+                                    <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>
+                                    <path d="M12 9v4"/>
+                                    <path d="M12 17h.01"/>
+                                </svg>
+                                {% set message = 'editor_tab.relation.' ~ (template.is_component ? 'no_use_warning' : 'no_extend_warning') %}
+                                {% set previous_token -%}
+                                    <span class="token">@Contao/{{ template.identifier }}.{{ template.extension }}</span>
+                                {%- endset %}
+                                {{ message|trans|replace({'%previous%': previous_token})|raw }}
+                            </div>
+                        {% endif %}
                     {% endif %}
                 </div>
             {% endif %}

--- a/core-bundle/src/Controller/BackendTemplateStudioController.php
+++ b/core-bundle/src/Controller/BackendTemplateStudioController.php
@@ -174,8 +174,10 @@ class BackendTemplateStudioController extends AbstractBackendController
             $templateInformation = $this->inspector->inspectTemplate($logicalName);
             $isComponent = $templateInformation->isComponent();
 
+            $templateNameInformation = $this->getTemplateNameInformation($logicalName);
+
             $template = [
-                ...$this->getTemplateNameInformation($logicalName),
+                ...$templateNameInformation,
                 'path' => $source->getPath(),
                 'code' => $source->getCode(),
                 'is_origin' => $i === $numTemplates - 1,
@@ -184,6 +186,7 @@ class BackendTemplateStudioController extends AbstractBackendController
                     'shadowed' => $shadowed,
                     'warning' => false,
                     'not_analyzable' => false,
+                    'legacy_pair' => $this->isLegacyIdentifier($templateNameInformation['identifier']),
                 ],
                 'annotations' => $canEdit && 0 === $i
                     ? $this->getAnnotations($logicalName, $templateInformation->getError())

--- a/core-bundle/src/Controller/BackendTemplateStudioController.php
+++ b/core-bundle/src/Controller/BackendTemplateStudioController.php
@@ -410,6 +410,7 @@ class BackendTemplateStudioController extends AbstractBackendController
         }
 
         $prefixTree = [];
+        $legacyNodes = [];
 
         foreach ($this->getFinder() as $identifier => $extension) {
             $parts = explode('/', $identifier);
@@ -434,6 +435,12 @@ class BackendTemplateStudioController extends AbstractBackendController
                 }
             };
 
+            // Group legacy templates under their own key
+            if ($this->isLegacyIdentifier($identifier)) {
+                $legacyNodes[$identifier] = [$leaf];
+                continue;
+            }
+
             $node = [...$node, $leaf];
         }
 
@@ -450,9 +457,23 @@ class BackendTemplateStudioController extends AbstractBackendController
         };
 
         $sortRecursive($prefixTree);
+        ksort($legacyNodes);
 
-        // Apply opinionated ordering
-        return ['content_element' => [], 'frontend_module' => [], 'component' => [], ...$prefixTree];
+        return array_filter([
+            // Apply opinionated ordering by explicitly placing keys of the prefix tree
+            // before merging it
+            'content_element' => [],
+            'frontend_module' => [],
+            'component' => [],
+            ...$prefixTree,
+            // Append legacy nodes to the end under a virtual "legacy" key
+            '(legacy)' => $legacyNodes,
+        ]);
+    }
+
+    private function isLegacyIdentifier(string $identifier): bool
+    {
+        return !str_contains($identifier, '/') && $this->loader->exists("@Contao/$identifier.html5");
     }
 
     /**


### PR DESCRIPTION
Closes #8868 

- [x] group legacy templates under a virtual node
- [x] correctly display the relation of format variants
- [ ] fixes from #8802 to correctly display `html5` templates
- [ ] legacy operations to create/rename/delete user templates and variants