### PR TITLE
Fix accessing a method that potentially does not exist

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -503,13 +503,19 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             }
         }
 
+        // Not explicitly configured or disabled means, we can apply our defaults which
+        // should be Loupe if it is available. Loupe is not installed, keep the search
+        // disabled (default)
         if (!class_exists(LoupeFactory::class)) {
             return $extensionConfigs;
         }
 
         $loupeFactory = new LoupeFactory();
 
-        if (!$loupeFactory->isSupported()) {
+        // Older versions of Loupe did not require dependencies in the composer.json
+        // directly. There we need to check if Loupe is supported. In newer versions of
+        // Loupe, this is ensured by Composer requirements.
+        if (method_exists($loupeFactory, 'isSupported') && !$loupeFactory->isSupported()) {
             return $extensionConfigs;
         }
 

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -503,9 +503,6 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             }
         }
 
-        // Not explicitly configured or disabled means, we can apply our defaults which
-        // should be Loupe if it is available. Loupe is not installed, keep the search
-        // disabled (default)
         if (!class_exists(LoupeFactory::class)) {
             return $extensionConfigs;
         }
@@ -513,7 +510,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         $loupeFactory = new LoupeFactory();
 
         // Older versions of Loupe did not require dependencies in the composer.json
-        // directly. There we need to check if Loupe is supported. In newer versions of
+        // directly. There, we need to check if Loupe is supported. In newer versions of
         // Loupe, this is ensured by Composer requirements.
         if (method_exists($loupeFactory, 'isSupported') && !$loupeFactory->isSupported()) {
             return $extensionConfigs;


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/9079

The dependency checker correctly detected, that we're using a class that we don't require. But we ignored it because we do a `class_exists()` check. This is fine but we forgot to also ensure the `method_exists()` on the object. 