### PR TITLE
Use `MockHttpClient` in `FactoryTest`

### DIFF
--- a/core-bundle/tests/Crawl/Escargot/FactoryTest.php
+++ b/core-bundle/tests/Crawl/Escargot/FactoryTest.php
@@ -98,7 +98,10 @@ class FactoryTest extends TestCase
             ->willReturn('subscriber-1')
         ;
 
-        $factory = new Factory($this->createMock(Connection::class), $this->mockContaoFramework(), $this->createMock(ContentUrlGenerator::class), new RequestStack());
+        $mockClient = new MockHttpClient();
+        $clientFactory = static fn (array $defaultOptions) => $mockClient;
+
+        $factory = new Factory($this->createMock(Connection::class), $this->mockContaoFramework(), $this->createMock(ContentUrlGenerator::class), new RequestStack(), [], [], $clientFactory);
         $factory->addSubscriber($subscriber1);
 
         $uriCollection = new BaseUriCollection([new Uri('https://contao.org')]);
@@ -121,7 +124,10 @@ class FactoryTest extends TestCase
             ->willReturn('subscriber-1')
         ;
 
-        $factory = new Factory($this->createMock(Connection::class), $this->mockContaoFramework(), $this->createMock(ContentUrlGenerator::class), new RequestStack());
+        $mockClient = new MockHttpClient();
+        $clientFactory = static fn (array $defaultOptions) => $mockClient;
+
+        $factory = new Factory($this->createMock(Connection::class), $this->mockContaoFramework(), $this->createMock(ContentUrlGenerator::class), new RequestStack(), [], [], $clientFactory);
         $factory->addSubscriber($subscriber1);
 
         $queue = new InMemoryQueue();

--- a/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
+++ b/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
@@ -166,7 +166,6 @@ final class GlobalStateWatcher implements AfterTestHook, BeforeTestHook
                 'Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag',
                 'Symfony\Component\ErrorHandler\\',
                 'Symfony\Component\Filesystem\\',
-                'Symfony\Component\HttpClient\Internal\CurlClientState',
                 'Symfony\Component\HttpClient\Response\MockResponse',
                 'Symfony\Component\Mime\Address',
                 'Symfony\Component\Mime\MimeTypes\\',

--- a/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
+++ b/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
@@ -166,6 +166,7 @@ final class GlobalStateWatcher implements AfterTestHook, BeforeTestHook
                 'Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag',
                 'Symfony\Component\ErrorHandler\\',
                 'Symfony\Component\Filesystem\\',
+                'Symfony\Component\HttpClient\Internal\CurlClientState',
                 'Symfony\Component\HttpClient\Response\MockResponse',
                 'Symfony\Component\Mime\Address',
                 'Symfony\Component\Mime\MimeTypes\\',


### PR DESCRIPTION
Fixes the current failure in the _Reverse order_ CI. `CurlClientState` is instantiated here for example:

```
contao/contao/core-bundle/tests/Crawl/Escargot/FactoryTest.php:130
contao/contao/core-bundle/src/Crawl/Escargot/Factory.php:167
contao/contao/core-bundle/src/Crawl/Escargot/Factory.php:193
contao/contao/core-bundle/src/Crawl/Escargot/Factory.php:66
contao/contao/vendor/symfony/http-client/HttpClient.php:55
contao/contao/vendor/symfony/http-client/CurlHttpClient.php:78
contao/contao/vendor/symfony/http-client/Internal/CurlClientState.php:44
```

This PR fixes that by using a `MockHttpClient` instead.