### PR TITLE
Correctly set the table on fake DC in copy callback

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -1300,7 +1300,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 							foreach ($GLOBALS['TL_DCA'][$k]['config']['oncopy_callback'] as $callback)
 							{
 								$dc = (new \ReflectionClass(self::class))->newInstanceWithoutConstructor();
-								$dc->table = $k;
+								$dc->strTable = $k;
 								$dc->id = $kk;
 
 								if (\is_array($callback))

--- a/core-bundle/contao/widgets/Picker.php
+++ b/core-bundle/contao/widgets/Picker.php
@@ -203,7 +203,7 @@ class Picker extends Widget
 				$dataContainer = DataContainer::getDriverForTable($strRelatedTable);
 
 				$dc = (new \ReflectionClass($dataContainer))->newInstanceWithoutConstructor();
-				$dc->table = $strRelatedTable;
+				$dc->strTable = $strRelatedTable;
 
 				while ($objRows->next())
 				{


### PR DESCRIPTION
See https://github.com/contao/contao/issues/8932
Alternative to https://github.com/contao/contao/pull/8933

This is a "minimal-invasive" fix for 5.3 LTS.