### PR TITLE
Do not swallow DCA exceptions

### DIFF
--- a/core-bundle/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/contao/library/Contao/DcaLoader.php
@@ -198,9 +198,11 @@ class DcaLoader extends Controller
 				{
 					include $strCachePath;
 				}
-				catch (\Throwable)
+				catch (\Throwable $e)
 				{
 					$filesystem->remove($strCachePath);
+
+					throw $e;
 				}
 			}
 		}


### PR DESCRIPTION
I had an error in my DCA file, which resulted in random issues because the DCA just wan't loaded. I don't think we should swallow these exceptions. Also notice that we don't do that in Contao 5.3, it must have been introduced somewhere in the meantime.