### PR TITLE
Pass through the `ImageInterface` instance in the figure builder

### DIFF
--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -296,13 +296,8 @@ class FigureBuilder
     public function fromImage(ImageInterface $image): self
     {
         $this->image = $image;
-        $this->filePath = $image->getPath();
 
-        if (!$this->filesystem->exists($this->filePath)) {
-            $this->lastException = new InvalidResourceException(\sprintf('No resource could be located at path "%s".', $this->filePath));
-        }
-
-        return $this;
+        return $this->fromPath($image->getPath());
     }
 
     /**

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -57,6 +57,11 @@ class FigureBuilder
     private FilesModel|null $filesModel = null;
 
     /**
+     * The image resource, if given.
+     */
+    private ImageInterface|null $image = null;
+
+    /**
      * User defined size configuration.
      *
      * @phpcsSuppress SlevomatCodingStandard.Classes.UnusedPrivateElements
@@ -290,7 +295,14 @@ class FigureBuilder
      */
     public function fromImage(ImageInterface $image): self
     {
-        return $this->fromPath($image->getPath());
+        $this->image = $image;
+        $this->filePath = $image->getPath();
+
+        if (!$this->filesystem->exists($this->filePath)) {
+            $this->lastException = new InvalidResourceException(\sprintf('No resource could be located at path "%s".', $this->filePath));
+        }
+
+        return $this;
     }
 
     /**
@@ -643,7 +655,7 @@ class FigureBuilder
 
         $imageResult = $this->locator
             ->get('contao.image.studio')
-            ->createImage($settings->filePath, $settings->sizeConfiguration, $settings->resizeOptions)
+            ->createImage($settings->image ?? $settings->filePath, $settings->sizeConfiguration, $settings->resizeOptions)
         ;
 
         // Define the values via closure to make their evaluation lazy

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -352,7 +352,7 @@ class FigureBuilderTest extends TestCase
             ->willReturn($filePathOutsideUploadDir)
         ;
 
-        $studio = $this->mockStudioForImage($filePathOutsideUploadDir);
+        $studio = $this->mockStudioForImage($image);
 
         $this->getFigureBuilder($studio)->fromImage($image)->build();
     }
@@ -427,7 +427,7 @@ class FigureBuilderTest extends TestCase
             Validator::class => $validatorAdapter,
         ]);
 
-        $studio = $this->mockStudioForImage($absoluteFilePath);
+        $studio = $this->mockStudioForImage($identifier instanceof ImageInterface ? $identifier : $absoluteFilePath);
 
         $this->getFigureBuilder($studio, $framework)->from($identifier)->build();
     }
@@ -1456,7 +1456,7 @@ class FigureBuilderTest extends TestCase
         return $builder->build();
     }
 
-    private function mockStudioForImage(string $expectedFilePath, string|null $expectedSizeConfiguration = null, ResizeOptions|null $resizeOptions = null): Studio&MockObject
+    private function mockStudioForImage(ImageInterface|string $expectedImage, string|null $expectedSizeConfiguration = null, ResizeOptions|null $resizeOptions = null): Studio&MockObject
     {
         $image = $this->createMock(ImageResult::class);
 
@@ -1464,7 +1464,7 @@ class FigureBuilderTest extends TestCase
         $studio
             ->expects($this->once())
             ->method('createImage')
-            ->with($expectedFilePath, $expectedSizeConfiguration, $resizeOptions)
+            ->with($expectedImage, $expectedSizeConfiguration, $resizeOptions)
             ->willReturn($image)
         ;
 


### PR DESCRIPTION
If you have something like this

```php
$image = $this->imageFactory
    ->create('foo/bar.jpg')
    ->setImportantPart(new ImportantPart(0, 0, 0.25, 1))
;

$figure = $this->studio->createFigureBuilder()
    ->fromImage($image)
    ->setSize('_my_size') // crops to 100x100
    ->build()
;

// Then render $figure in template
```

the programatically set `ImportantPart` will get lost, because `fromImage()` in the `FigureBuilder` currently just executes `fromPath()`, which creates a new empty `ImageInterface` instance. This PR allows the `ImageInterface` instance to be passed through.
