### PR TITLE
Do not check the publishing state for content URL results

### DIFF
--- a/calendar-bundle/src/Routing/CalendarEventsResolver.php
+++ b/calendar-bundle/src/Routing/CalendarEventsResolver.php
@@ -41,20 +41,20 @@ class CalendarEventsResolver implements ContentUrlResolverInterface
             case 'internal':
                 $pageAdapter = $this->framework->getAdapter(PageModel::class);
 
-                return ContentUrlResult::redirect($pageAdapter->findPublishedById($content->jumpTo));
+                return ContentUrlResult::redirect($pageAdapter->findById($content->jumpTo));
 
             // Link to an article
             case 'article':
                 $articleAdapter = $this->framework->getAdapter(ArticleModel::class);
 
-                return ContentUrlResult::redirect($articleAdapter->findPublishedById($content->articleId));
+                return ContentUrlResult::redirect($articleAdapter->findById($content->articleId));
         }
 
         $pageAdapter = $this->framework->getAdapter(PageModel::class);
         $calendarAdapter = $this->framework->getAdapter(CalendarModel::class);
 
         // Link to the default page
-        return ContentUrlResult::resolve($pageAdapter->findPublishedById((int) $calendarAdapter->findById($content->pid)?->jumpTo));
+        return ContentUrlResult::resolve($pageAdapter->findById((int) $calendarAdapter->findById($content->pid)?->jumpTo));
     }
 
     public function getParametersForContent(object $content, PageModel $pageModel): array

--- a/calendar-bundle/tests/Routing/CalendarEventsResolverTest.php
+++ b/calendar-bundle/tests/Routing/CalendarEventsResolverTest.php
@@ -39,10 +39,10 @@ class CalendarEventsResolverTest extends ContaoTestCase
         $jumpTo = $this->mockClassWithProperties(PageModel::class);
         $content = $this->mockClassWithProperties(CalendarEventsModel::class, ['source' => 'internal', 'jumpTo' => 42]);
 
-        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter = $this->mockAdapter(['findById']);
         $pageAdapter
             ->expects($this->once())
-            ->method('findPublishedById')
+            ->method('findById')
             ->with(42)
             ->willReturn($jumpTo)
         ;
@@ -61,10 +61,10 @@ class CalendarEventsResolverTest extends ContaoTestCase
         $article = $this->mockClassWithProperties(ArticleModel::class);
         $content = $this->mockClassWithProperties(CalendarEventsModel::class, ['source' => 'article', 'articleId' => 42]);
 
-        $articleAdapter = $this->mockAdapter(['findPublishedById']);
+        $articleAdapter = $this->mockAdapter(['findById']);
         $articleAdapter
             ->expects($this->once())
-            ->method('findPublishedById')
+            ->method('findById')
             ->with(42)
             ->willReturn($article)
         ;
@@ -84,10 +84,10 @@ class CalendarEventsResolverTest extends ContaoTestCase
         $calendar = $this->mockClassWithProperties(CalendarModel::class, ['jumpTo' => 42]);
         $content = $this->mockClassWithProperties(CalendarEventsModel::class, ['source' => '']);
 
-        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter = $this->mockAdapter(['findById']);
         $pageAdapter
             ->expects($this->once())
-            ->method('findPublishedById')
+            ->method('findById')
             ->with(42)
             ->willReturn($target)
         ;

--- a/core-bundle/src/Routing/Content/PageResolver.php
+++ b/core-bundle/src/Routing/Content/PageResolver.php
@@ -35,7 +35,7 @@ class PageResolver implements ContentUrlResolverInterface
                 $pageAdapter = $this->framework->getAdapter(PageModel::class);
 
                 if ($content->jumpTo) {
-                    $forwardPage = $pageAdapter->findPublishedById($content->jumpTo);
+                    $forwardPage = $pageAdapter->findById($content->jumpTo);
                 } else {
                     $forwardPage = $pageAdapter->findFirstPublishedRegularByPid($content->id);
                 }

--- a/core-bundle/tests/Routing/Content/PageResolverTest.php
+++ b/core-bundle/tests/Routing/Content/PageResolverTest.php
@@ -64,10 +64,10 @@ class PageResolverTest extends TestCase
         $content = $this->mockClassWithProperties(PageModel::class, ['id' => 42, 'type' => 'forward', 'jumpTo' => 43]);
         $jumpTo = $this->mockClassWithProperties(PageModel::class, ['id' => 43]);
 
-        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter = $this->mockAdapter(['findById']);
         $pageAdapter
             ->expects($this->once())
-            ->method('findPublishedById')
+            ->method('findById')
             ->with(43)
             ->willReturn($jumpTo)
         ;

--- a/faq-bundle/src/Routing/FaqResolver.php
+++ b/faq-bundle/src/Routing/FaqResolver.php
@@ -34,7 +34,7 @@ class FaqResolver implements ContentUrlResolverInterface
         $pageAdapter = $this->framework->getAdapter(PageModel::class);
         $categoryAdapter = $this->framework->getAdapter(FaqCategoryModel::class);
 
-        return ContentUrlResult::resolve($pageAdapter->findPublishedById((int) $categoryAdapter->findById($content->pid)?->jumpTo));
+        return ContentUrlResult::resolve($pageAdapter->findById((int) $categoryAdapter->findById($content->pid)?->jumpTo));
     }
 
     public function getParametersForContent(object $content, PageModel $pageModel): array

--- a/faq-bundle/tests/Routing/FaqResolverTest.php
+++ b/faq-bundle/tests/Routing/FaqResolverTest.php
@@ -26,10 +26,10 @@ class FaqResolverTest extends ContaoTestCase
         $category = $this->mockClassWithProperties(FaqCategoryModel::class, ['jumpTo' => 42]);
         $content = $this->createMock(FaqModel::class);
 
-        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter = $this->mockAdapter(['findById']);
         $pageAdapter
             ->expects($this->once())
-            ->method('findPublishedById')
+            ->method('findById')
             ->with(42)
             ->willReturn($target)
         ;

--- a/news-bundle/src/Routing/NewsResolver.php
+++ b/news-bundle/src/Routing/NewsResolver.php
@@ -41,20 +41,20 @@ class NewsResolver implements ContentUrlResolverInterface
             case 'internal':
                 $pageAdapter = $this->framework->getAdapter(PageModel::class);
 
-                return ContentUrlResult::redirect($pageAdapter->findPublishedById($content->jumpTo));
+                return ContentUrlResult::redirect($pageAdapter->findById($content->jumpTo));
 
             // Link to an article
             case 'article':
                 $articleAdapter = $this->framework->getAdapter(ArticleModel::class);
 
-                return ContentUrlResult::redirect($articleAdapter->findPublishedById($content->articleId));
+                return ContentUrlResult::redirect($articleAdapter->findById($content->articleId));
         }
 
         $pageAdapter = $this->framework->getAdapter(PageModel::class);
         $archiveAdapter = $this->framework->getAdapter(NewsArchiveModel::class);
 
         // Link to the default page
-        return ContentUrlResult::resolve($pageAdapter->findPublishedById((int) $archiveAdapter->findById($content->pid)?->jumpTo));
+        return ContentUrlResult::resolve($pageAdapter->findById((int) $archiveAdapter->findById($content->pid)?->jumpTo));
     }
 
     public function getParametersForContent(object $content, PageModel $pageModel): array

--- a/news-bundle/tests/Routing/NewsResolverTest.php
+++ b/news-bundle/tests/Routing/NewsResolverTest.php
@@ -39,10 +39,10 @@ class NewsResolverTest extends ContaoTestCase
         $jumpTo = $this->mockClassWithProperties(PageModel::class);
         $content = $this->mockClassWithProperties(NewsModel::class, ['source' => 'internal', 'jumpTo' => 42]);
 
-        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter = $this->mockAdapter(['findById']);
         $pageAdapter
             ->expects($this->once())
-            ->method('findPublishedById')
+            ->method('findById')
             ->with(42)
             ->willReturn($jumpTo)
         ;
@@ -61,10 +61,10 @@ class NewsResolverTest extends ContaoTestCase
         $article = $this->mockClassWithProperties(ArticleModel::class);
         $content = $this->mockClassWithProperties(NewsModel::class, ['source' => 'article', 'articleId' => 42]);
 
-        $articleAdapter = $this->mockAdapter(['findPublishedById']);
+        $articleAdapter = $this->mockAdapter(['findById']);
         $articleAdapter
             ->expects($this->once())
-            ->method('findPublishedById')
+            ->method('findById')
             ->with(42)
             ->willReturn($article)
         ;
@@ -85,10 +85,10 @@ class NewsResolverTest extends ContaoTestCase
 
         $content = $this->mockClassWithProperties(NewsModel::class, ['source' => '']);
 
-        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter = $this->mockAdapter(['findById']);
         $pageAdapter
             ->expects($this->once())
-            ->method('findPublishedById')
+            ->method('findById')
             ->with(42)
             ->willReturn($target)
         ;

--- a/newsletter-bundle/src/Routing/NewsletterResolver.php
+++ b/newsletter-bundle/src/Routing/NewsletterResolver.php
@@ -34,7 +34,7 @@ class NewsletterResolver implements ContentUrlResolverInterface
         $pageAdapter = $this->framework->getAdapter(PageModel::class);
         $channelAdapter = $this->framework->getAdapter(NewsletterChannelModel::class);
 
-        return ContentUrlResult::resolve($pageAdapter->findPublishedById((int) $channelAdapter->findById($content->pid)?->jumpTo));
+        return ContentUrlResult::resolve($pageAdapter->findById((int) $channelAdapter->findById($content->pid)?->jumpTo));
     }
 
     public function getParametersForContent(object $content, PageModel $pageModel): array

--- a/newsletter-bundle/tests/Routing/NewsletterResolverTest.php
+++ b/newsletter-bundle/tests/Routing/NewsletterResolverTest.php
@@ -26,10 +26,10 @@ class NewsletterResolverTest extends ContaoTestCase
         $channel = $this->mockClassWithProperties(NewsletterChannelModel::class, ['jumpTo' => 42]);
         $content = $this->createMock(NewsletterModel::class);
 
-        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter = $this->mockAdapter(['findById']);
         $pageAdapter
             ->expects($this->once())
-            ->method('findPublishedById')
+            ->method('findById')
             ->with(42)
             ->willReturn($target)
         ;


### PR DESCRIPTION
Fixes #8915

When generating content URLs for news, events etc, we absolutely do know the target page. If that target page is unpublished, the routing currently fails. That does not make much sense though, because you do want to get to the correct page, but want to get a 404 if preview is not enabled. Or be able to enable preview if you are on the preview entry point.