### PR TITLE
Add the missing `toggle-state-controller` to `be_main.html.twig`

### DIFF
--- a/core-bundle/contao/templates/twig/be_main.html.twig
+++ b/core-bundle/contao/templates/twig/be_main.html.twig
@@ -11,8 +11,9 @@
     .set('id', 'top')
     .addClass('be_main')
     .addClass('popup', isPopup)
-    .set('data-controller', 'contao--tooltips')
-    .set('data-action', 'touchstart@document->contao--tooltips#touchStart')
+    .set('data-controller', 'contao--tooltips contao--toggle-state')
+    .set('data-action', 'touchstart@document->contao--tooltips#touchStart keydown.esc@document->contao--toggle-state#close')
+    .set('data-contao--toggle-state-active-class', 'active')
     .mergeWith(bodyAttributes|default)
 -%}
 
@@ -85,7 +86,7 @@
 
         {% block left %}
             {% if not isPopup %}
-                <aside id="left">
+                <aside id="left" data-contao--toggle-state-target="controls">
                     {{ menu|raw }}
                     <div class="version">
                         {% block version %}


### PR DESCRIPTION
### Description

The `be_main` twig surrogate template from https://github.com/contao/contao/pull/9046 was missing the changes from https://github.com/contao/contao/pull/8618, thus removing the menu toggle functionality on mobile.