### PR TITLE
Fix the legacy accordion templates

### DIFF
--- a/core-bundle/contao/templates/elements/ce_accordionSingle.html5
+++ b/core-bundle/contao/templates/elements/ce_accordionSingle.html5
@@ -1,7 +1,7 @@
 
 <section class="<?= $this->class ?> ce_accordion ce_text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
 
-  <div<?php $this->attrs()->addClass($this->toggler)->addStyle($this->headlineStyle) ?>>
+  <div<?= $this->attrs()->addClass($this->toggler)->addStyle($this->headlineStyle) ?>>
     <?= $this->headline ?>
   </div>
 

--- a/core-bundle/contao/templates/elements/ce_accordionStart.html5
+++ b/core-bundle/contao/templates/elements/ce_accordionStart.html5
@@ -1,7 +1,7 @@
 
 <section class="<?= $this->class ?> ce_accordion block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
 
-  <div<?php $this->attrs()->addClass($this->toggler)->addStyle($this->headlineStyle) ?>>
+  <div<?= $this->attrs()->addClass($this->toggler)->addStyle($this->headlineStyle) ?>>
     <?= $this->headline ?>
   </div>
 


### PR DESCRIPTION
### Description

Using `<?php` without an echo will never output the HTMLAttributes, thus not setting the class "toggler". This breaks existing legacy accordion elements due to the JS init not working anymore (the `.toggler` class is missing).

This PR uses the shorthand echo tag to output them correctly.

<img width="1504" height="930" alt="grafik" src="https://github.com/user-attachments/assets/5abff5f1-a264-49b5-8d33-82b7738c42fb" />