### PR TITLE
Use the original Swiper markup

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/swiper.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/swiper.html.twig
@@ -35,17 +35,15 @@
         {% block controls %}
             {% if not as_editor_view %}
                 {% set button_prev_attributes = attrs()
-                    .set('type', 'button')
                     .addClass('swiper-button-prev')
                     .mergeWith(button_prev_attributes|default)
                 %}
-                <button{{ button_prev_attributes }}></button>
+                <div{{ button_prev_attributes }}></div>
                 {% set button_next_attributes = attrs()
-                    .set('type', 'button')
                     .addClass('swiper-button-next')
                     .mergeWith(button_next_attributes|default)
                 %}
-                <button{{ button_next_attributes }}></button>
+                <div{{ button_next_attributes }}></div>
                 {% set pagination_attributes = attrs()
                     .addClass('swiper-pagination')
                     .mergeWith(pagination_attributes|default)

--- a/core-bundle/tests/Controller/ContentElement/SwiperControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/SwiperControllerTest.php
@@ -58,8 +58,8 @@ class SwiperControllerTest extends ContentElementTestCase
                             image
                         </div>
                     </div>
-                    <button type="button" class="swiper-button-prev"></button>
-                    <button type="button" class="swiper-button-next"></button>
+                    <div class="swiper-button-prev"></div>
+                    <div class="swiper-button-next"></div>
                     <div class="swiper-pagination"></div>
                 </div>
             </div>


### PR DESCRIPTION
Swiper recommends using `<div>` elements for the navigation buttons (see https://swiperjs.com/get-started#add-swiper-html-layout), however, we use `<button>` elements. Therefore, the default button CSS is applied which does not look good:

<img width="302" height="253" alt="" src="https://github.com/user-attachments/assets/951d52de-0b0f-4ab5-8741-850844150b9f" />

This PR changes our Swiper template to use the recommended markup. Swiper adds `role="button"` anyway, so this should not be a problem.

**Edit:** We have to check https://github.com/contao/contao/pull/6626#discussion_r1435067002 before merging this.