### PR TITLE
Remove the back button from Twig templates

### DIFF
--- a/core-bundle/contao/templates/twig/be_maintenance.html.twig
+++ b/core-bundle/contao/templates/twig/be_maintenance.html.twig
@@ -1,5 +1,2 @@
-<div id="tl_buttons">
-    <a href="{{ href }}" class="header_back" title="{{ title }}">{{ button }}</a>
-</div>
 
 {{ content|raw }}

--- a/core-bundle/contao/templates/twig/be_two_factor.html.twig
+++ b/core-bundle/contao/templates/twig/be_two_factor.html.twig
@@ -1,9 +1,5 @@
 {% trans_default_domain "contao_default" %}
 
-<div id="tl_buttons">
-    <a href="{{ href }}" class="header_back" title="{{ 'MSC.backBTTitle'|trans }}">{{ 'MSC.backBT'|trans }}</a>
-</div>
-
 <div class="two-factor">
     <h2 class="sub_headline">{{ 'MSC.twoFactorAuthentication'|trans }}</h2>
     {{ messages }}


### PR DESCRIPTION
These have been removed in #8817 but survived the Twig migration.