### PR TITLE
Fixes flashing of mobile navigation when loading the page

### DIFF
--- a/core-bundle/assets/styles/frontend/navigation.pcss
+++ b/core-bundle/assets/styles/frontend/navigation.pcss
@@ -25,12 +25,20 @@
     --skip-focus-border-color: #f47c00;
 }
 
-body.navigation-open {
-    overflow: hidden;
+body {
+    &:not(.navigation-open):not(.nav-is-desktop) .navigation-main {
+        opacity: 0;
+        pointer-events: none;
+        visibility: hidden;
+    }
 
-    header .logo {
-        position: relative;
-        z-index: 7;
+    &.navigation-open {
+        overflow: hidden;
+    
+        header .logo {
+            position: relative;
+            z-index: 7;
+        }
     }
 }
 
@@ -173,12 +181,6 @@ body.nav-is-mobile {
                 backdrop-filter: blur(1px);
                 z-index: 1;
             }
-        }
-
-        &:not(.is-active) {
-            opacity: 0;
-            visibility: hidden;
-            pointer-events: none;
         }
 
         :is(a, strong) {


### PR DESCRIPTION
The mobile navigation is viewed on every page load for a very short time (.15s) because:

```
body.nav-is-mobile .navigation-main {
    transition: opacity .15s ease-in-out,visibility .1s;
}
```

This is because the body class nav-is-mobile is added with java script after page load.