### PR TITLE
Ignore web profiler requests in the search index and fix the back end request regex

### DIFF
--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -63,7 +63,12 @@ class SearchIndexListener
         }
 
         // Do not handle Contao backend requests
-        if (preg_match('~(?:^|/)'.preg_quote($this->contaoBackendRoutePrefix, '~').'~', $request->getPathInfo())) {
+        if (preg_match('~(?:^|/)'.preg_quote($this->contaoBackendRoutePrefix, '~').'(?:$|/)~', $request->getPathInfo())) {
+            return;
+        }
+
+        // Do not handle profiler requests
+        if (preg_match('~(?:^|/)/_wdt/~', $request->getPathInfo())) {
             return;
         }
 

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -63,12 +63,12 @@ class SearchIndexListener
         }
 
         // Do not handle Contao backend requests
-        if (preg_match('~(?:^|/)'.preg_quote($this->contaoBackendRoutePrefix, '~').'(?:$|/)~', $request->getPathInfo())) {
+        if (preg_match('~(?:^|/)'.preg_quote(ltrim($this->contaoBackendRoutePrefix, '/'), '~').'(?:$|/)~', $request->getPathInfo())) {
             return;
         }
 
         // Do not handle profiler requests
-        if (preg_match('~(?:^|/)/_wdt/~', $request->getPathInfo())) {
+        if (preg_match('~(?:^|/)_wdt/~', $request->getPathInfo())) {
             return;
         }
 

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -57,7 +57,7 @@ class SearchIndexListenerTest extends TestCase
     public static function getRequestResponse(): iterable
     {
         yield 'Should index because the response was successful and contains ld+json information' => [
-            Request::create('/foobar'),
+            Request::create('/contao-likes-to-index-things'),
             new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             true,
@@ -106,6 +106,14 @@ class SearchIndexListenerTest extends TestCase
 
         yield 'Should be skipped because it is a contao backend request' => [
             Request::create('/contao?do=article'),
+            new Response(),
+            SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
+            false,
+            false,
+        ];
+
+        yield 'Should be skipped because it is a web profiler request' => [
+            Request::create('/_wdt/123'),
             new Response(),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,


### PR DESCRIPTION
Currently the `SearchIndexMessage` is always dispatched for the `/_wdt/{token}` requests of the Symfony profiler in debug mode. This PR fixes that by skipping such URLs.

This PR also fixes 2 issues in the regex for the Contao back end request. First, it had a double slash in it - as `$this->contaoBackendRoutePrefix` already contains a leading slash.

Secondly, if you happen to have a regular page in the frontend that has an alias starting with `contao`, e.g. `/contao-is-awesome`, then that page would never be indexed.