### PR TITLE
Fix error when using a SQL expression for a label

### DIFF
--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -376,7 +376,11 @@ class ValueFormatter implements ResetInterface
     {
         // Cannot use isset() because the value can be NULL
         if (!\array_key_exists($id, $this->foreignValueCache[$table][$field] ?? [])) {
-            $dbField = $this->connection->getDatabasePlatform()->quoteSingleIdentifier($field);
+            $dbField = $field;
+            if (preg_match('/^[A-Za-z0-9_$]+$/', $field)) {
+                $dbField = $this->connection->getDatabasePlatform()->quoteSingleIdentifier($field);
+            }
+
             $value = $this->connection->fetchOne("SELECT $dbField FROM $table WHERE id=?", [$id]);
 
             $this->foreignValueCache[$table][$field][$id] = false === $value ? $id : $value;


### PR DESCRIPTION
Since https://github.com/contao/contao/pull/9030 the exception below is thrown if a SQL expression is used as the `foreignKey` attribute of a DCA field.
This is because the expression gets quoted and the resulting SQL query looks something like this, which is not correct: 
```
SELECT `CONCAT(title, ' (ID ', id, ')')` FROM tl_form WHERE id=?
```
(This exact case can easily be reproduced with terminal42/contao-leads)

I guess something like the [`preg_match` that previously prevented this](https://github.com/contao/contao/blob/5.x/core-bundle/contao/library/Contao/Database.php#L678) has to be added in the `fetchForeignValue` method of the `ValueFormatter`. There doesn't seem to be a way to let dbal check for this.
<br><br>
<details>
<summary>[3/3] InvalidFieldNameException</summary>

```
Doctrine\DBAL\Exception\InvalidFieldNameException:
An exception occurred while executing a query: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'CONCAT(title, ' (ID ', id, ')')' in 'SELECT'

  at vendor/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php:69
  at Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter->convert(object(Exception), object(Query))
     (vendor/doctrine/dbal/src/Connection.php:1976)
  at Doctrine\DBAL\Connection->handleDriverException(object(Exception), object(Query))
     (vendor/doctrine/dbal/src/Connection.php:1918)
  at Doctrine\DBAL\Connection->convertExceptionDuringQuery(object(Exception), 'SELECT `CONCAT(title, \' (ID \', id, \')\')` FROM tl_form WHERE id=?', array(5), array())
     (vendor/doctrine/dbal/src/Connection.php:1111)
  at Doctrine\DBAL\Connection->executeQuery('SELECT `CONCAT(title, \' (ID \', id, \')\')` FROM tl_form WHERE id=?', array(5), array())
     (vendor/doctrine/dbal/src/Connection.php:627)
  at Doctrine\DBAL\Connection->fetchOne('SELECT `CONCAT(title, \' (ID \', id, \')\')` FROM tl_form WHERE id=?', array(5))
     (vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:380)
  at Contao\CoreBundle\DataContainer\ValueFormatter->fetchForeignValue('tl_form', 'CONCAT(title, \' (ID \', id, \')\')', 5)
     (vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:259)
  at Contao\CoreBundle\DataContainer\ValueFormatter->getLabel('tl_form', 'CONCAT(title, \' (ID \', id, \')\')', 5, object(DC_Table))
     (vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:129)
  at Contao\CoreBundle\DataContainer\ValueFormatter->formatFilterOptions('tl_lead', 'form_id', array(5), object(DC_Table))
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:5524)
  at Contao\DC_Table->filterMenu(1)
     (vendor/contao/contao/core-bundle/contao/classes/DataContainer.php:1095)
  at Contao\DataContainer->panel()
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:485)
  at Contao\DC_Table->showAll()
     (vendor/contao/contao/core-bundle/contao/classes/Backend.php:456)
  at Contao\Backend->getBackendModule('lead', null)
     (vendor/contao/contao/core-bundle/contao/controllers/BackendMain.php:148)
  at Contao\BackendMain->run()
     (vendor/contao/contao/core-bundle/src/Controller/BackendController.php:44)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:42)
  at require('.../public/index.php')
     (/Users/lukasbableck/.composer/vendor/laravel/valet/server.php:110)     
```
</details>
<details>
<summary>[2/3] Exception</summary>

```
Doctrine\DBAL\Driver\PDO\Exception:
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'CONCAT(title, ' (ID ', id, ')')' in 'SELECT'

  at vendor/doctrine/dbal/src/Driver/PDO/Exception.php:24
  at Doctrine\DBAL\Driver\PDO\Exception::new(object(PDOException))
     (vendor/doctrine/dbal/src/Driver/PDO/Statement.php:132)
  at Doctrine\DBAL\Driver\PDO\Statement->execute(null)
     (vendor/doctrine/dbal/src/Driver/Middleware/AbstractStatementMiddleware.php:69)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute(null)
     (vendor/doctrine/dbal/src/Logging/Statement.php:98)
  at Doctrine\DBAL\Logging\Statement->execute(null)
     (vendor/doctrine/dbal/src/Driver/Middleware/AbstractStatementMiddleware.php:69)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute(null)
     (vendor/symfony/doctrine-bridge/Middleware/Debug/DBAL3/Statement.php:70)
  at Symfony\Bridge\Doctrine\Middleware\Debug\DBAL3\Statement->execute()
     (vendor/doctrine/dbal/src/Connection.php:1104)
  at Doctrine\DBAL\Connection->executeQuery('SELECT `CONCAT(title, \' (ID \', id, \')\')` FROM tl_form WHERE id=?', array(5), array())
     (vendor/doctrine/dbal/src/Connection.php:627)
  at Doctrine\DBAL\Connection->fetchOne('SELECT `CONCAT(title, \' (ID \', id, \')\')` FROM tl_form WHERE id=?', array(5))
     (vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:380)
  at Contao\CoreBundle\DataContainer\ValueFormatter->fetchForeignValue('tl_form', 'CONCAT(title, \' (ID \', id, \')\')', 5)
     (vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:259)
  at Contao\CoreBundle\DataContainer\ValueFormatter->getLabel('tl_form', 'CONCAT(title, \' (ID \', id, \')\')', 5, object(DC_Table))
     (vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:129)
  at Contao\CoreBundle\DataContainer\ValueFormatter->formatFilterOptions('tl_lead', 'form_id', array(5), object(DC_Table))
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:5524)
  at Contao\DC_Table->filterMenu(1)
     (vendor/contao/contao/core-bundle/contao/classes/DataContainer.php:1095)
  at Contao\DataContainer->panel()
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:485)
  at Contao\DC_Table->showAll()
     (vendor/contao/contao/core-bundle/contao/classes/Backend.php:456)
  at Contao\Backend->getBackendModule('lead', null)
     (vendor/contao/contao/core-bundle/contao/controllers/BackendMain.php:148)
  at Contao\BackendMain->run()
     (vendor/contao/contao/core-bundle/src/Controller/BackendController.php:44)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:42)
  at require('.../contao5x/public/index.php')
     (/Users/lukasbableck/.composer/vendor/laravel/valet/server.php:110)  
```
</details>
<details>
<summary>[1/3] PDOException</summary>

```
PDOException:
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'CONCAT(title, ' (ID ', id, ')')' in 'SELECT'

  at vendor/doctrine/dbal/src/Driver/PDO/Statement.php:130
  at PDOStatement->execute(null)
     (vendor/doctrine/dbal/src/Driver/PDO/Statement.php:130)
  at Doctrine\DBAL\Driver\PDO\Statement->execute(null)
     (vendor/doctrine/dbal/src/Driver/Middleware/AbstractStatementMiddleware.php:69)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute(null)
     (vendor/doctrine/dbal/src/Logging/Statement.php:98)
  at Doctrine\DBAL\Logging\Statement->execute(null)
     (vendor/doctrine/dbal/src/Driver/Middleware/AbstractStatementMiddleware.php:69)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute(null)
     (vendor/symfony/doctrine-bridge/Middleware/Debug/DBAL3/Statement.php:70)
  at Symfony\Bridge\Doctrine\Middleware\Debug\DBAL3\Statement->execute()
     (vendor/doctrine/dbal/src/Connection.php:1104)
  at Doctrine\DBAL\Connection->executeQuery('SELECT `CONCAT(title, \' (ID \', id, \')\')` FROM tl_form WHERE id=?', array(5), array())
     (vendor/doctrine/dbal/src/Connection.php:627)
  at Doctrine\DBAL\Connection->fetchOne('SELECT `CONCAT(title, \' (ID \', id, \')\')` FROM tl_form WHERE id=?', array(5))
     (vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:380)
  at Contao\CoreBundle\DataContainer\ValueFormatter->fetchForeignValue('tl_form', 'CONCAT(title, \' (ID \', id, \')\')', 5)
     (vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:259)
  at Contao\CoreBundle\DataContainer\ValueFormatter->getLabel('tl_form', 'CONCAT(title, \' (ID \', id, \')\')', 5, object(DC_Table))
     (vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:129)
  at Contao\CoreBundle\DataContainer\ValueFormatter->formatFilterOptions('tl_lead', 'form_id', array(5), object(DC_Table))
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:5524)
  at Contao\DC_Table->filterMenu(1)
     (vendor/contao/contao/core-bundle/contao/classes/DataContainer.php:1095)
  at Contao\DataContainer->panel()
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:485)
  at Contao\DC_Table->showAll()
     (vendor/contao/contao/core-bundle/contao/classes/Backend.php:456)
  at Contao\Backend->getBackendModule('lead', null)
     (vendor/contao/contao/core-bundle/contao/controllers/BackendMain.php:148)
  at Contao\BackendMain->run()
     (vendor/contao/contao/core-bundle/src/Controller/BackendController.php:44)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:42)
  at require('.../public/index.php')
     (/Users/lukasbableck/.composer/vendor/laravel/valet/server.php:110)   
```
</details>