### PR TITLE
Remove surrogate template for previously removed original template

### DIFF
--- a/core-bundle/contao/templates/twig/be_widget_chpw.html.twig
+++ b/core-bundle/contao/templates/twig/be_widget_chpw.html.twig
@@ -1,5 +1,0 @@
-<div class="widget widget-password wizard">
-    <label for="password">{{ password }}</label>
-    <input type="password" name="password" id="ctrl_password" class="tl_text" value="" autocomplete="new-password" placeholder="{{ password }}" required>
-    {{ wizard|raw }}
-</div>


### PR DESCRIPTION
The `be_widget_chpw` template was removed in https://github.com/contao/contao/commit/231a8e7d007e49c81cb3b81e83681b7702725699#diff-adba1fcb1fdf7969618108021987e8356fe9b154d6a10e8ebf78781d9d7adc5c during the phase of adding the surrogate templates. 

We missed removing it as well.