### PR TITLE
Provide the index to SEAL when reindexing

### DIFF
--- a/core-bundle/src/Search/Backend/Seal/SealUtil.php
+++ b/core-bundle/src/Search/Backend/Seal/SealUtil.php
@@ -23,7 +23,7 @@ class SealUtil
 
     public static function internalReindexConfigToSealReindexConfig(ReindexConfig $reindexConfig): SealReindexConfig
     {
-        $sealConfig = new SealReindexConfig();
+        $sealConfig = (new SealReindexConfig())->withIndex(SealReindexProvider::getIndex());
 
         if ($reindexConfig->getUpdateSince()) {
             $sealConfig = $sealConfig->withDateTimeBoundary($reindexConfig->getUpdateSince());

--- a/core-bundle/tests/Search/Backend/Seal/SealUtilTest.php
+++ b/core-bundle/tests/Search/Backend/Seal/SealUtilTest.php
@@ -16,6 +16,7 @@ use CmsIg\Seal\Reindex\ReindexConfig as SealReindexConfig;
 use Contao\CoreBundle\Search\Backend\Document;
 use Contao\CoreBundle\Search\Backend\GroupedDocumentIds;
 use Contao\CoreBundle\Search\Backend\ReindexConfig;
+use Contao\CoreBundle\Search\Backend\Seal\SealReindexProvider;
 use Contao\CoreBundle\Search\Backend\Seal\SealUtil;
 use PHPUnit\Framework\TestCase;
 
@@ -44,6 +45,7 @@ class SealUtilTest extends TestCase
         $sealReindexConfig = SealUtil::internalReindexConfigToSealReindexConfig($reindexConfig);
 
         $this->assertSame(['foobar__42', 'foobar__99', 'other__12'], $sealReindexConfig->getIdentifiers());
+        $this->assertSame(SealReindexProvider::getIndex(), $sealReindexConfig->getIndex());
     }
 
     public function testSealConfigToInternalConfig(): void


### PR DESCRIPTION
The current SEAL architecture requires `ReindexProviders` to be registered for a given index (cannot be multiple) and the `ReindexConfig` [must define which indexes it wants to reindex in case documents are limited](https://github.com/PHP-CMSIG/search/blob/0.12/packages/seal/src/Engine.php#L222).

We have one central ReindexProvider for SEAL that delegates to our own providers, hence we have to always only provide our own index.