### PR TITLE
Add `|default` to `toolbar_attributes` to fix "Variable does not exist" error

### DIFF
--- a/core-bundle/contao/templates/twig/frontend_preview/toolbar.html.twig
+++ b/core-bundle/contao/templates/twig/frontend_preview/toolbar.html.twig
@@ -2,7 +2,7 @@
 
 {% set toolbar_attributes = attrs(attributes)
     .addClass('cto-toolbar__inside')
-    .mergeWith(toolbar_attributes)
+    .mergeWith(toolbar_attributes|default)
 %}
 
 <div class="cto-toolbar__open">


### PR DESCRIPTION
In the current 5.x-dev, if you're in the frontend preview with the debug mode enabled, the preview toolbar wont work and instead the following error is displayed. This PR fixes that by adding a `|default`.

<img width="893" height="34" alt="image" src="https://github.com/user-attachments/assets/2db18cd9-3857-4da8-bb07-de1c4e4bf9a3" />

\
Only 5.x is affected, because this problem was introduced by https://github.com/contao/contao/pull/8852.