### PR TITLE
Fix using the deprecated `DependencyInjection` extension

### DIFF
--- a/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
+++ b/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
@@ -14,8 +14,8 @@ namespace Contao\ManagerBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class ContaoManagerExtension extends Extension
 {


### PR DESCRIPTION
> The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Contao\ManagerBundle\DependencyInjection\ContaoManagerExtension".

Looks like this has been fixed in all bundles except the `contao/manager-bundle`