### PR TITLE
Add a viewport tag to the new default layout template

### DIFF
--- a/core-bundle/contao/templates/twig/layout/default.html.twig
+++ b/core-bundle/contao/templates/twig/layout/default.html.twig
@@ -24,9 +24,9 @@
          <title>{{ title }}</title>
     {%- endblock -%}
 
-    {%- block viewport %}
+    {% block viewport %}
         <meta name="viewport" content="width=device-width,initial-scale=1.0,shrink-to-fit=no">
-    {%- endblock -%}
+    {% endblock %}
 
     {# @var \Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag head_bag #}
     {% set head_bag = response_context.head %}

--- a/core-bundle/contao/templates/twig/layout/default.html.twig
+++ b/core-bundle/contao/templates/twig/layout/default.html.twig
@@ -24,6 +24,10 @@
          <title>{{ title }}</title>
     {%- endblock -%}
 
+    {%- block viewport %}
+        <meta name="viewport" content="width=device-width,initial-scale=1.0,shrink-to-fit=no">
+    {%- endblock -%}
+
     {# @var \Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag head_bag #}
     {% set head_bag = response_context.head %}
 


### PR DESCRIPTION
Fixes #8948

Not sure if `{%- endblock -%}` with `%-` and `-%` is correct. There are all kinds of variations used in the template 😄 