### PR TITLE
Use the image UUID in search results

### DIFF
--- a/core-bundle/contao/modules/ModuleSearch.php
+++ b/core-bundle/contao/modules/ModuleSearch.php
@@ -292,17 +292,17 @@ class ModuleSearch extends Module
 				continue;
 			}
 
-			$figure = $this->buildFigureFromId($v['https://schema.org/primaryImageOfPage']['@id'] ?? null, $result['url']);
+			$figureMeta = new Metadata(array_filter(array(
+				Metadata::VALUE_CAPTION => $v['https://schema.org/primaryImageOfPage']['caption'] ?? null,
+				Metadata::VALUE_TITLE => $v['https://schema.org/primaryImageOfPage']['name'] ?? null,
+				Metadata::VALUE_ALT => $v['https://schema.org/primaryImageOfPage']['alternateName'] ?? null,
+			)));
+
+			$figure = $this->buildFigureFromId($v['https://schema.org/primaryImageOfPage']['@id'] ?? null, $result['url'], $figureMeta);
 
 			if (!$figure)
 			{
 				$baseUrls = array_filter(array(Environment::get('base'), System::getContainer()->get('contao.assets.files_context')->getStaticUrl()));
-
-				$figureMeta = new Metadata(array_filter(array(
-					Metadata::VALUE_CAPTION => $v['https://schema.org/primaryImageOfPage']['caption'] ?? null,
-					Metadata::VALUE_TITLE => $v['https://schema.org/primaryImageOfPage']['name'] ?? null,
-					Metadata::VALUE_ALT => $v['https://schema.org/primaryImageOfPage']['alternateName'] ?? null,
-				)));
 
 				$figure = System::getContainer()->get('contao.image.studio')->createFigureBuilder()
 					->fromUrl($v['https://schema.org/primaryImageOfPage']['contentUrl'], $baseUrls)
@@ -325,7 +325,7 @@ class ModuleSearch extends Module
 		}
 	}
 
-	private function buildFigureFromId(string|null $id, string $url): Figure|null
+	private function buildFigureFromId(string|null $id, string $url, Metadata|null $metadata): Figure|null
 	{
 		if (!$id || !str_starts_with($id, '#/schema/image/'))
 		{
@@ -342,6 +342,7 @@ class ModuleSearch extends Module
 		return System::getContainer()->get('contao.image.studio')->createFigureBuilder()
 			->fromUuid($uuid)
 			->setSize($this->imgSize)
+			->setMetadata($metadata)
 			->setLinkHref($url)
 			->buildIfResourceExists();
 	}

--- a/core-bundle/contao/modules/ModuleSearch.php
+++ b/core-bundle/contao/modules/ModuleSearch.php
@@ -325,7 +325,7 @@ class ModuleSearch extends Module
 		}
 	}
 
-	private function buildFigureFromId(string|null $id, string $url, Metadata|null $metadata): Figure|null
+	private function buildFigureFromId(string|null $id, string $url, Metadata $metadata): Figure|null
 	{
 		if (!$id || !str_starts_with($id, '#/schema/image/'))
 		{

--- a/core-bundle/contao/modules/ModuleSearch.php
+++ b/core-bundle/contao/modules/ModuleSearch.php
@@ -287,7 +287,7 @@ class ModuleSearch extends Module
 
 		foreach ($meta as $v)
 		{
-			if (!isset($v['https://schema.org/primaryImageOfPage']['contentUrl']) && !isset($v['https://schema.org/primaryImageOfPage']['@id']))
+			if (!isset($v['https://schema.org/primaryImageOfPage']['contentUrl'], $v['https://schema.org/primaryImageOfPage']['@id']))
 			{
 				continue;
 			}

--- a/core-bundle/contao/modules/ModuleSearch.php
+++ b/core-bundle/contao/modules/ModuleSearch.php
@@ -304,7 +304,9 @@ class ModuleSearch extends Module
 			{
 				$baseUrls = array_filter(array(Environment::get('base'), System::getContainer()->get('contao.assets.files_context')->getStaticUrl()));
 
-				$figure = System::getContainer()->get('contao.image.studio')->createFigureBuilder()
+				$figure = System::getContainer()
+					->get('contao.image.studio')
+					->createFigureBuilder()
 					->fromUrl($v['https://schema.org/primaryImageOfPage']['contentUrl'], $baseUrls)
 					->setSize($this->imgSize)
 					->setMetadata($figureMeta)
@@ -339,7 +341,9 @@ class ModuleSearch extends Module
 			return null;
 		}
 
-		return System::getContainer()->get('contao.image.studio')->createFigureBuilder()
+		return System::getContainer()
+			->get('contao.image.studio')
+			->createFigureBuilder()
 			->fromUuid($uuid)
 			->setSize($this->imgSize)
 			->setMetadata($metadata)


### PR DESCRIPTION
Fixes #8491 as outlined in [here](https://github.com/contao/contao/issues/8491#issuecomment-3642652159).

I wasn't actually able to reproduce [this](https://github.com/contao/contao/issues/8487#issuecomment-3305784825), i.e.

> fix the `/public` prefix in the `contentUrl` in certain cases

But it should not happen anymore with this PR anyway, as long as the original resource still exists in the DBAFS.