### PR TITLE
Add a `Vary` header for back end responses

### DIFF
--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -158,8 +158,6 @@ class BackendMain extends Backend
 			$response->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
 		}
 
-		$response->headers->set('Vary', 'Accept');
-
 		return $response;
 	}
 

--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -158,6 +158,8 @@ class BackendMain extends Backend
 			$response->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
 		}
 
+		$response->headers->set('Vary', 'Accept');
+
 		return $response;
 	}
 

--- a/core-bundle/src/EventListener/BackendCacheResponseListener.php
+++ b/core-bundle/src/EventListener/BackendCacheResponseListener.php
@@ -35,9 +35,8 @@ class BackendCacheResponseListener
         $request = $event->getRequest();
         $response = $event->getResponse();
 
-        // Requests with "Accept: text/vnd.turbo-stream.html, text/html" might return a
-        // different response body than "Accept: text/html" (#9128)
-        $response->headers->set('Vary', 'Accept');
+        // Vary on Accept and Turbo-Frame (#9128)
+        $response->headers->set('Vary', 'Accept, Turbo-Frame');
 
         if ($request->headers->has('x-turbo-request-id') && $request->isMethodCacheable() && Response::HTTP_OK === $response->getStatusCode()) {
             $response->headers->set('Cache-Control', 'private, max-age='.$this->turboMaxAge.', must-revalidate');

--- a/core-bundle/src/EventListener/BackendCacheResponseListener.php
+++ b/core-bundle/src/EventListener/BackendCacheResponseListener.php
@@ -36,7 +36,11 @@ class BackendCacheResponseListener
         $response = $event->getResponse();
 
         if ($request->headers->has('x-turbo-request-id') && $request->isMethodCacheable() && Response::HTTP_OK === $response->getStatusCode()) {
-            $event->getResponse()->headers->set('Cache-Control', 'private, max-age='.$this->turboMaxAge.', must-revalidate');
+            $response->headers->set('Cache-Control', 'private, max-age='.$this->turboMaxAge.', must-revalidate');
+
+            // Requests with "Accept: text/vnd.turbo-stream.html, text/html" might return a
+            // different response body than "Accept: text/html" (#9128)
+            $response->headers->set('Vary', 'Accept');
 
             return;
         }

--- a/core-bundle/src/EventListener/BackendCacheResponseListener.php
+++ b/core-bundle/src/EventListener/BackendCacheResponseListener.php
@@ -35,12 +35,12 @@ class BackendCacheResponseListener
         $request = $event->getRequest();
         $response = $event->getResponse();
 
+        // Requests with "Accept: text/vnd.turbo-stream.html, text/html" might return a
+        // different response body than "Accept: text/html" (#9128)
+        $response->headers->set('Vary', 'Accept');
+
         if ($request->headers->has('x-turbo-request-id') && $request->isMethodCacheable() && Response::HTTP_OK === $response->getStatusCode()) {
             $response->headers->set('Cache-Control', 'private, max-age='.$this->turboMaxAge.', must-revalidate');
-
-            // Requests with "Accept: text/vnd.turbo-stream.html, text/html" might return a
-            // different response body than "Accept: text/html" (#9128)
-            $response->headers->set('Vary', 'Accept');
 
             return;
         }

--- a/core-bundle/tests/EventListener/BackendCacheResponseListenerTest.php
+++ b/core-bundle/tests/EventListener/BackendCacheResponseListenerTest.php
@@ -135,6 +135,25 @@ class BackendCacheResponseListenerTest extends TestCase
         $this->assertTrue($response->headers->hasCacheControlDirective('no-store'));
     }
 
+    public function testSetsVaryHeader(): void
+    {
+        $response = new Response();
+
+        $request = new Request();
+        $request->setMethod(Request::METHOD_POST);
+
+        $event = new ResponseEvent(
+            $this->createStub(KernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            $response,
+        );
+
+        (new BackendCacheResponseListener($this->createScopeMatcher(true)))($event);
+
+        $this->assertSame('Accept', $response->headers->get('Vary'));
+    }
+
     private function createScopeMatcher(bool $isBackendMainRequest): ScopeMatcher
     {
         $scopeMatcher = $this->createMock(ScopeMatcher::class);

--- a/core-bundle/tests/EventListener/BackendCacheResponseListenerTest.php
+++ b/core-bundle/tests/EventListener/BackendCacheResponseListenerTest.php
@@ -151,7 +151,7 @@ class BackendCacheResponseListenerTest extends TestCase
 
         (new BackendCacheResponseListener($this->createScopeMatcher(true)))($event);
 
-        $this->assertSame('Accept', $response->headers->get('Vary'));
+        $this->assertSame('Accept, Turbo-Frame', $response->headers->get('Vary'));
     }
 
     private function createScopeMatcher(bool $isBackendMainRequest): ScopeMatcher


### PR DESCRIPTION
Fixes #9128

Since https://github.com/contao/contao/pull/8971 the same request URI might return a different response body depending on whether the request is done for a specific Turbo Frame or not. Thus we need to set `Vary` accordingly as well.

We either have to `Vary: turbo-frame` or `Vary: Accept`. Technically the former would suffice, but I was thinking it makes sense to `Vary` on `Accept` in general (because if you had `Accept: application/json` for example, you'd surely want that to be cached separately as well) - this PR currently implements the latter. Or should we even `Vary: Accept, turbo-frame` @Toflar & @m-vo wdyt?