### PR TITLE
Simplify the `contao_collector.html.twig` template

### DIFF
--- a/core-bundle/contao/templates/twig/web_debug_toolbar/contao_collector.html.twig
+++ b/core-bundle/contao/templates/twig/web_debug_toolbar/contao_collector.html.twig
@@ -82,45 +82,33 @@
 
     <h2>Image resizing and previews</h2>
     <p>
-        Imagine service currently in use: <code>{{ collector.imageChecks.imagine_service }}</code><br>
+        Imagine service in use: <code>{{ collector.imageChecks.imagine_service }}</code><br>
         This can be changed in the <code>contao.image.imagine_service</code> configuration.
     </p>
-    <p>The following image formats are supported on your system.</p>
+    <p>The following image formats are supported on your system:</p>
     <table>
         <thead>
         <tr>
-            <th colspan="3">
-                Image formats
-            </th>
+            <th colspan="3">Image formats</th>
         </tr>
         </thead>
         <tbody>
         {% for format in collector.imageChecks.formats %}
             <tr>
-                <td>
-                    {% if format.supported %}
-                        ✅
-                    {% else %}
-                        🚨
-                    {% endif %}
-                </td>
-                <td>
-                    {{ format.label|upper }}
-                </td>
-                <td>
-                    <code>{{ format.error }}</code>
-                </td>
+                <td>{% if format.supported %}✅{% else %}🚨{% endif %}</td>
+                <td>{{ format.label|upper }}</td>
+                <td>{{ format.error }}</td>
             </tr>
         {% endfor %}
         </tbody>
     </table>
 
     {% if collector.backendSearchChecks|default %}
-        <h2>Back End Search</h2>
+        <h2>Back end search</h2>
         {% if collector.backendSearchChecks.available %}
-            <p>✅ The back end search is currently available.</p>
+            <p>✅ The back end search is available.</p>
         {% else %}
-            <p>🚨 The back end search is currently not available.</p>
+            <p>🚨 The back end search is not available.</p>
         {% endif %}
         <table>
             <thead>
@@ -134,9 +122,9 @@
                         <td>{% if collector.backendSearchChecks.sqlite_supported %}✅{% else %}🚨{% endif %}</td>
                         <td>
                             {% if collector.backendSearchChecks.sqlite_supported %}
-                                The following PHP extensions are enabled: <code>{{ collector.backendSearchChecks.sqlite_supported|join('</code>, <code>')|raw }}</code>.
+                                The following PHP extensions are enabled: {{ collector.backendSearchChecks.sqlite_supported|join(', ') }}
                             {% else %}
-                                One of the following PHP extensions need to be enabled: <code>pdo_sqlite</code>, <code>sqlite3</code>.
+                                One of the following PHP extensions needs to be enabled: pdo_sqlite, sqlite3
                             {% endif %}
                         </td>
                     </tr>
@@ -145,9 +133,9 @@
                     <td>{% if collector.backendSearchChecks.supervisor_supported %}✅{% else %}{% if collector.backendSearchChecks.cli_workers_running %}ℹ️{% else %}🚨{% endif %}{% endif %}</td>
                     <td>
                         {% if collector.backendSearchChecks.supervisor_supported %}
-                            The <code>SuperVisor</code> is supported.
+                            Using the SuperVisor is supported.
                         {% else %}
-                            Using the <code>SuperVisor</code> is currently not supported and thus Contao's default messenger queues are not processed automatically.
+                            Using the SuperVisor is not supported and thus Contao's default messenger queues are not processed automatically.
                         {% endif %}
                     </td>
                 </tr>
@@ -155,9 +143,9 @@
                     <td>{% if not collector.backendSearchChecks.pnctl_disabled %}✅{% else %}{% if collector.backendSearchChecks.cli_workers_running %}ℹ️{% else %}🚨{% endif %}{% endif %}</td>
                     <td>
                         {% if not collector.backendSearchChecks.pnctl_disabled %}
-                            The <code>pnctl_*</code> functions are not disabled.
+                            The pnctl_* functions are available.
                         {% else %}
-                            Some <code>pnctl_*</code> functions are disabled in PHP's <code>disable_functions</code> setting.
+                            Some pnctl_* functions are disabled in PHP's disable_functions setting.
                         {% endif %}
                     </td>
                 </tr>
@@ -165,9 +153,9 @@
                     <td>{% if collector.backendSearchChecks.cron_running %}✅{% else %}{% if collector.backendSearchChecks.cli_workers_running %}ℹ️{% else %}🚨{% endif %}{% endif %}</td>
                     <td>
                         {% if collector.backendSearchChecks.cron_running %}
-                            The <code>contao:cron</code> cronjob is executed minutely on the command line.
+                            The contao:cron cronjob is executed minutely on the command line.
                         {% else %}
-                            The <code>contao:cron</code> cronjob is currently not executed minutely on the command line and thus Contao's default messenger queues are not processed automatically.
+                            The contao:cron cronjob is not executed minutely on the command line and thus Contao's default messenger queues are not processed automatically.
                         {% endif %}
                     </td>
                 </tr>
@@ -177,7 +165,7 @@
                         {% if collector.backendSearchChecks.cli_workers_running %}
                             The messenger queues are processed on the command line.
                         {% else %}
-                            The messenger queues are currently not processed on the command line.
+                            The messenger queues are not processed on the command line.
                         {% endif %}
                     </td>
                 </tr>


### PR DESCRIPTION
Fixes a few typos and removes redundant `<code></code>` tags inside `<td></td>` where everything is monospaced already.

I have also removed the word "currently" because if the server e.g. does not support the back end search, the back end search is simply _not available_ and not just _currently not available_. To me, the latter sounds like it might be available if you come back in an hour 😄 