### PR TITLE
Add a conflict for `symfony/var-exporter` `8.x`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -209,7 +209,7 @@
         "doctrine/annotations": "<1.9",
         "doctrine/cache": "<1.10",
         "nikic/php-parser": "4.7.0",
-        "symfony/var-exporter": ">=8@dev",
+        "symfony/var-exporter": ">=8",
         "terminal42/contao-ce-access": "<3.0",
         "thecodingmachine/safe": "<1.2",
         "web-auth/webauthn-symfony-bundle": "5.1.* <5.1.3 || 5.2.0 || 5.2.1",

--- a/composer.json
+++ b/composer.json
@@ -209,6 +209,7 @@
         "doctrine/annotations": "<1.9",
         "doctrine/cache": "<1.10",
         "nikic/php-parser": "4.7.0",
+        "symfony/var-exporter": ">=8@dev",
         "terminal42/contao-ce-access": "<3.0",
         "thecodingmachine/safe": "<1.2",
         "web-auth/webauthn-symfony-bundle": "5.1.* <5.1.3 || 5.2.0 || 5.2.1",

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -74,7 +74,7 @@
         "phpunit/phpunit": "^11.5"
     },
     "conflict": {
-        "symfony/var-exporter": ">=8@dev"
+        "symfony/var-exporter": ">=8"
     },
     "autoload": {
         "psr-4": {

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -73,6 +73,9 @@
         "contao/news-bundle": "self.version",
         "phpunit/phpunit": "^11.5"
     },
+    "conflict": {
+        "symfony/var-exporter": ">=8@dev"
+    },
     "autoload": {
         "psr-4": {
             "Contao\\ManagerBundle\\": "src/"


### PR DESCRIPTION
Fixes #9057 as discussed there by adding a conflict for `"symfony/var-exporter": ">=8@dev"` in our `contao/manager-bundle`.