### PR TITLE
Add null check for undefined array key

### DIFF
--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -2445,7 +2445,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 							$operations = System::getContainer()->get('contao.data_container.operations_builder')->initialize($this->strTable);
 
 							$operations->append(array(
-								'label' => $GLOBALS['TL_LANG']['tl_files']['upload'][0],
+								'label' => $GLOBALS['TL_LANG']['tl_files']['upload'][0] ?? '',
 								'title' => \sprintf($GLOBALS['TL_LANG']['tl_files']['upload'][1], $currentEncoded),
 								'href' => $this->addToUrl('&amp;act=move&amp;mode=2&amp;pid=' . $currentEncoded),
 								'icon' => 'new.svg',


### PR DESCRIPTION
I get a lot of warnings when the file manager gets opened in the backend (production system):

`Warning: Undefined array key 0`

<img width="1884" height="868" alt="Bildschirmfoto 2025-10-27 um 11 51 54" src="https://github.com/user-attachments/assets/b5b7ff57-7362-463c-9cc8-f5e54cb54c07" />
