### PR TITLE
Fix HTML escaping for SQLite supported extensions

### DIFF
--- a/core-bundle/contao/templates/twig/web_debug_toolbar/contao_collector.html.twig
+++ b/core-bundle/contao/templates/twig/web_debug_toolbar/contao_collector.html.twig
@@ -134,7 +134,7 @@
                         <td>{% if collector.backendSearchChecks.sqlite_supported %}✅{% else %}🚨{% endif %}</td>
                         <td>
                             {% if collector.backendSearchChecks.sqlite_supported %}
-                                The following PHP extensions are enabled: <code>{{ collector.backendSearchChecks.sqlite_supported|join('</code>, <code>') }}</code>.
+                                The following PHP extensions are enabled: <code>{{ collector.backendSearchChecks.sqlite_supported|join('</code>, <code>')|raw }}</code>.
                             {% else %}
                                 One of the following PHP extensions need to be enabled: <code>pdo_sqlite</code>, <code>sqlite3</code>.
                             {% endif %}


### PR DESCRIPTION
Nice to have that new backend search check! :) Just one little thing: 
<img width="813" height="46" alt="Bildschirmfoto 2025-11-01 um 11 44 13" src="https://github.com/user-attachments/assets/217223d7-6870-4f70-9f75-26794229cdae" />
