### PR TITLE
Remove the `loupe-seal-adapter` from the manager bundle

### DIFF
--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -29,7 +29,6 @@
     "require": {
         "php": "^8.3",
         "ext-json": "*",
-        "cmsig/seal-loupe-adapter": "^0.12.2",
         "contao/core-bundle": "self.version",
         "contao/manager-plugin": "^2.4",
         "doctrine/dbal": "^3.6 || ^4.0",


### PR DESCRIPTION
Shouldn't be required anymore with the `contao/loupe-bridge`?