### PR TITLE
Fix a typo for `addBefore` in `ModuleFaqReader`

### DIFF
--- a/faq-bundle/contao/modules/ModuleFaqReader.php
+++ b/faq-bundle/contao/modules/ModuleFaqReader.php
@@ -125,7 +125,7 @@ class ModuleFaqReader extends Module
 		$this->Template->question = $objFaq->question;
 		$this->Template->answer = StringUtil::encodeEmail($objFaq->answer);
 		$this->Template->addImage = false;
-		$this->Template->before = false;
+		$this->Template->addBefore = false;
 
 		// Add image
 		if ($objFaq->addImage)


### PR DESCRIPTION
Fixes a small typo in the `ModuleFaqReader`.