### PR TITLE
Add the request object(s) to the request stack in the constructor

### DIFF
--- a/core-bundle/tests/Asset/ContaoContextTest.php
+++ b/core-bundle/tests/Asset/ContaoContextTest.php
@@ -72,8 +72,7 @@ class ContaoContextTest extends TestCase
 
         $request->attributes->set('pageModel', $page);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $context = $this->getContaoContext('staticPlugins', $requestStack);
 
@@ -90,8 +89,7 @@ class ContaoContextTest extends TestCase
             ->willReturn($basePath)
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $page = $this->getPageWithDetails();
         $page->rootUseSSL = $useSSL;
@@ -122,8 +120,7 @@ class ContaoContextTest extends TestCase
             ->willReturn('/foo')
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $page = $this->getPageWithDetails();
         $page->rootUseSSL = true;
@@ -150,8 +147,7 @@ class ContaoContextTest extends TestCase
         $request = new Request();
         $request->attributes = new ParameterBag(['pageModel' => $page]);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $context = $this->getContaoContext('', $requestStack);
 
@@ -167,8 +163,7 @@ class ContaoContextTest extends TestCase
         $request = new Request();
         $request->attributes = $this->createMock(ParameterBag::class);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $context = $this->getContaoContext('', $requestStack);
 

--- a/core-bundle/tests/Contao/PaginationTest.php
+++ b/core-bundle/tests/Contao/PaginationTest.php
@@ -55,8 +55,7 @@ class PaginationTest extends TestCase
     {
         $currentPage = $data['currentPage'] ?? 1;
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request(['page' => $currentPage]));
+        $requestStack = new RequestStack([new Request(['page' => $currentPage])]);
 
         System::getContainer()->set('request_stack', $requestStack);
 

--- a/core-bundle/tests/Contao/RootPageDependentSelectTest.php
+++ b/core-bundle/tests/Contao/RootPageDependentSelectTest.php
@@ -57,8 +57,7 @@ class RootPageDependentSelectTest extends TestCase
             ->willReturn('Choose module for "%s"')
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()]);
 
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('contao.framework', $this->mockContaoFramework([PageModel::class => $pageAdapter]));

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -301,8 +301,7 @@ class AbstractBackendControllerTest extends TestCase
         $request = new Request();
         $request->setSession(new Session($sessionStorage));
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);
@@ -367,8 +366,7 @@ class AbstractBackendControllerTest extends TestCase
             )
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request ?? new Request(server: $_SERVER));
+        $requestStack = new RequestStack([$request ?? new Request(server: $_SERVER)]);
 
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
         $scopeMatcher

--- a/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
+++ b/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
@@ -294,8 +294,7 @@ class BackendCsvImportControllerTest extends TestCase
         $request ??= new Request();
         $request->setSession($this->mockSession());
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         System::getContainer()->set('request_stack', $requestStack);
 

--- a/core-bundle/tests/Controller/BackendSearchControllerTest.php
+++ b/core-bundle/tests/Controller/BackendSearchControllerTest.php
@@ -80,8 +80,7 @@ class BackendSearchControllerTest extends TestCase
             ->willReturn('<stream>')
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $container = new ContainerBuilder();
         $container->set('twig', $twig);

--- a/core-bundle/tests/Controller/BackendTemplateStudioControllerTest.php
+++ b/core-bundle/tests/Controller/BackendTemplateStudioControllerTest.php
@@ -176,8 +176,7 @@ class BackendTemplateStudioControllerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request ?? new Request());
+        $requestStack = new RequestStack([$request ?? new Request()]);
 
         $container = $this->getContainerWithContaoConfiguration($this->getTempDir());
         $container->set('security.token_storage', $this->createMock(TokenStorageInterface::class));

--- a/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
@@ -97,8 +97,7 @@ class ContentElementControllerTest extends TestCase
     public function testDoesNotCreateTheTemplateFromACustomTplInTheBackend(): void
     {
         $request = new Request([], [], ['_scope' => 'backend']);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $this->container->set('request_stack', $requestStack);
         $this->container->set('contao.routing.scope_matcher', $this->mockScopeMatcher());

--- a/core-bundle/tests/Controller/FrontendModule/FeedReaderControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/FeedReaderControllerTest.php
@@ -93,8 +93,7 @@ class FeedReaderControllerTest extends TestCase
         ]);
 
         $request = new Request([], [], ['_scope' => 'frontend']);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $controller = $this->getController($feedIo, $cache, $requestStack);
         $response = $controller($request, $model, 'main');
@@ -131,8 +130,7 @@ class FeedReaderControllerTest extends TestCase
         ]);
 
         $request = new Request([], [], ['_scope' => 'frontend']);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $controller = $this->getController($feedIo, $cache, $requestStack);
         $response = $controller($request, $model, 'main');
@@ -163,8 +161,7 @@ class FeedReaderControllerTest extends TestCase
         ]);
 
         $request = new Request([], [], ['_scope' => 'frontend']);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger
@@ -214,8 +211,7 @@ class FeedReaderControllerTest extends TestCase
         ]);
 
         $request = new Request(['page_r42' => 2], [], ['_scope' => 'frontend']);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $assertTwigContext = function (array $context) {
             $this->assertCount(1, $context['elements']);
@@ -285,8 +281,7 @@ class FeedReaderControllerTest extends TestCase
         ]);
 
         $request = new Request(['page_r42' => 2], [], ['_scope' => 'frontend']);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $assertTwigContext = function (array $context) {
             $this->assertCount(2, $context['elements']);

--- a/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
@@ -72,8 +72,7 @@ class RootPageDependentModulesControllerTest extends TestCase
 
         $request = new Request([], [], ['_scope' => 'frontend', 'pageModel' => $page]);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $controller = new RootPageDependentModulesController();
         $controller->setContainer($this->mockContainer($requestStack));
@@ -94,8 +93,7 @@ class RootPageDependentModulesControllerTest extends TestCase
 
         $request = new Request([], [], ['_scope' => 'frontend', 'pageModel' => $page]);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $controller = new RootPageDependentModulesController();
         $controller->setContainer($this->mockContainer($requestStack, 'example-content'));

--- a/core-bundle/tests/Controller/Page/AbstractLayoutPageControllerTest.php
+++ b/core-bundle/tests/Controller/Page/AbstractLayoutPageControllerTest.php
@@ -212,8 +212,7 @@ class AbstractLayoutPageControllerTest extends TestCase
         $request = Request::create('https://localhost');
         $request->attributes->set('pageModel', $page);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $pageFinder = new PageFinder(
             $framework,

--- a/core-bundle/tests/EventListener/DataContainer/BackendFavoritesListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/BackendFavoritesListenerTest.php
@@ -69,8 +69,7 @@ class BackendFavoritesListenerTest extends TestCase
         $request->query->set('act', 'create');
         $request->query->set('data', base64_encode($url));
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $listener = new BackendFavoritesListener($security, $requestStack);
         $listener->enableEditing();
@@ -108,8 +107,7 @@ class BackendFavoritesListenerTest extends TestCase
         $request = new Request();
         $request->query->set('act', 'create');
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $listener = new BackendFavoritesListener($security, $requestStack);
         $listener->enableEditing();
@@ -136,8 +134,7 @@ class BackendFavoritesListenerTest extends TestCase
             ->willReturn($this->createMock(UserInterface::class))
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()]);
 
         $listener = new BackendFavoritesListener($security, $requestStack);
         $listener->enableEditing();
@@ -161,8 +158,7 @@ class BackendFavoritesListenerTest extends TestCase
         $request->query->set('return', '1');
         $request->request->set('saveNclose', '1');
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $listener = new BackendFavoritesListener($this->createMock(Security::class), $requestStack);
         $redirect = null;
@@ -188,8 +184,7 @@ class BackendFavoritesListenerTest extends TestCase
         $request->query->set('return', '1');
         $request->request->set('save', '1');
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $listener = new BackendFavoritesListener($this->createMock(Security::class), $requestStack);
         $listener->redirectBack($dataContainer);
@@ -206,8 +201,7 @@ class BackendFavoritesListenerTest extends TestCase
         $request = new Request();
         $request->request->set('saveNclose', '1');
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $listener = new BackendFavoritesListener($this->createMock(Security::class), $requestStack);
         $listener->redirectBack($dataContainer);

--- a/core-bundle/tests/EventListener/DataContainer/TemplateOptionsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/TemplateOptionsListenerTest.php
@@ -112,8 +112,7 @@ class TemplateOptionsListenerTest extends TestCase
         $request = new Request(['act' => 'overrideAll']);
         $request->setSession($session);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $result = $this->createMock(Result::class);
         $result

--- a/core-bundle/tests/EventListener/Menu/BackendFavoritesListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendFavoritesListenerTest.php
@@ -84,8 +84,7 @@ class BackendFavoritesListenerTest extends TestCase
         $request = Request::create('https://localhost/contao?do=pages&act=edit&id=3');
         $request->setSession($session);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $connection = $this->createMock(Connection::class);
         $connection
@@ -254,8 +253,7 @@ class BackendFavoritesListenerTest extends TestCase
         $request = Request::create('https://localhost/contao?do=pages&act=edit&id=3');
         $request->setSession($session);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $connection = $this->createMock(Connection::class);
         $connection

--- a/core-bundle/tests/EventListener/Menu/BackendPreviewListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendPreviewListenerTest.php
@@ -49,8 +49,7 @@ class BackendPreviewListenerTest extends ContaoTestCase
         $request->query->set('do', $do);
         $request->query->set('id', $id);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $eventDispatcher = $this->createMock(EventDispatcher::class);
         $eventDispatcher

--- a/core-bundle/tests/EventListener/Menu/BackendTemplateStudioListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendTemplateStudioListenerTest.php
@@ -178,8 +178,7 @@ class BackendTemplateStudioListenerTest extends ContaoTestCase
         $request = new Request();
         $request->attributes->set('_controller', BackendTemplateStudioController::class);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $listener = new BackendTemplateStudioListener($security, $router, $requestStack, $translator, true);
         $listener($event);

--- a/core-bundle/tests/Fragment/FragmentHandlerTest.php
+++ b/core-bundle/tests/Fragment/FragmentHandlerTest.php
@@ -255,8 +255,7 @@ class FragmentHandlerTest extends TestCase
         $fragmentHandler ??= $this->createMock(BaseFragmentHandler::class);
         $pageFinder ??= $this->createMock(PageFinder::class);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         return new FragmentHandler($renderers, $fragmentHandler, $requestStack, $registry, $preHandlers, $pageFinder, true);
     }

--- a/core-bundle/tests/Framework/ContaoFrameworkTest.php
+++ b/core-bundle/tests/Framework/ContaoFrameworkTest.php
@@ -357,8 +357,7 @@ class ContaoFrameworkTest extends TestCase
 
         $framework->reset();
 
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create('/index.html'));
+        $requestStack = new RequestStack([Request::create('/index.html')]);
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -1577,8 +1577,7 @@ class FigureBuilderTest extends TestCase
         $request = Request::create('https://localhost');
         $request->attributes->set('pageModel', $pageModel);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $pageFinder = new PageFinder(
             $framework ?? $this->mockContaoFramework(),

--- a/core-bundle/tests/Image/Studio/LightboxResultTest.php
+++ b/core-bundle/tests/Image/Studio/LightboxResultTest.php
@@ -70,8 +70,7 @@ class LightboxResultTest extends TestCase
         $request = Request::create('https://localhost');
         $request->attributes->set('pageModel', $pageModel);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $pageFinder = new PageFinder(
             $framework,
@@ -125,8 +124,7 @@ class LightboxResultTest extends TestCase
         $request = Request::create('https://localhost');
         $request->attributes->set('pageModel', $pageModel);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $pageFinder = new PageFinder(
             $framework,

--- a/core-bundle/tests/InsertTag/InsertTagParserTest.php
+++ b/core-bundle/tests/InsertTag/InsertTagParserTest.php
@@ -43,8 +43,7 @@ class InsertTagParserTest extends TestCase
     {
         parent::setUp();
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()]);
 
         $container = $this->getContainerWithContaoConfiguration($this->getTempDir());
         $container->set('contao.security.token_checker', $this->createMock(TokenChecker::class));

--- a/core-bundle/tests/InsertTag/Resolver/FormatDateInsertTagTest.php
+++ b/core-bundle/tests/InsertTag/Resolver/FormatDateInsertTagTest.php
@@ -92,8 +92,7 @@ class FormatDateInsertTagTest extends TestCase
         $request = new Request();
         $request->attributes->set('pageModel', $pageModel);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $listener = new FormatDateInsertTag($this->getFramework(), $requestStack);
 

--- a/core-bundle/tests/Mailer/ContaoMailerTest.php
+++ b/core-bundle/tests/Mailer/ContaoMailerTest.php
@@ -37,8 +37,7 @@ class ContaoMailerTest extends TestCase
         $request = new Request();
         $request->attributes->set('pageModel', $pageModel);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $transport = $this->createMock(TransportInterface::class);
         $mailer = new Mailer($transport);

--- a/core-bundle/tests/Monolog/ContaoTableProcessorTest.php
+++ b/core-bundle/tests/Monolog/ContaoTableProcessorTest.php
@@ -86,8 +86,7 @@ class ContaoTableProcessorTest extends TestCase
     {
         $request = new Request([], [], [], [], [], ['HTTP_USER_AGENT' => 'Contao test']);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $processor = $this->getContaoTableProcessor($requestStack);
 

--- a/core-bundle/tests/Routing/Content/StringResolverTest.php
+++ b/core-bundle/tests/Routing/Content/StringResolverTest.php
@@ -79,8 +79,7 @@ class StringResolverTest extends TestCase
             ->willReturn($insertTagResult)
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create($baseUrl));
+        $requestStack = new RequestStack([Request::create($baseUrl)]);
 
         $requestContext = new RequestContext();
         $urlHelper = new UrlHelper($requestStack, $requestContext);

--- a/core-bundle/tests/Routing/Enhancer/InputEnhancerTest.php
+++ b/core-bundle/tests/Routing/Enhancer/InputEnhancerTest.php
@@ -50,8 +50,7 @@ class InputEnhancerTest extends TestCase
         $framework = $this->mockContaoFramework([Input::class => $input]);
 
         $request = Request::create('/');
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $defaults = [
             'pageModel' => $this->mockPageModel($language, $urlPrefix),
@@ -94,8 +93,7 @@ class InputEnhancerTest extends TestCase
         $framework = $this->mockContaoFramework([Input::class => $input]);
 
         $request = Request::create('/');
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $defaults = [
             'pageModel' => $this->mockPageModel('en', ''),
@@ -126,8 +124,7 @@ class InputEnhancerTest extends TestCase
         $framework = $this->mockContaoFramework([Input::class => $input]);
 
         $request = Request::create('/');
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $defaults = [
             'pageModel' => $this->createMock(PageModel::class),
@@ -153,8 +150,7 @@ class InputEnhancerTest extends TestCase
         $framework = $this->mockContaoFramework([Input::class => $input]);
 
         $request = Request::create('/?foo=bar');
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $defaults = [
             'pageModel' => $this->mockPageModel('en', ''),
@@ -186,8 +182,7 @@ class InputEnhancerTest extends TestCase
         $framework = $this->mockContaoFramework($adapters);
 
         $request = Request::create('/');
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $defaults = [
             'pageModel' => $this->mockPageModel('en', ''),

--- a/core-bundle/tests/Routing/PageFinderTest.php
+++ b/core-bundle/tests/Routing/PageFinderTest.php
@@ -52,8 +52,7 @@ class PageFinderTest extends TestCase
         $request = Request::create('https://localhost');
         $request->attributes->set('pageModel', $pageModel);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $pageFinder = new PageFinder(
             $this->mockContaoFramework(),

--- a/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
@@ -149,8 +149,7 @@ class CoreResponseContextFactoryTest extends TestCase
             ])
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create('https://example.com/'));
+        $requestStack = new RequestStack([Request::create('https://example.com/')]);
 
         $cpHandlerFactory = new CspHandlerFactory(new CspParser(new PolicyManager()));
 
@@ -257,8 +256,7 @@ class CoreResponseContextFactoryTest extends TestCase
             ])
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create('https://example.com/'));
+        $requestStack = new RequestStack([Request::create('https://example.com/')]);
 
         $pageModel = $this->mockClassWithProperties(PageModel::class);
         $pageModel->id = 0;

--- a/core-bundle/tests/Routing/ResponseContext/ResponseContextAccessorTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/ResponseContextAccessorTest.php
@@ -26,7 +26,7 @@ class ResponseContextAccessorTest extends TestCase
 {
     public function testGettingAndSettingTheResponseContext(): void
     {
-        $requestStack = new RequestStack();
+        $requestStack = new RequestStack([new Request()]);
         $context = new ResponseContext();
         $accessor = new ResponseContextAccessor($requestStack);
 
@@ -34,16 +34,13 @@ class ResponseContextAccessorTest extends TestCase
         $this->assertSame($accessor, $accessor->setResponseContext($context));
         $this->assertNull($accessor->getResponseContext());
 
-        $requestStack->push(new Request());
-
         $this->assertSame($accessor, $accessor->setResponseContext($context));
         $this->assertSame($context, $accessor->getResponseContext());
     }
 
     public function testFinalizing(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()]);
 
         $accessor = new ResponseContextAccessor($requestStack);
 

--- a/core-bundle/tests/Routing/ResponseContext/ResponseContextAccessorTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/ResponseContextAccessorTest.php
@@ -26,7 +26,7 @@ class ResponseContextAccessorTest extends TestCase
 {
     public function testGettingAndSettingTheResponseContext(): void
     {
-        $requestStack = new RequestStack([new Request()]);
+        $requestStack = new RequestStack();
         $context = new ResponseContext();
         $accessor = new ResponseContextAccessor($requestStack);
 
@@ -34,6 +34,8 @@ class ResponseContextAccessorTest extends TestCase
         $this->assertSame($accessor, $accessor->setResponseContext($context));
         $this->assertNull($accessor->getResponseContext());
 
+        $requestStack->push(new Request());
+        
         $this->assertSame($accessor, $accessor->setResponseContext($context));
         $this->assertSame($context, $accessor->getResponseContext());
     }

--- a/core-bundle/tests/Routing/ResponseContext/ResponseContextAccessorTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/ResponseContextAccessorTest.php
@@ -35,7 +35,7 @@ class ResponseContextAccessorTest extends TestCase
         $this->assertNull($accessor->getResponseContext());
 
         $requestStack->push(new Request());
-        
+
         $this->assertSame($accessor, $accessor->setResponseContext($context));
         $this->assertSame($context, $accessor->getResponseContext());
     }

--- a/core-bundle/tests/Security/Authentication/ContaoStrategyTest.php
+++ b/core-bundle/tests/Security/Authentication/ContaoStrategyTest.php
@@ -50,8 +50,7 @@ class ContaoStrategyTest extends TestCase
 
     public function testUsesDefaultDecisionStrategyIfFirewallMapHasNoConfig(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()]);
 
         $accessDecisionManager = new ContaoStrategy(
             $this->mockAccessDecisionStrategy(true),
@@ -65,8 +64,7 @@ class ContaoStrategyTest extends TestCase
 
     public function testUsesPriorityStrategyIfContaoFrontendRequest(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request([], [], ['_scope' => 'frontend']));
+        $requestStack = new RequestStack([new Request([], [], ['_scope' => 'frontend'])]);
 
         $accessDecisionManager = new ContaoStrategy(
             $this->mockAccessDecisionStrategy(false),
@@ -80,8 +78,7 @@ class ContaoStrategyTest extends TestCase
 
     public function testUsesPriorityStrategyIfContaoBackendRequest(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request([], [], ['_scope' => 'backend']));
+        $requestStack = new RequestStack([new Request([], [], ['_scope' => 'backend'])]);
 
         $accessDecisionManager = new ContaoStrategy(
             $this->mockAccessDecisionStrategy(false),

--- a/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
@@ -312,8 +312,7 @@ class FrontendPreviewAuthenticatorTest extends TestCase
         $request = new Request();
         $request->setSession($session);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $security ??= $this->createMock(Security::class);
         $tokenStorage ??= $this->createMock(TokenStorageInterface::class);

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -58,7 +58,7 @@ class TokenCheckerTest extends TestCase
         ;
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext($firewallContext),
             $tokenStorage,
             new AuthenticationTrustResolver(),
@@ -111,7 +111,7 @@ class TokenCheckerTest extends TestCase
         ;
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext($firewallContext),
             $tokenStorage,
             new AuthenticationTrustResolver(),
@@ -142,7 +142,7 @@ class TokenCheckerTest extends TestCase
         $request->setSession($session);
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(FrontendUser::class),
             new AuthenticationTrustResolver(),
@@ -163,7 +163,7 @@ class TokenCheckerTest extends TestCase
         $request->setSession($session);
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext('contao_frontend'),
             $this->mockTokenStorage(BackendUser::class),
             new AuthenticationTrustResolver(),
@@ -200,7 +200,7 @@ class TokenCheckerTest extends TestCase
         ;
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(FrontendUser::class),
             new AuthenticationTrustResolver(),
@@ -285,7 +285,7 @@ class TokenCheckerTest extends TestCase
     public function testAccessingThePreviewIsAllowedForBackendUser(): void
     {
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($this->createMock(Request::class)),
+            new RequestStack([$this->createMock(Request::class)]),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
             new AuthenticationTrustResolver(),
@@ -320,7 +320,7 @@ class TokenCheckerTest extends TestCase
         ;
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
             new AuthenticationTrustResolver(),
@@ -361,7 +361,7 @@ class TokenCheckerTest extends TestCase
         $request->setSession($session);
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
             new AuthenticationTrustResolver(),
@@ -391,7 +391,7 @@ class TokenCheckerTest extends TestCase
         $request->setSession($session);
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext('contao_frontend'),
             $this->mockTokenStorage(FrontendUser::class),
             new AuthenticationTrustResolver(),
@@ -427,7 +427,7 @@ class TokenCheckerTest extends TestCase
         $request->setSession($session);
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
             new AuthenticationTrustResolver(),
@@ -454,7 +454,7 @@ class TokenCheckerTest extends TestCase
         $request->setSession($session);
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext('contao_frontend'),
             $tokenStorage,
             new AuthenticationTrustResolver(),
@@ -473,7 +473,7 @@ class TokenCheckerTest extends TestCase
         $request->setSession($session);
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
             new AuthenticationTrustResolver(),
@@ -517,7 +517,7 @@ class TokenCheckerTest extends TestCase
         ;
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack($request),
+            new RequestStack([$request]),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
             new AuthenticationTrustResolver(),
@@ -546,11 +546,6 @@ class TokenCheckerTest extends TestCase
         $data->setValue($user, ['id' => 1, 'username' => 'foobar']);
 
         return $user;
-    }
-
-    private function mockRequestStack(Request $request): RequestStack
-    {
-        return new RequestStack([$request]);
     }
 
     private function mockFirewallMapWithConfigContext(string $context): FirewallMap&MockObject

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -550,10 +550,7 @@ class TokenCheckerTest extends TestCase
 
     private function mockRequestStack(Request $request): RequestStack
     {
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
-
-        return $requestStack;
+        return new RequestStack([$request]);
     }
 
     private function mockFirewallMapWithConfigContext(string $context): FirewallMap&MockObject

--- a/core-bundle/tests/Security/Authenticator/ContaoLoginAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authenticator/ContaoLoginAuthenticatorTest.php
@@ -90,7 +90,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
 
         $this->assertFalse($authenticator->isInteractive());
 
-        $requestStack = new RequestStack([new Request()], [$request]);
+        $requestStack = new RequestStack([new Request()]);
 
         $authenticator = $this->getContaoLoginAuthenticator(requestStack: $requestStack);
 
@@ -99,7 +99,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
         $request = new Request();
         $request->attributes->set('pageModel', $this->createMock(PageModel::class));
 
-        $requestStack = new RequestStack();
+        $requestStack = new RequestStack([$request]);
 
         $authenticator = $this->getContaoLoginAuthenticator(requestStack: $requestStack);
 

--- a/core-bundle/tests/Security/Authenticator/ContaoLoginAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authenticator/ContaoLoginAuthenticatorTest.php
@@ -90,8 +90,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
 
         $this->assertFalse($authenticator->isInteractive());
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()], [$request]);
 
         $authenticator = $this->getContaoLoginAuthenticator(requestStack: $requestStack);
 
@@ -101,7 +100,6 @@ class ContaoLoginAuthenticatorTest extends TestCase
         $request->attributes->set('pageModel', $this->createMock(PageModel::class));
 
         $requestStack = new RequestStack();
-        $requestStack->push($request);
 
         $authenticator = $this->getContaoLoginAuthenticator(requestStack: $requestStack);
 

--- a/core-bundle/tests/Security/SecurityTestCase.php
+++ b/core-bundle/tests/Security/SecurityTestCase.php
@@ -27,8 +27,7 @@ abstract class SecurityTestCase extends TestCase
         $request = new Request();
         $request->attributes->set('_scope', $scope);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('request_stack', $requestStack);

--- a/core-bundle/tests/Twig/Runtime/UrlRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/UrlRuntimeTest.php
@@ -21,8 +21,7 @@ class UrlRuntimeTest extends TestCase
 {
     public function testPrefixesRelativeUrls(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()]);
 
         $runtime = new UrlRuntime($requestStack);
 
@@ -35,8 +34,7 @@ class UrlRuntimeTest extends TestCase
         $request->server->set('SCRIPT_NAME', '/managed-edition/public/index.php');
         $request->server->set('SCRIPT_FILENAME', '/managed-edition/public/index.php');
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $runtime = new UrlRuntime($requestStack);
 
@@ -54,8 +52,7 @@ class UrlRuntimeTest extends TestCase
     {
         $request = new Request();
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $runtime = new UrlRuntime($requestStack);
 

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -102,8 +102,7 @@ class TwigIntegrationTest extends TestCase
             ),
         );
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request = new Request());
+        $requestStack = new RequestStack([$request = new Request()]);
 
         $filesystemLoader = $this->createMock(ContaoFilesystemLoader::class);
         $filesystemLoader

--- a/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -47,8 +47,7 @@ class BackendMenuListenerTest extends ContaoTestCase
         $request = new Request();
         $request->server->set('QUERY_STRING', 'do=page');
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $translator = $this->getTranslator();
 
@@ -94,8 +93,7 @@ class BackendMenuListenerTest extends ContaoTestCase
 
     public function testAddsTheHoverClassIfTheDebugModeIsEnabled(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()]);
 
         $translator = $this->getTranslator();
         $router = $this->createMock(RouterInterface::class);
@@ -201,8 +199,7 @@ class BackendMenuListenerTest extends ContaoTestCase
             ->willReturnArgument(0)
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, $managerPath, null);
         $listener($event);
@@ -233,8 +230,7 @@ class BackendMenuListenerTest extends ContaoTestCase
         $router = $this->createMock(RouterInterface::class);
         $translator = $this->getTranslator();
 
-        $requestStack = new RequestStack();
-        $requestStack->push($this->createMock(Request::class));
+        $requestStack = new RequestStack([$this->createMock(Request::class)]);
 
         $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, null, null);
         $listener($event);


### PR DESCRIPTION
Introduced in Symfony 7.2 (https://github.com/symfony/symfony/pull/57909) so we can clean that up.