### PR TITLE
Make class optional again for global operation with icon and button callback

### DIFF
--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -870,7 +870,7 @@ abstract class DataContainer extends Backend
 			{
 				$icon = Controller::addAssetsUrlTo(Image::getPath($config['icon']));
 				$config['attributes']->addStyle("background-image: url('$icon')");
-				$config['class'] = trim($config['class'] . ' header_icon');
+				$config['class'] = trim(($config['class'] ?? '') . ' header_icon');
 			}
 
 			if (\is_array($config['button_callback'] ?? null))


### PR DESCRIPTION
If you have a global operation with a defined icon and a (legacy) `button_callback`, the following error might occur:

```
ErrorException:
Warning: Undefined array key "class"

  at vendor\contao\contao\core-bundle\src\DataContainer\DataContainerOperation.php:80
  at Contao\CoreBundle\DataContainer\DataContainerOperation->offsetGet('class')
     (vendor\contao\contao\core-bundle\contao\classes\DataContainer.php:873)
  at Contao\DataContainer->{closure:Contao\DataContainer::generateGlobalButtons():861}(object(DataContainerOperation))
     (vendor\contao\contao\core-bundle\src\DataContainer\AbstractDataContainerOperationsBuilder.php:210)
  at Contao\CoreBundle\DataContainer\AbstractDataContainerOperationsBuilder->executeButtonCallback(object(Closure), object(DataContainerOperation), object(Closure))
     (vendor\contao\contao\core-bundle\src\DataContainer\DataContainerGlobalOperationsBuilder.php:164)
  at Contao\CoreBundle\DataContainer\DataContainerGlobalOperationsBuilder->generateOperation('foobar', array('icon' => 'clipboard.svg', 'button_callback' => object(Closure), 'label' => null), object(DC_Table), object(Closure))
     (vendor\contao\contao\core-bundle\src\DataContainer\DataContainerGlobalOperationsBuilder.php:150)
  at Contao\CoreBundle\DataContainer\DataContainerGlobalOperationsBuilder->addGlobalButtons(object(DC_Table), object(Closure))
     (vendor\contao\contao\core-bundle\contao\classes\DataContainer.php:891)
  at Contao\DataContainer->generateGlobalButtons(object(DataContainerGlobalOperationsBuilder))
     (vendor\contao\contao\core-bundle\contao\drivers\DC_Table.php:3523)
```

e.g.:

```php
// contao/dca/tl_page.php
$GLOBALS['TL_DCA']['tl_page']['list']['global_operations']['foobar'] = [
    'icon' => 'clipboard.svg',
    'button_callback' => function (string|null $href, string $label, string $title, string|null $class, string $attributes): string {
        return 'foobar';
    },
];
```

This PR restores the behaviour to as it was prior to Contao 5.6:

https://github.com/contao/contao/blob/74573eea4f432f8aadb532d12e744d9145f00459/core-bundle/contao/classes/DataContainer.php#L1015