### PR TITLE
Convert the TextField input value using `StringUtil::specialChars()`

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1574,15 +1574,6 @@ abstract class Widget extends Controller
 
 		return '';
 	}
-
-	protected static function specialcharsValue($strString): string
-	{
-		return str_replace(
-			array('&amp;#35;', '&amp;#60;', '&amp;#62;', '&amp;#40;', '&amp;#41;', '&amp;#92;', '&amp;#61;', '&amp;#34;', '&amp;#39;'),
-			array('&#35;', '&#60;', '&#62;', '&#40;', '&#41;', '&#92;', '&#61;', '&#34;', '&#39;'),
-			StringUtil::specialchars((string) $strString, false, true),
-		);
-	}
 }
 
 class_alias(Widget::class, 'Widget');

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1574,6 +1574,15 @@ abstract class Widget extends Controller
 
 		return '';
 	}
+
+	protected static function specialcharsValue($strString): string
+	{
+		return str_replace(
+			array('&amp;#35;', '&amp;#60;', '&amp;#62;', '&amp;#40;', '&amp;#41;', '&amp;#92;', '&amp;#61;', '&amp;#34;', '&amp;#39;'),
+			array('&#35;', '&#60;', '&#62;', '&#40;', '&#41;', '&#92;', '&#61;', '&#34;', '&#39;'),
+			StringUtil::specialchars((string) $strString, false, true),
+		);
+	}
 }
 
 class_alias(Widget::class, 'Widget');

--- a/core-bundle/src/Resources/contao/widgets/TextField.php
+++ b/core-bundle/src/Resources/contao/widgets/TextField.php
@@ -193,7 +193,7 @@ class TextField extends Widget
 				$this->strName,
 				$this->strId . '_' . $i,
 				$this->size,
-				self::specialcharsValue(@$this->varValue[$i]), // see #4979
+				StringUtil::specialchars(@$this->varValue[$i], false, true), // see #4979
 				$blnPlaceholderArray && isset($this->arrAttributes['placeholder'][$i]) ? ' placeholder="' . StringUtil::specialcharsAttribute($this->arrAttributes['placeholder'][$i]) . '"' : '',
 				$this->getAttributes($blnPlaceholderArray ? array('placeholder') : array())
 			);

--- a/core-bundle/src/Resources/contao/widgets/TextField.php
+++ b/core-bundle/src/Resources/contao/widgets/TextField.php
@@ -193,7 +193,7 @@ class TextField extends Widget
 				$this->strName,
 				$this->strId . '_' . $i,
 				$this->size,
-				StringUtil::specialchars(@$this->varValue[$i], false, true), // see #4979
+				StringUtil::specialchars(@$this->varValue[$i]), // see #4979
 				$blnPlaceholderArray && isset($this->arrAttributes['placeholder'][$i]) ? ' placeholder="' . StringUtil::specialcharsAttribute($this->arrAttributes['placeholder'][$i]) . '"' : '',
 				$this->getAttributes($blnPlaceholderArray ? array('placeholder') : array())
 			);


### PR DESCRIPTION
### Description

* fixes #9041

e1d801247ced45647a26a97c3ce66efe749902ff  updated the TextField widget to use `specialcharsValue` for XSS protection, this does only exist in Contao 5.