### PR TITLE
Fix the template migration

### DIFF
--- a/core-bundle/src/Migration/Version506/LayoutTemplateMigration.php
+++ b/core-bundle/src/Migration/Version506/LayoutTemplateMigration.php
@@ -32,6 +32,18 @@ class LayoutTemplateMigration extends AbstractMigration
 
     public function shouldRun(): bool
     {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        if (!$schemaManager->tablesExist(['tl_layout'])) {
+            return false;
+        }
+
+        $columns = $schemaManager->listTableColumns('tl_layout');
+
+        if (!\array_key_exists('type', $columns) || !\array_key_exists('template', $columns)) {
+            return false;
+        }
+
         $test = $this->connection->fetchOne("SELECT TRUE FROM tl_layout WHERE type='modern' AND template='layout/default' LIMIT 1");
 
         return false !== $test;


### PR DESCRIPTION
The changes in https://github.com/contao/contao/pull/9004 currently break migrations, especially if upgrading from Contao 4.13