### PR TITLE
Fix `isHidden()` for `ContentProxy`

### DIFF
--- a/core-bundle/contao/elements/ContentProxy.php
+++ b/core-bundle/contao/elements/ContentProxy.php
@@ -84,7 +84,7 @@ class ContentProxy extends ContentElement
 
 	public function __set($strKey, $varValue)
 	{
-		$this->reference->attributes['templateProperties'][$strKey] = $this->arrData[$strKey] = $varValue;
+		$this->reference->attributes['templateProperties'][$strKey] = $varValue;
 	}
 
 	public function __get($strKey)

--- a/core-bundle/contao/elements/ContentProxy.php
+++ b/core-bundle/contao/elements/ContentProxy.php
@@ -50,6 +50,14 @@ class ContentProxy extends ContentElement
 		}
 
 		$this->strColumn = $strColumn;
+		$this->objModel = $this->reference->attributes['contentModel'] ?? null;
+
+		if (\is_int($this->objModel))
+		{
+			$this->objModel = ContentModel::findById($this->objModel);
+		}
+
+		$this->arrData = $this->objModel?->row() ?? array();
 
 		// Do not call parent constructor
 	}
@@ -76,17 +84,17 @@ class ContentProxy extends ContentElement
 
 	public function __set($strKey, $varValue)
 	{
-		$this->reference->attributes['templateProperties'][$strKey] = $varValue;
+		$this->reference->attributes['templateProperties'][$strKey] = $this->arrData[$strKey] = $varValue;
 	}
 
 	public function __get($strKey)
 	{
-		return $this->reference->attributes['templateProperties'][$strKey] ?? null;
+		return $this->reference->attributes['templateProperties'][$strKey] ?? $this->arrData[$strKey] ?? null;
 	}
 
 	public function __isset($strKey)
 	{
-		return isset($this->reference->attributes['templateProperties'][$strKey]);
+		return isset($this->reference->attributes['templateProperties'][$strKey]) || isset($this->arrData[$strKey]);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8013 

This fixes the aforementioned issue as discussed in #8976. Since `Contao\ContentProxy` does not load the model's data onto itself and has it's own `__get()` method which only accesses the `templateProperties` if present, `$this->invisible` (etc.) in the `ContentElement::isHidden()` method simply do not exist and thus fragments were always rendered when retrieved via `Controller::getContentElement()`.

This affects the `content_element()` Twig function, the `{{insert_content::*}}` Insert Tag as well as the `alias` content element.

This PR fixes this by populating `$this->arrData` of the `ContentProxy` instance (just as regular `ContentElement` instances would) and then allowing access to that data via `__get()`. If custom data is set via `templateProperties`, that data still has priority.