### PR TITLE
Allow overriding the table header and footer blocks

### DIFF
--- a/core-bundle/contao/templates/twig/component/_table.html.twig
+++ b/core-bundle/contao/templates/twig/component/_table.html.twig
@@ -79,8 +79,8 @@
             {% endif %}
 
             {# Header #}
-            {% if header %}
-                {% block table_header %}
+            {% block table_header %}
+                {% if header %}
                     <thead{{ table_header_attributes|default }}>
                     {% block table_header_inner %}
                         <tr>
@@ -98,12 +98,12 @@
                         </tr>
                     {% endblock %}
                     </thead>
-                {% endblock %}
-            {% endif %}
+                {% endif %}
+            {% endblock %}
 
             {# Footer #}
-            {% if footer %}
-                {% block table_footer %}
+            {% block table_footer %}
+                {% if footer %}
                     <tfoot{{ table_footer_attributes|default }}>
                     {% block table_footer_inner %}
                         <tr>
@@ -117,8 +117,8 @@
                         </tr>
                     {% endblock %}
                     </tfoot>
-                {% endblock %}
-            {% endif %}
+                {% endif %}
+            {% endblock %}
 
             {# Body #}
             {% block table_body %}


### PR DESCRIPTION
I want to reuse the `_table` component for my own table, but make use of the sorting alogrithm. Currently I can only customize the header and footer if the respective variables are defined.