### PR TITLE
Increase the field length for the ALTCHA challenge

### DIFF
--- a/core-bundle/src/Entity/Altcha.php
+++ b/core-bundle/src/Entity/Altcha.php
@@ -31,7 +31,7 @@ class Altcha
     #[GeneratedValue]
     protected int $id;
 
-    #[Column(type: 'string', length: 64, nullable: false)]
+    #[Column(type: 'string', length: 128, nullable: false)]
     protected string $challenge;
 
     #[Column(type: 'datetime_immutable')]


### PR DESCRIPTION
Fixes

```
PDOException:
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'challenge' at row 1

  at vendor\doctrine\dbal\src\Driver\PDO\Statement.php:55
  at PDOStatement->execute()
     (vendor\doctrine\dbal\src\Driver\PDO\Statement.php:55)
  at Doctrine\DBAL\Driver\PDO\Statement->execute()
     (vendor\doctrine\dbal\src\Driver\Middleware\AbstractStatementMiddleware.php:24)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute()
     (vendor\doctrine\dbal\src\Logging\Statement.php:46)
  at Doctrine\DBAL\Logging\Statement->execute()
     (vendor\doctrine\dbal\src\Driver\Middleware\AbstractStatementMiddleware.php:24)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute()
     (vendor\symfony\doctrine-bridge\Middleware\Debug\Statement.php:58)
  at Symfony\Bridge\Doctrine\Middleware\Debug\Statement->execute()
     (vendor\doctrine\dbal\src\Statement.php:104)
  at Doctrine\DBAL\Statement->execute()
     (vendor\doctrine\dbal\src\Statement.php:133)
  at Doctrine\DBAL\Statement->executeStatement()
     (vendor\doctrine\orm\src\Persisters\Entity\BasicEntityPersister.php:253)
  at Doctrine\ORM\Persisters\Entity\BasicEntityPersister->executeInserts()
     (vendor\doctrine\orm\src\UnitOfWork.php:1059)
  at Doctrine\ORM\UnitOfWork->executeInserts()
     (vendor\doctrine\orm\src\UnitOfWork.php:402)
  at Doctrine\ORM\UnitOfWork->commit()
     (vendor\doctrine\orm\src\EntityManager.php:268)
  at Doctrine\ORM\EntityManager->flush()
     (vendor\contao\contao\core-bundle\src\Altcha\Altcha.php:104)
```

The challenge is generated via PHP's `hash()` which will return 128 hexits for SHA-512.

(discovered via https://github.com/contao/contao/issues/9028#issuecomment-3581673120)
