### PR TITLE
Set widget error on onbeforesubmit exception

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3144,6 +3144,7 @@ System::getContainer()->get('contao.data_container.global_operations_builder')->
 					{
 						$this->noReload = true;
 						Message::addError($e->getMessage());
+						System::getContainer()->get('request_stack')?->getMainRequest()->attributes->set('_contao_widget_error', true);
 
 						break;
 					}


### PR DESCRIPTION
Our `BackendMain` controller triggers a 422 error for twig (https://github.com/contao/contao/blob/6a5d05f570f23a804a8484c58c5582ab7ec14a5e/core-bundle/contao/controllers/BackendMain.php#L156) if a widget has errors (https://github.com/contao/contao/blob/6a5d05f570f23a804a8484c58c5582ab7ec14a5e/core-bundle/contao/library/Contao/Widget.php#L496).

This however does not work on errors from `onbeforesubmit_callback`, which results in Turbo generating an error like
> Error: Form responses must redirect to another location