### PR TITLE
Set `nameValue` for widgets using the `row-wizard-controller`

### DIFF
--- a/core-bundle/contao/templates/twig/backend/widget/key_value_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/key_value_wizard.html.twig
@@ -3,6 +3,7 @@
 {% set table_attributes = attrs()
     .set('id', 'ctrl_' ~ id)
     .set('data-controller', 'contao--row-wizard')
+    .set('data-contao--row-wizard-name-value', id)
     .addClass('tl_key_value_wizard')
 %}
 <table{{ table_attributes }}>

--- a/core-bundle/contao/templates/twig/backend/widget/list_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/list_wizard.html.twig
@@ -3,6 +3,7 @@
 {% set list_attributes = attrs()
     .set('id', 'ctrl_' ~ id)
     .set('data-controller', 'contao--row-wizard contao--sortable')
+    .set('data-contao--row-wizard-name-value', id)
     .set('data-contao--sortable-handle-value', '.drag-handle')
     .set('data-contao--row-wizard-target', 'body')
     .addClass('tl_listwizard')

--- a/core-bundle/contao/templates/twig/backend/widget/module_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/module_wizard.html.twig
@@ -3,6 +3,7 @@
 {% set table_attributes = attrs()
     .set('id', 'ctrl_' ~ id)
     .set('data-controller', 'contao--row-wizard')
+    .set('data-contao--row-wizard-name-value', id)
     .addClass('tl_modulewizard')
 %}
 <table{{ table_attributes }}>

--- a/core-bundle/contao/templates/twig/backend/widget/option_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/option_wizard.html.twig
@@ -3,6 +3,7 @@
 {% set table_attributes = attrs()
     .set('id', 'ctrl_' ~ id)
     .set('data-controller', 'contao--row-wizard')
+    .set('data-contao--row-wizard-name-value', id)
     .addClass('tl_optionwizard')
 %}
 <table{{ table_attributes }}>

--- a/core-bundle/contao/templates/twig/backend/widget/section_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/section_wizard.html.twig
@@ -3,6 +3,7 @@
 {% set table_attributes = attrs()
     .set('id', 'ctrl_' ~ id)
     .set('data-controller', 'contao--row-wizard')
+    .set('data-contao--row-wizard-name-value', id)
     .addClass('tl_sectionwizard')
 %}
 <table{{ table_attributes }}>


### PR DESCRIPTION
### Description

_This only affects 5.x_

Creating new rows within the following widgets using the row-wizard-controller do not work as expected due to the index not being updated.

It's due to `this.nameValue` being mandatory now - has been generalized for the sake of the RowWizard.
https://github.com/contao/contao/blob/74dbd1cc84158718669c2e1275500283ca5bcba2/core-bundle/assets/controllers/row-wizard-controller.js#L108-L110
