### PR TITLE
Fix the back end pagination

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -5848,14 +5848,14 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			$this->redirect(preg_replace('/&(amp;)?lp=[^&]+/i', '', Environment::get('requestUri')));
 		}
 
+		$paginationConfig = (new PaginationConfig('lp', (int) $this->total, (int) $limit))->withIgnoreOutOfBounds();
+
 		if ($limit)
 		{
-			Input::setGet('lp', $offset / $limit + 1); // see #6923
+			$paginationConfig = $paginationConfig->withCurrentPage($offset / $limit + 1);
 		}
 
-		$pagination = System::getContainer()->get('contao.pagination.factory')->create(
-			(new PaginationConfig('lp', (int) $this->total, (int) $limit))->withIgnoreOutOfBounds()
-		);
+		$pagination = System::getContainer()->get('contao.pagination.factory')->create($paginationConfig);
 
 		return System::getContainer()->get('twig')->render('@Contao/backend/component/_pagination.html.twig', array('pagination' => $pagination));
 	}

--- a/core-bundle/contao/templates/twig/backend/component/_pagination.html.twig
+++ b/core-bundle/contao/templates/twig/backend/component/_pagination.html.twig
@@ -3,7 +3,7 @@
 {% block pagination_component %}
     {% if pagination.pageCount > 1 %}
         {% set pagination_attributes = attrs(pagination_attributes|default)
-            .addClass('pagination')
+            .addClass(['pagination', 'pagination-' ~ pagination.queryParameterName])
             .set('role', 'navigation')
             .set('aria-label', 'MSC.pagination'|trans)
         %}

--- a/core-bundle/src/Pagination/Pagination.php
+++ b/core-bundle/src/Pagination/Pagination.php
@@ -32,7 +32,7 @@ class Pagination implements PaginationInterface
     {
         $this->pageCount = $config->getPerPage() > 0 ? (int) ceil($config->getTotal() / $config->getPerPage()) : 0;
 
-        $currentPage = $this->config->getRequest()?->query->getInt($this->getQueryParameterName(), 1) ?? 1;
+        $currentPage = $config->getCurrentPage() ?? $this->config->getRequest()?->query->getInt($this->getQueryParameterName(), 1) ?? 1;
 
         if ($currentPage < 1 || $currentPage > $this->pageCount) {
             if (!$config->getIgnoreOutOfBounds()) {

--- a/core-bundle/src/Pagination/PaginationConfig.php
+++ b/core-bundle/src/Pagination/PaginationConfig.php
@@ -22,6 +22,8 @@ class PaginationConfig
 
     private bool $ignoreOutOfBounds = false;
 
+    private int|null $currentPage = null;
+
     public function __construct(
         private readonly string $queryParameterName,
         private readonly int $total,
@@ -64,6 +66,17 @@ class PaginationConfig
         return $clone;
     }
 
+    /**
+     * Forces the pagination to use the given page number as the current page.
+     */
+    public function withCurrentPage(int $currentPage): self
+    {
+        $clone = clone $this;
+        $clone->currentPage = $currentPage;
+
+        return $clone;
+    }
+
     public function getQueryParameterName(): string
     {
         return $this->queryParameterName;
@@ -92,5 +105,10 @@ class PaginationConfig
     public function getIgnoreOutOfBounds(): bool
     {
         return $this->ignoreOutOfBounds;
+    }
+
+    public function getCurrentPage(): int|null
+    {
+        return $this->currentPage;
     }
 }

--- a/core-bundle/tests/Pagination/PaginationTest.php
+++ b/core-bundle/tests/Pagination/PaginationTest.php
@@ -22,7 +22,7 @@ class PaginationTest extends TestCase
 {
     public function testCreatesPagination(): void
     {
-        $request = Request::create('/foobar?page=2');
+        $request = Request::create('/foobar?page=2&lorem=ipsum');
 
         $pagination = new Pagination((new PaginationConfig('page', 100, 5))->withRequest($request)->withPageRange(10));
 
@@ -37,7 +37,7 @@ class PaginationTest extends TestCase
         $this->assertSame(range(1, 10), $pagination->getPages());
         $this->assertSame('page', $pagination->getQueryParameterName());
         $this->assertSame(5, $pagination->getPerPage());
-        $this->assertSame('/foobar?page=3', $pagination->getUrlForPage(3));
+        $this->assertSame('/foobar?page=3&lorem=ipsum', $pagination->getUrlForPage(3));
     }
 
     public function testThrowsOutOfRangeException(): void
@@ -71,5 +71,23 @@ class PaginationTest extends TestCase
 
         $this->assertNull($pagination->getNext());
         $this->assertNull($pagination->getLast());
+    }
+
+    public function testUsesForcedCurrentPage(): void
+    {
+        $request = Request::create('/foobar?page=2');
+
+        $config = (new PaginationConfig('page', 100, 5))
+            ->withRequest($request)
+            ->withPageRange(10)
+            ->withCurrentPage(3)
+        ;
+
+        $pagination = new Pagination($config);
+
+        $this->assertSame(3, $pagination->getCurrent());
+        $this->assertSame(2, $pagination->getPrevious());
+        $this->assertSame(4, $pagination->getNext());
+        $this->assertSame('/foobar?page=4', $pagination->getUrlForPage(4));
     }
 }


### PR DESCRIPTION
This PR fixes two issues:

* The old back end pagination received its current page parameter via `Input::setGet()` in `DC_Table`, which the new one obviously does not, as we only check the regular request object. This causes #9035 - and is fixed by introducing a new `withCurrentPage()` config, so that you can override the current page from the outside.
* The old back end pagination also had a `.pagination-lp` (and `.pagination-vp`) CSS class, which was missing for the new pagination. This PR re-introduces that class for the back end pagination, fixing the styling of the pagination.

I have also updated an existing test so that it verifies that existing parameters are retained in the pagination URLs (unrelated to these 2 issues).