### PR TITLE
[RFC] Outline how to get rid of |raw

### DIFF
--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Controller\Backend\FavoriteController;
 use Contao\CoreBundle\Exception\AccessDeniedException;
+use Contao\CoreBundle\Twig\Markup\SafeHtmlVariable;
 use Knp\Bundle\TimeBundle\DateTimeFormatter;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
@@ -246,7 +247,7 @@ class BackendMain extends Backend
 		$data['charset'] = System::getContainer()->getParameter('kernel.charset');
 		$data['home'] = $GLOBALS['TL_LANG']['MSC']['home'];
 		$data['isPopup'] = Input::get('popup');
-		$data['learnMore'] = \sprintf($GLOBALS['TL_LANG']['MSC']['learnMore'], '<a href="https://contao.org" target="_blank" rel="noreferrer noopener">contao.org</a>');
+		$data['learnMore'] = SafeHtmlVariable::create(\sprintf($GLOBALS['TL_LANG']['MSC']['learnMore'], '<a href="https://contao.org" target="_blank" rel="noreferrer noopener">contao.org</a>'));
 		$data['containerClass'] = BackendUser::getInstance()->backendWidth;
 
 		$twig = $container->get('twig');

--- a/core-bundle/contao/templates/twig/be_main.html.twig
+++ b/core-bundle/contao/templates/twig/be_main.html.twig
@@ -95,7 +95,7 @@
                     {{ menu|raw }}
                     <div class="version">
                         {% block version %}
-                            {{ version }}<br>{{ learnMore|raw }}
+                            {{ version }}<br>{{ learnMore }}
                         {% endblock %}
                     </div>
                 </aside>

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -30,6 +30,7 @@ use Contao\CoreBundle\Twig\Interop\ContaoEscaperNodeVisitor;
 use Contao\CoreBundle\Twig\Interop\PhpTemplateProxyNode;
 use Contao\CoreBundle\Twig\Interop\PhpTemplateProxyNodeVisitor;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
+use Contao\CoreBundle\Twig\Markup\SafeHtmlVariable;
 use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
 use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
 use Contao\CoreBundle\Twig\Runtime\BackendHelperRuntime;
@@ -94,6 +95,7 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
         $escaperRuntime->addSafeClass(HtmlAttributes::class, ['html', 'contao_html']);
         $escaperRuntime->addSafeClass(HighlightResult::class, ['html', 'contao_html']);
         $escaperRuntime->addSafeClass(DataContainerOperationsBuilder::class, ['html', 'contao_html']);
+        $escaperRuntime->addSafeClass(SafeHtmlVariable::class, ['html', 'contao_html']);
 
         $this->environment->addGlobal(
             'request_token',

--- a/core-bundle/src/Twig/Markup/SafeHtmlVariable.php
+++ b/core-bundle/src/Twig/Markup/SafeHtmlVariable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Contao\CoreBundle\Twig\Markup;
+
+class SafeHtmlVariable implements \Stringable
+{
+    public function __construct(private readonly string $variable)
+    {
+
+    }
+
+    public static function create(string $variable): SafeHtmlVariable
+    {
+        return new self($variable);
+    }
+
+    public function __toString(): string
+    {
+        return $this->variable;
+    }
+}


### PR DESCRIPTION
I would like to propose trying to get rid of `|raw` (and maybe `sanitize()`) in Twig templates everywhere. I know it's not going to be easy and it's probably something for later versions but here's why I think using `|raw` in Contao is fundamentally flawed:

`|raw` is perfectly fine for projects. You write the controllers and you control the templates. You know exactly what input you have, where you pass the variables, in what context etc. - **you are in full control**.

In my opinion, this is different in a CMS like Contao that by defnition is extensible. We want to write reusable templates and we don't always know the contents of the variables passed on to the templates.

Here's an example: Think of the simplest `table.html.twig`. This could be a template provided by the Contao core or an imaginary **extension A** and meant as a reusable template:

```twig
<table>
    {% for row in rows %}
        <tr>
            {% for cell in row %}
                <td>{{ cell }}</td>
            {% endfor %}
        </tr>
    {% endfor %}
</table>
```

That's great, now I can re-use that in my project or my own **extension B** I want to publish:

```php
$rows = [
    ['Cell 1', 'Cell 2', 'Cell 3'],
    ['Cell 4', 'Cell 5', 'Cell 6']
];

echo $twig->render('table.html.twig', [
    'rows' => $rows
]);
```

Nice! However, now we have a problem because as soon as I want to wrap `Cell 1` into a `<strong>Cell 1</strong>`, this doesn't work anymore. I need to ask the developer of **extension A** or the Contao core to update the `table.html.twig`. But now, how? Like so?

```twig
<table>
    {% for row in rows %}
        <tr>
            {% for cell in row %}
                <td>{{ cell|raw }}</td>
            {% endfor %}
        </tr>
    {% endfor %}
</table>
```

Cool, this now fixes the problem for **extension B**, because `<strong>Cell 1</strong>` now works. But what if **extension C** did this?

```php
$rows = [
    ['Cell 1', 'Cell 2', 'Cell 3'],
    ['Cell 4', 'Cell 5', $request->query->get('user-input')]
];

echo $twig->render('table.html.twig', [
    'rows' => $rows
]);
```

Right. Previously, this was safe. And as soon as you update the template, you have now created an XSS attack vector 😞 
So what do you do? You resort to the sanitizer:

```twig
<table>
    {% for row in rows %}
        <tr>
            {% for cell in row %}
                <td>{{ cell||sanitize_html('contao') }}</td>
            {% endfor %}
        </tr>
    {% endfor %}
</table>
```

This is now still safe, while still allowing `<strong>Cell 1</strong>`. But what if I want to use `<button onclick="alert('Hello!')">Click me</button>`? It's perfectly safe but it doesn't work because `onclick` is of course sanitized and removed.

I think the logic should be reversed. Contao is a system that can be put together with lots of different extensions. It's a pluggable system. If you want to build re-usable components, you have no clue whether the content you will receive is safe or not. The one that knows, is the developer that **uses** the template and **passes** the variable to the template.

There's a very easy way to fix this: You can mark variables safe for Twig, which is a concept we already use for `HtmlAttributes` and Co. so it's nothing new. 
By using a `SafeHtmlVariable` like illustrated in this PR, we could achieve exactly that.

```php
$rows = [
    ['Cell 1', 'Cell 2', 'Cell 3'],
    ['Cell 4', 'Cell 5', SafeHtmlVariable::create($this->sanitizer->sanitize($request->query->get('user-input'))]
];

echo $twig->render('table.html.twig', [
    'rows' => $rows
]);
```

The original template remains unchanged:

```twig
<table>
    {% for row in rows %}
        <tr>
            {% for cell in row %}
                <td>{{ cell }}</td>
            {% endfor %}
        </tr>
    {% endfor %}
</table>
```

So the extension that did do this, is still safe, because the contents will get encoded:

```php
$rows = [
    ['Cell 1', 'Cell 2', 'Cell 3'],
    ['Cell 4', 'Cell 5', $request->query->get('user-input')]
];

echo $twig->render('table.html.twig', [
    'rows' => $rows
]);
```

Now, the responsibility for making the cell contents safe is put on the one **passing the variables on to the template**. Because they are the one knowing the contents of that variable they pass! They can also pass `SafeHtmlVariable::create('<button onclick="alert(\'Hello!\')">Click me</button>')` and it would work. Of course it's their repsonsiblity to make sure that the variable **is actually safe**.

By the way: This would also work in Twig out-of-the-box without any special handling. There's been a [`Markup`](https://github.com/twigphp/Twig/blob/3.x/src/Markup.php) class since day one which is there to do exactly that: Mark variables as safe. But the problem I have with just re-using that is that it marks a variable safe for **all** the strategies, not just `html` which I think is dangerous.

The changes in the `be_main.html.twig` are for illustration purposes. And this issue is a brain dump 😊 
