### PR TITLE
Don't show the override all button for DC_Folder contexts

### DIFF
--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -154,6 +154,12 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 		)
 	),
 
+	// Callbacks for ButtonsBuilder
+	'select' => array
+	(
+		'buttons_callback' => array(array('tl_files', 'hideOverrideAllButton'))
+	),
+
 	// Palettes
 	'palettes' => array
 	(
@@ -1029,5 +1035,12 @@ class tl_files extends Backend
   </div>' . (Config::get('showHelp') ? '
   <p class="tl_help tl_tip">' . $GLOBALS['TL_LANG']['tl_files']['syncExclude'][1] . '</p>' : '') . '
 </div>';
+	}
+
+	public function hideOverrideAllButton($buttons, DataContainer $dc)
+	{
+		unset($buttons['override']);
+
+		return $buttons;
 	}
 }

--- a/core-bundle/src/DataContainer/ButtonsBuilder.php
+++ b/core-bundle/src/DataContainer/ButtonsBuilder.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\DataContainer;
 
 use Contao\DataContainer;
-use Contao\DC_Folder;
 use Contao\Input;
 use Contao\System;
 use Twig\Environment;
@@ -103,7 +102,7 @@ class ButtonsBuilder
             $arrButtons['cut'] = '<button type="submit" name="cut" id="cut" class="tl_submit" accesskey="x">'.$GLOBALS['TL_LANG']['MSC']['moveSelected'].'</button>';
         }
 
-        if (!($GLOBALS['TL_DCA'][$strTable]['config']['notEditable'] ?? null) && !$dc instanceof DC_Folder) {
+        if (!($GLOBALS['TL_DCA'][$strTable]['config']['notEditable'] ?? null)) {
             $arrButtons['override'] = '<button type="submit" name="override" id="override" class="tl_submit" accesskey="v">'.$GLOBALS['TL_LANG']['MSC']['overrideSelected'].'</button>';
         }
 

--- a/core-bundle/src/DataContainer/ButtonsBuilder.php
+++ b/core-bundle/src/DataContainer/ButtonsBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\DataContainer;
 
 use Contao\DataContainer;
+use Contao\DC_Folder;
 use Contao\Input;
 use Contao\System;
 use Twig\Environment;
@@ -102,7 +103,7 @@ class ButtonsBuilder
             $arrButtons['cut'] = '<button type="submit" name="cut" id="cut" class="tl_submit" accesskey="x">'.$GLOBALS['TL_LANG']['MSC']['moveSelected'].'</button>';
         }
 
-        if (!($GLOBALS['TL_DCA'][$strTable]['config']['notEditable'] ?? null)) {
+        if (!($GLOBALS['TL_DCA'][$strTable]['config']['notEditable'] ?? null) && !$dc instanceof DC_Folder) {
             $arrButtons['override'] = '<button type="submit" name="override" id="override" class="tl_submit" accesskey="v">'.$GLOBALS['TL_LANG']['MSC']['overrideSelected'].'</button>';
         }
 


### PR DESCRIPTION
Hide button for `OverrideAll` action in `DC_Folder` contexts.

Fixes #8973