### PR TITLE
Fix using the deprecated `Template::attr()` method

### DIFF
--- a/core-bundle/contao/templates/backend/be_main.html5
+++ b/core-bundle/contao/templates/backend/be_main.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->rootAttributes = $this
-    ->attr()
+    ->attrs()
     ->set('lang', $this->language)
     ->set('data-controller', 'contao--scroll-offset')
     ->set('data-action', 'store-scroll-offset@window->contao--scroll-offset#store contao--tinymce:editor-loaded->contao--scroll-offset#scrollToWidgetError turbo:render@document->contao--scroll-offset#restore')
@@ -9,7 +9,7 @@ $this->rootAttributes = $this
 ;
 
 $this->bodyAttributes = $this
-    ->attr($this->attributes)
+    ->attrs($this->attributes)
     ->set('id', 'top')
     ->addClass('be_main')
     ->addClass('popup', $this->isPopup)

--- a/core-bundle/contao/templates/block/block_searchable.html5
+++ b/core-bundle/contao/templates/block/block_searchable.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'block'])
     ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)

--- a/core-bundle/contao/templates/elements/ce_accordionSingle.html5
+++ b/core-bundle/contao/templates/elements/ce_accordionSingle.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'ce_accordion', 'ce_text', 'block'])
     ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)

--- a/core-bundle/contao/templates/elements/ce_accordionStart.html5
+++ b/core-bundle/contao/templates/elements/ce_accordionStart.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'ce_accordion', 'block'])
     ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)

--- a/core-bundle/contao/templates/elements/ce_headline.html5
+++ b/core-bundle/contao/templates/elements/ce_headline.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass($this->class)
     ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)

--- a/core-bundle/contao/templates/elements/ce_sliderStart.html5
+++ b/core-bundle/contao/templates/elements/ce_sliderStart.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'block'])
     ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)

--- a/core-bundle/contao/templates/elements/ce_teaser.html5
+++ b/core-bundle/contao/templates/elements/ce_teaser.html5
@@ -3,7 +3,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr()
+    ->attrs()
     ->addClass('ce_text')
     ->mergeWith($this->wrapperAttributes)
 ;

--- a/core-bundle/contao/templates/elements/ce_toplink.html5
+++ b/core-bundle/contao/templates/elements/ce_toplink.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'block'])
     ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)

--- a/core-bundle/contao/templates/forms/form_explanation.html5
+++ b/core-bundle/contao/templates/forms/form_explanation.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr()
+    ->attrs()
     ->addClass([$this->prefix, 'explanation', $this->class])
     ->mergeWith($this->wrapperAttributes)
 ;

--- a/core-bundle/contao/templates/forms/form_row.html5
+++ b/core-bundle/contao/templates/forms/form_row.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr()
+    ->attrs()
     ->addClass([$this->prefix, $this->class])
     ->mergeWith($this->wrapperAttributes)
 ;

--- a/core-bundle/contao/templates/forms/form_wrapper.html5
+++ b/core-bundle/contao/templates/forms/form_wrapper.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'block'])
     ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)

--- a/core-bundle/contao/templates/frontend/fe_page.html5
+++ b/core-bundle/contao/templates/frontend/fe_page.html5
@@ -1,14 +1,14 @@
 <?php
 
 $this->rootAttributes = $this
-    ->attr()
+    ->attrs()
     ->set('lang', $this->language)
     ->set('dir', 'rtl', $this->isRTL)
     ->mergeWith($this->rootAttributes)
 ;
 
 $this->bodyAttributes = $this
-    ->attr()
+    ->attrs()
     ->set('id', 'top')
     ->addClass($this->class)
     ->setIfExists('onload', $this->onload)

--- a/core-bundle/contao/templates/member/member_default.html5
+++ b/core-bundle/contao/templates/member/member_default.html5
@@ -3,7 +3,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'block'])
     ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)

--- a/core-bundle/contao/templates/member/member_grouped.html5
+++ b/core-bundle/contao/templates/member/member_grouped.html5
@@ -3,7 +3,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'block'])
     ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)

--- a/core-bundle/contao/templates/modules/mod_article.html5
+++ b/core-bundle/contao/templates/modules/mod_article.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'block'])
     ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)

--- a/core-bundle/contao/templates/modules/mod_articlenav.html5
+++ b/core-bundle/contao/templates/modules/mod_articlenav.html5
@@ -3,7 +3,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr()
+    ->attrs()
     ->addClass('pagination')
     ->mergeWith($this->wrapperAttributes)
 ;

--- a/core-bundle/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/contao/templates/modules/mod_breadcrumb.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'block'])
     ->addStyle($this->style ?? '')
     ->set('aria-label', $this->trans('MSC.breadcrumbMenu'))

--- a/core-bundle/contao/templates/modules/mod_login.html5
+++ b/core-bundle/contao/templates/modules/mod_login.html5
@@ -3,7 +3,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr()
+    ->attrs()
     ->addClass($this->logout ? 'logout' : 'login')
     ->mergeWith($this->wrapperAttributes)
 ;

--- a/core-bundle/contao/templates/modules/mod_navigation.html5
+++ b/core-bundle/contao/templates/modules/mod_navigation.html5
@@ -1,7 +1,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr($this->cssID)
+    ->attrs($this->cssID)
     ->addClass([$this->class, 'block'])
     ->addStyle($this->style ?? '')
     ->setIfExists('aria-label', $this->ariaLabel)

--- a/core-bundle/contao/templates/modules/mod_two_factor.html5
+++ b/core-bundle/contao/templates/modules/mod_two_factor.html5
@@ -3,7 +3,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr()
+    ->attrs()
     ->addClass('two-factor')
     ->mergeWith($this->wrapperAttributes)
 ;

--- a/listing-bundle/contao/templates/info/info_default.html5
+++ b/listing-bundle/contao/templates/info/info_default.html5
@@ -3,7 +3,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr()
+    ->attrs()
     ->addClass('listing')
     ->mergeWith($this->wrapperAttributes)
 ;

--- a/listing-bundle/contao/templates/listing/list_default.html5
+++ b/listing-bundle/contao/templates/listing/list_default.html5
@@ -3,7 +3,7 @@
 <?php
 
 $this->wrapperAttributes = $this
-    ->attr()
+    ->attrs()
     ->addClass(['ce_table', 'listing'])
     ->mergeWith($this->wrapperAttributes)
 ;


### PR DESCRIPTION
> User Deprecated: Since contao/core-bundle 5.3: Using "$this->attr()" in templates is deprecated and will no longer work in Contao 6. Use "$this->attrs()" instead.