### PR TITLE
Fix table sorting error in mutation observer

### DIFF
--- a/core-bundle/contao/templates/twig/component/_table.html.twig
+++ b/core-bundle/contao/templates/twig/component/_table.html.twig
@@ -176,7 +176,9 @@
                         script.addEventListener('load', () => {
                             new MutationObserver(function (mutations) {
                                 mutations.forEach(function (mutation) {
-                                    initTree(mutation.target)
+                                    if (mutation.target instanceof HTMLElement) {
+                                        initTree(mutation.target)
+                                    }
                                 });
                             }).observe(document, {
                                 childList: true,


### PR DESCRIPTION
Fixes JS error
```
TypeError: root.matches is not a function. (In 'root.matches('table[data-sortable-table]')', 'root.matches' is undefined)
```