### PR TITLE
Fix an error when trying to render a deleted CE/FM via Twig function

### DIFF
--- a/core-bundle/src/Twig/Runtime/FragmentRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FragmentRuntime.php
@@ -69,7 +69,7 @@ final class FragmentRuntime implements RuntimeExtensionInterface
     /**
      * @param class-string<ContentModel|ModuleModel> $class
      */
-    private function getModel(string $class, int|string $typeOrId, array $data = []): ContentModel|ModuleModel
+    private function getModel(string $class, int|string $typeOrId, array $data = []): ContentModel|ModuleModel|null
     {
         if (is_numeric($typeOrId)) {
             /** @var Adapter<ContentModel|ModuleModel> $adapter */
@@ -78,6 +78,10 @@ final class FragmentRuntime implements RuntimeExtensionInterface
         } else {
             $model = $this->framework->createInstance($class);
             $model->type = $typeOrId;
+        }
+
+        if (null === $model) {
+            return null;
         }
 
         foreach ($data as $k => $v) {

--- a/core-bundle/tests/Twig/Runtime/FragmentRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/FragmentRuntimeTest.php
@@ -190,4 +190,33 @@ class FragmentRuntimeTest extends TestCase
 
         $this->assertSame('runtime-result', $result);
     }
+
+    public function testRenderContentFromUnavailableId(): void
+    {
+        $controllerAdapter = $this->mockAdapter(['getContentElement']);
+        $controllerAdapter
+            ->expects($this->once())
+            ->method('getContentElement')
+            ->with(null)
+            ->willReturn('')
+        ;
+
+        $contentAdapter = $this->mockAdapter(['findById']);
+        $contentAdapter
+            ->expects($this->once())
+            ->method('findById')
+            ->with(42)
+            ->willReturn(null)
+        ;
+
+        $framework = $this->mockContaoFramework([
+            Controller::class => $controllerAdapter,
+            ContentModel::class => $contentAdapter,
+        ]);
+
+        $runtime = new FragmentRuntime($framework);
+        $result = $runtime->renderContent(42, ['foo' => 'bar']);
+
+        $this->assertSame('', $result);
+    }
 }

--- a/core-bundle/tests/Twig/Runtime/FragmentRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/FragmentRuntimeTest.php
@@ -83,6 +83,35 @@ class FragmentRuntimeTest extends TestCase
         $this->assertSame('runtime-result', $result);
     }
 
+    public function testRenderModuleFromUnavailableId(): void
+    {
+        $controllerAdapter = $this->mockAdapter(['getFrontendModule']);
+        $controllerAdapter
+            ->expects($this->once())
+            ->method('getFrontendModule')
+            ->with(null)
+            ->willReturn('')
+        ;
+
+        $moduleAdapter = $this->mockAdapter(['findById']);
+        $moduleAdapter
+            ->expects($this->once())
+            ->method('findById')
+            ->with(42)
+            ->willReturn(null)
+        ;
+
+        $framework = $this->mockContaoFramework([
+            Controller::class => $controllerAdapter,
+            ModuleModel::class => $moduleAdapter,
+        ]);
+
+        $runtime = new FragmentRuntime($framework);
+        $result = $runtime->renderModule(42, ['foo' => 'bar']);
+
+        $this->assertSame('', $result);
+    }
+
     public function testRenderContentFromType(): void
     {
         $controllerAdapter = $this->mockAdapter(['getContentElement']);


### PR DESCRIPTION
Fixes the error mentioned in https://github.com/contao/contao/pull/8783#pullrequestreview-3377509580

Basically if you try to render a content element or a module that was deleted, with the `content_element` or `frontend_module` Twig function, for example by having a content element or module included in a Twig layout and deleting it, without removing it from the layout, the error below will occur.
I noticed that in the Twig layouts, but this can happen everywhere where the Twig functions are used with IDs basically. That's why this PR is targeted against 5.3.

Returning `null` should be fine I think, as both `Controller::getFrontendModule` and `Controller::getContentElement` will just return an empty string when `null` is passed.

```
[2/2] RuntimeError
--
Twig\Error\RuntimeError:
An exception has been thrown during the rendering of a template ("Call to a member function preventSaving() on null") in "@Contao/layout/_element_group.html.twig" at line 3.

  at vendor/contao/core-bundle/contao/templates/twig/layout/_element_group.html.twig:3
  at Twig\Template->yieldBlock()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:67)
  at __TwigTemplate_f8a52777649db8fbc9ac11f99e658fad->doDisplay()
     (vendor/twig/twig/src/Template.php:402)
  at Twig\Template->yield()
     (vendor/twig/twig/src/Template.php:358)
  at Twig\Template->display()
     (vendor/twig/twig/src/Template.php:373)
  at Twig\Template->render()
     (vendor/twig/twig/src/TemplateWrapper.php:51)
  at Twig\TemplateWrapper->render()
     (vendor/twig/twig/src/Environment.php:333)
  at Twig\Environment->render()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:448)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->doRenderView()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:232)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->renderView()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:234)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->renderSlot()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:167)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->{closure:Contao\CoreBundle\Controller\Page\AbstractLayoutPageController::addDefaultDataToTemplate():167}()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:175)
  at class@anonymous/.../vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:167$4d15->__toString()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:277)
  at __TwigTemplate_d5796d1117cfa32597a1dcdfc93fa9cb->block_body_content()
     (vendor/twig/twig/src/Template.php:446)
  at Twig\Template->yieldBlock()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:233)
  at __TwigTemplate_d5796d1117cfa32597a1dcdfc93fa9cb->block_body()
     (vendor/twig/twig/src/Template.php:446)
  at Twig\Template->yieldBlock()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:80)
  at __TwigTemplate_d5796d1117cfa32597a1dcdfc93fa9cb->doDisplay()
     (vendor/twig/twig/src/Template.php:402)
  at Twig\Template->yield()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:63)
  at __TwigTemplate_d1fbb10d4bc5cbf96abe22bb8d4150d3->doDisplay()
     (vendor/twig/twig/src/Template.php:402)
  at Twig\Template->yield()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:58)
  at __TwigTemplate_f49395b87390525b593ad204250ea339->doDisplay()
     (vendor/twig/twig/src/Template.php:402)
  at Twig\Template->yield()
     (vendor/twig/twig/src/Template.php:358)
  at Twig\Template->display()
     (vendor/twig/twig/src/Template.php:373)
  at Twig\Template->render()
     (vendor/twig/twig/src/TemplateWrapper.php:51)
  at Twig\TemplateWrapper->render()
     (vendor/twig/twig/src/Environment.php:333)
  at Twig\Environment->render()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:448)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->doRenderView()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:453)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->doRender()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:253)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->render()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:226)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->render()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:92)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->{closure:Contao\CoreBundle\Controller\Page\AbstractLayoutPageController::createTemplate():92}()
     (vendor/contao/core-bundle/src/Twig/LayoutTemplate.php:85)
  at Contao\CoreBundle\Twig\LayoutTemplate->getResponse()
     (vendor/contao/core-bundle/src/Controller/Page/RegularPageController.php:24)
  at Contao\CoreBundle\Controller\Page\RegularPageController->getResponse()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:55)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->__invoke()
     (vendor/contao/core-bundle/contao/controllers/FrontendIndex.php:68)
  at Contao\FrontendIndex->renderPage()
     (vendor/symfony/http-kernel/HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:42)   
     
[1/2] Error
Error:
Call to a member function preventSaving() on null

  at vendor/contao/core-bundle/src/Twig/Runtime/FragmentRuntime.php:99
  at Contao\CoreBundle\Twig\Runtime\FragmentRuntime->getModel()
     (vendor/contao/core-bundle/src/Twig/Runtime/FragmentRuntime.php:41)
  at Contao\CoreBundle\Twig\Runtime\FragmentRuntime->renderModule()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:103)
  at __TwigTemplate_f8a52777649db8fbc9ac11f99e658fad->block_element()
     (vendor/twig/twig/src/Template.php:446)
  at Twig\Template->yieldBlock()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:67)
  at __TwigTemplate_f8a52777649db8fbc9ac11f99e658fad->doDisplay()
     (vendor/twig/twig/src/Template.php:402)
  at Twig\Template->yield()
     (vendor/twig/twig/src/Template.php:358)
  at Twig\Template->display()
     (vendor/twig/twig/src/Template.php:373)
  at Twig\Template->render()
     (vendor/twig/twig/src/TemplateWrapper.php:51)
  at Twig\TemplateWrapper->render()
     (vendor/twig/twig/src/Environment.php:333)
  at Twig\Environment->render()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:448)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->doRenderView()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:232)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->renderView()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:234)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->renderSlot()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:167)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->{closure:Contao\CoreBundle\Controller\Page\AbstractLayoutPageController::addDefaultDataToTemplate():167}()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:175)
  at class@anonymous/.../vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:167$4d15->__toString()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:277)
  at __TwigTemplate_d5796d1117cfa32597a1dcdfc93fa9cb->block_body_content()
     (vendor/twig/twig/src/Template.php:446)
  at Twig\Template->yieldBlock()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:233)
  at __TwigTemplate_d5796d1117cfa32597a1dcdfc93fa9cb->block_body()
     (vendor/twig/twig/src/Template.php:446)
  at Twig\Template->yieldBlock()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:80)
  at __TwigTemplate_d5796d1117cfa32597a1dcdfc93fa9cb->doDisplay()
     (vendor/twig/twig/src/Template.php:402)
  at Twig\Template->yield()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:63)
  at __TwigTemplate_d1fbb10d4bc5cbf96abe22bb8d4150d3->doDisplay()
     (vendor/twig/twig/src/Template.php:402)
  at Twig\Template->yield()
     (vendor/twig/twig/src/Environment.php(420) : eval()'d code:58)
  at __TwigTemplate_f49395b87390525b593ad204250ea339->doDisplay()
     (vendor/twig/twig/src/Template.php:402)
  at Twig\Template->yield()
     (vendor/twig/twig/src/Template.php:358)
  at Twig\Template->display()
     (vendor/twig/twig/src/Template.php:373)
  at Twig\Template->render()
     (vendor/twig/twig/src/TemplateWrapper.php:51)
  at Twig\TemplateWrapper->render()
     (vendor/twig/twig/src/Environment.php:333)
  at Twig\Environment->render()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:448)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->doRenderView()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:453)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->doRender()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:253)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->render()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:226)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->render()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:92)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->{closure:Contao\CoreBundle\Controller\Page\AbstractLayoutPageController::createTemplate():92}()
     (vendor/contao/core-bundle/src/Twig/LayoutTemplate.php:85)
  at Contao\CoreBundle\Twig\LayoutTemplate->getResponse()
     (vendor/contao/core-bundle/src/Controller/Page/RegularPageController.php:24)
  at Contao\CoreBundle\Controller\Page\RegularPageController->getResponse()
     (vendor/contao/core-bundle/src/Controller/Page/AbstractLayoutPageController.php:55)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->__invoke()
     (vendor/contao/core-bundle/contao/controllers/FrontendIndex.php:68)
  at Contao\FrontendIndex->renderPage()
     (vendor/symfony/http-kernel/HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:42)              
```