### PR TITLE
Correctly bypass the password change for impersonated users

### DIFF
--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -55,7 +55,7 @@ class BackendMain extends Backend
 		$user = BackendUser::getInstance();
 
 		// Password change required
-		if ($user->pwChange && !$authorizationChecker->isGranted('ROLE_PREVIOUS_ADMIN'))
+		if ($user->pwChange && !$authorizationChecker->isGranted('IS_IMPERSONATOR'))
 		{
 			$this->redirect($container->get('router')->generate('contao_backend_password'));
 		}


### PR DESCRIPTION
If you currently try to impersonate a back end user that needs a password change, you can no longer access that backend. The `ROLE_PREVIOUS_ADMIN` has been deprecated in Symfony 5 and removed in Symfony 6.

see https://github.com/symfony/symfony/pull/35858