### PR TITLE
Allow confirming opt-in tokens as long as they are valid

### DIFF
--- a/comments-bundle/contao/models/CommentsNotifyModel.php
+++ b/comments-bundle/contao/models/CommentsNotifyModel.php
@@ -106,7 +106,7 @@ class CommentsNotifyModel extends Model
 	}
 
 	/**
-	 * Find subscriptions that have not been activated for more than 24 hours
+	 * Find subscriptions that have not been confirmed while the opt-in token was valid
 	 *
 	 * @param array $arrOptions An optional options array
 	 *
@@ -117,8 +117,8 @@ class CommentsNotifyModel extends Model
 		$t = static::$strTable;
 		$objDatabase = Database::getInstance();
 
-		$objResult = $objDatabase->prepare("SELECT * FROM $t WHERE active=0 AND EXISTS (SELECT * FROM tl_opt_in_related r LEFT JOIN tl_opt_in o ON r.pid=o.id WHERE r.relTable='$t' AND r.relId=$t.id AND o.createdOn<=? AND o.confirmedOn=0 AND o.token LIKE 'com-%')")
-								 ->execute(strtotime('-24 hours'));
+		$objResult = $objDatabase->prepare("SELECT * FROM $t WHERE active=0 AND EXISTS (SELECT * FROM tl_opt_in_related r LEFT JOIN tl_opt_in o ON r.pid=o.id WHERE r.relTable='$t' AND r.relId=$t.id AND o.removeOn<=? AND o.confirmedOn=0 AND o.token LIKE 'com-%')")
+								 ->execute(time());
 
 		if ($objResult->numRows < 1)
 		{

--- a/core-bundle/contao/dca/tl_opt_in.php
+++ b/core-bundle/contao/dca/tl_opt_in.php
@@ -40,7 +40,7 @@ $GLOBALS['TL_DCA']['tl_opt_in'] = array
 				'id' => 'primary',
 				'tstamp' => 'index',
 				'token' => 'unique',
-				'removeOn' => 'index'
+				'removeOn,confirmedOn' => 'index'
 			)
 		)
 	),
@@ -207,6 +207,6 @@ class tl_opt_in extends Backend
 	 */
 	public function resendButton($row, $href, $label, $title, $icon, $attributes)
 	{
-		return (!$row['confirmedOn'] &&!$row['invalidatedThrough'] && $row['emailSubject'] && $row['emailText'] && $row['createdOn'] > strtotime('-24 hours')) ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '"' . $attributes . '>' . Image::getHtml($icon, $title) . '</a> ' : '';
+		return (!$row['confirmedOn'] &&!$row['invalidatedThrough'] && $row['emailSubject'] && $row['emailText'] && $row['removeOn'] > time()) ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '"' . $attributes . '>' . Image::getHtml($icon, $title) . '</a> ' : '';
 	}
 }

--- a/core-bundle/contao/modules/ModuleRegistration.php
+++ b/core-bundle/contao/modules/ModuleRegistration.php
@@ -448,9 +448,9 @@ class ModuleRegistration extends Module
 		$container = System::getContainer();
 
 		$optIn = $container->get('contao.opt_in');
-		$optIn->setRemoveOn('+' . ($container->getParameter('contao.registration.expiration') + 2) . ' days');
+		$removeOn = new \DateTime('+' . $container->getParameter('contao.registration.expiration') . ' days');
 
-		$optInToken = $optIn->create('reg', $arrData['email'], array('tl_member'=>array($arrData['id'])));
+		$optInToken = $optIn->create('reg', $arrData['email'], array('tl_member'=>array($arrData['id'])), $removeOn);
 
 		// Prepare the simple token data
 		$arrTokenData = $arrData;

--- a/core-bundle/src/OptIn/OptIn.php
+++ b/core-bundle/src/OptIn/OptIn.php
@@ -19,8 +19,6 @@ use Contao\OptInModel;
 
 class OptIn implements OptInInterface
 {
-    private string $removeOn = '+3 days';
-
     /**
      * @internal
      */
@@ -28,12 +26,7 @@ class OptIn implements OptInInterface
     {
     }
 
-    public function setRemoveOn(string $removeOn): void
-    {
-        $this->removeOn = $removeOn;
-    }
-
-    public function create(string $prefix, string $email, array $related): OptInTokenInterface
+    public function create(string $prefix, string $email, array $related, \DateTimeInterface|null $validUntil = null): OptInTokenInterface
     {
         if ($prefix) {
             $prefix = rtrim($prefix, '-');
@@ -49,13 +42,17 @@ class OptIn implements OptInInterface
             $token = $prefix.'-'.substr($token, \strlen($prefix) + 1);
         }
 
+        if (!$validUntil) {
+            $validUntil = new \DateTime('+24 hours');
+        }
+
         $this->framework->initialize();
 
         $optIn = $this->framework->createInstance(OptInModel::class);
         $optIn->tstamp = time();
         $optIn->token = $token;
         $optIn->createdOn = time();
-        $optIn->removeOn = strtotime($this->removeOn);
+        $optIn->removeOn = $validUntil->getTimestamp();
         $optIn->email = $email;
         $optIn->save();
 
@@ -87,9 +84,16 @@ class OptIn implements OptInInterface
             return;
         }
 
+        $time = strtotime('+2 days');
         $adapter = $this->framework->getAdapter(Model::class);
 
         foreach ($tokens as $token) {
+            // Keep unconfirmed tokens for two additional days to ensure they are not removed
+            // before the cron jobs that purge unconfirmed subscriptions have run.
+            if (!$token->confirmedOn && $token->removeOn < $time) {
+                continue;
+            }
+
             $delete = true;
 
             // If the token has been confirmed, check if the related records still exist

--- a/core-bundle/src/OptIn/OptIn.php
+++ b/core-bundle/src/OptIn/OptIn.php
@@ -84,13 +84,13 @@ class OptIn implements OptInInterface
             return;
         }
 
-        $time = strtotime('+2 days');
+        $time = strtotime('-2 days');
         $adapter = $this->framework->getAdapter(Model::class);
 
         foreach ($tokens as $token) {
             // Keep unconfirmed tokens for two additional days to ensure they are not removed
             // before the cron jobs that purge unconfirmed subscriptions have run.
-            if (!$token->confirmedOn && $token->removeOn < $time) {
+            if (!$token->confirmedOn && $token->removeOn > $time) {
                 continue;
             }
 

--- a/core-bundle/src/OptIn/OptInInterface.php
+++ b/core-bundle/src/OptIn/OptInInterface.php
@@ -19,7 +19,7 @@ interface OptInInterface
      *
      * @param array<string, array<int>> $related An array of related tables and IDs
      */
-    public function create(string $prefix, string $email, array $related): OptInTokenInterface;
+    public function create(string $prefix, string $email, array $related/* , \DateTimeInterface|null $validUntil = null */): OptInTokenInterface;
 
     /**
      * Finds a double opt-in token by its identifier.
@@ -30,9 +30,4 @@ interface OptInInterface
      * Purges expired tokens.
      */
     public function purgeTokens(): void;
-
-    /**
-     * Allow setting the remove time.
-     */
-    public function setRemoveOn(string $removeOn): void;
 }

--- a/core-bundle/src/OptIn/OptInToken.php
+++ b/core-bundle/src/OptIn/OptInToken.php
@@ -36,7 +36,7 @@ class OptInToken implements OptInTokenInterface
 
     public function isValid(): bool
     {
-        return !$this->model->invalidatedThrough && $this->model->createdOn > strtotime('-24 hours');
+        return !$this->model->invalidatedThrough && $this->model->removeOn > time();
     }
 
     public function confirm(): void

--- a/core-bundle/tests/OptIn/OptInTest.php
+++ b/core-bundle/tests/OptIn/OptInTest.php
@@ -189,7 +189,7 @@ class OptInTest extends TestCase
     {
         $properties = [
             'confirmedOn' => 0,
-            'removeOn' => strtotime('+2 days'),
+            'removeOn' => strtotime('-2 days'),
         ];
 
         $token = $this->mockClassWithProperties(OptInModel::class, $properties);
@@ -229,7 +229,7 @@ class OptInTest extends TestCase
     {
         $properties = [
             'confirmedOn' => 0,
-            'removeOn' => strtotime('+2 days -1 minute'),
+            'removeOn' => strtotime('-2 days +1 minute'),
         ];
 
         $token = $this->mockClassWithProperties(OptInModel::class, $properties);

--- a/core-bundle/tests/OptIn/OptInTokenTest.php
+++ b/core-bundle/tests/OptIn/OptInTokenTest.php
@@ -56,8 +56,7 @@ class OptInTokenTest extends TestCase
     public function testConfirmsAToken(): void
     {
         $model = $this->mockClassWithProperties(OptInModel::class);
-        $model->createdOn = time();
-        $model->confirmedOn = 0;
+        $model->removeOn = strtotime('+24 hours');
 
         $model
             ->expects($this->once())
@@ -75,8 +74,7 @@ class OptInTokenTest extends TestCase
     {
         $related = $this->mockClassWithProperties(OptInModel::class);
         $related->token = 'reg-first';
-        $related->createdOn = time();
-        $related->confirmedOn = 0;
+        $related->removeOn = strtotime('+24 hours');
 
         $related
             ->expects($this->once())
@@ -101,8 +99,7 @@ class OptInTokenTest extends TestCase
 
         $model = $this->mockClassWithProperties(OptInModel::class);
         $model->token = 'reg-second';
-        $model->createdOn = time();
-        $model->confirmedOn = 0;
+        $model->removeOn = strtotime('+24 hours');
 
         $model
             ->expects($this->once())
@@ -121,8 +118,7 @@ class OptInTokenTest extends TestCase
     {
         $related = $this->mockClassWithProperties(OptInModel::class);
         $related->token = 'reg-first';
-        $related->createdOn = time();
-        $related->confirmedOn = 0;
+        $related->removeOn = strtotime('+24 hours');
 
         $related
             ->expects($this->never())
@@ -147,8 +143,7 @@ class OptInTokenTest extends TestCase
 
         $model = $this->mockClassWithProperties(OptInModel::class);
         $model->token = 'reg-second';
-        $model->createdOn = time();
-        $model->confirmedOn = 0;
+        $model->removeOn = strtotime('+24 hours');
 
         $model
             ->expects($this->once())
@@ -179,8 +174,7 @@ class OptInTokenTest extends TestCase
     public function testDoesNotConfirmAnExpiredToken(): void
     {
         $model = $this->mockClassWithProperties(OptInModel::class);
-        $model->createdOn = strtotime('-1 day');
-        $model->confirmedOn = 0;
+        $model->removeOn = time();
 
         $token = $this->getToken($model);
 
@@ -193,8 +187,7 @@ class OptInTokenTest extends TestCase
     public function testSendsATokenViaEmail(): void
     {
         $model = $this->mockClassWithProperties(OptInModel::class);
-        $model->createdOn = time();
-        $model->confirmedOn = 0;
+        $model->removeOn = strtotime('+24 hours');
         $model->emailSubject = '';
         $model->emailText = '';
 
@@ -239,8 +232,7 @@ class OptInTokenTest extends TestCase
     public function testDoesNotSendAnExpiredTokenViaEmail(): void
     {
         $model = $this->mockClassWithProperties(OptInModel::class);
-        $model->createdOn = strtotime('-1 day');
-        $model->confirmedOn = 0;
+        $model->removeOn = time();
 
         $token = $this->getToken($model);
 
@@ -253,8 +245,7 @@ class OptInTokenTest extends TestCase
     public function testRequiresSubjectAndTextToSendToken(): void
     {
         $model = $this->mockClassWithProperties(OptInModel::class);
-        $model->createdOn = time();
-        $model->confirmedOn = 0;
+        $model->removeOn = strtotime('+24 hours');
         $model->emailSubject = '';
         $model->emailText = '';
 
@@ -274,8 +265,7 @@ class OptInTokenTest extends TestCase
     public function testDoesNotRequireSubjectAndTextToResendToken(): void
     {
         $model = $this->mockClassWithProperties(OptInModel::class);
-        $model->createdOn = time();
-        $model->confirmedOn = 0;
+        $model->removeOn = strtotime('+24 hours');
         $model->emailSubject = 'Subject';
         $model->emailText = 'Text';
 

--- a/newsletter-bundle/contao/models/NewsletterRecipientsModel.php
+++ b/newsletter-bundle/contao/models/NewsletterRecipientsModel.php
@@ -99,7 +99,7 @@ class NewsletterRecipientsModel extends Model
 	}
 
 	/**
-	 * Find subscriptions that have not been activated for more than 24 hours
+	 * Find subscriptions that have not been confirmed while the opt-in token was valid
 	 *
 	 * @param array $arrOptions An optional options array
 	 *
@@ -110,8 +110,8 @@ class NewsletterRecipientsModel extends Model
 		$t = static::$strTable;
 		$objDatabase = Database::getInstance();
 
-		$objResult = $objDatabase->prepare("SELECT * FROM $t WHERE active=0 AND EXISTS (SELECT * FROM tl_opt_in_related r LEFT JOIN tl_opt_in o ON r.pid=o.id WHERE r.relTable='$t' AND r.relId=$t.id AND o.createdOn<=? AND o.confirmedOn=0 AND o.token LIKE 'nl-%')")
-								 ->execute(strtotime('-24 hours'));
+		$objResult = $objDatabase->prepare("SELECT * FROM $t WHERE active=0 AND EXISTS (SELECT * FROM tl_opt_in_related r LEFT JOIN tl_opt_in o ON r.pid=o.id WHERE r.relTable='$t' AND r.relId=$t.id AND o.removeOn<=? AND o.confirmedOn=0 AND o.token LIKE 'nl-%')")
+								 ->execute(time());
 
 		if ($objResult->numRows < 1)
 		{


### PR DESCRIPTION
This PR fixes several issues:

1. It reverts the interface changes from #8511, which are a BC break and can only be made in Contao 6.
2. It allows confirming opt-in tokens as long as they are valid instead of only within the first 24 hours.
3. It moves the entire "keep opt-in tokens two days longer" logic into the `OptIn` class. Everyone else can just check the `removeOn` date without having to worry about `+2 days` or `-24 hours`.
