### PR TITLE
Merge an existing `Vary` header

### DIFF
--- a/core-bundle/src/EventListener/BackendCacheResponseListener.php
+++ b/core-bundle/src/EventListener/BackendCacheResponseListener.php
@@ -36,7 +36,7 @@ class BackendCacheResponseListener
         $response = $event->getResponse();
 
         // Vary on Accept and Turbo-Frame (#9128)
-        $response->headers->set('Vary', 'Accept, Turbo-Frame');
+        $response->setVary(array_unique([...$response->getVary(), 'Accept', 'Turbo-Frame']));
 
         if ($request->headers->has('x-turbo-request-id') && $request->isMethodCacheable() && Response::HTTP_OK === $response->getStatusCode()) {
             $response->headers->set('Cache-Control', 'private, max-age='.$this->turboMaxAge.', must-revalidate');

--- a/core-bundle/src/EventListener/BackendCacheResponseListener.php
+++ b/core-bundle/src/EventListener/BackendCacheResponseListener.php
@@ -36,7 +36,7 @@ class BackendCacheResponseListener
         $response = $event->getResponse();
 
         // Vary on Accept and Turbo-Frame (#9128)
-        $response->setVary(array_unique([...$response->getVary(), 'Accept', 'Turbo-Frame']));
+        $response->setVary(['Accept', 'Turbo-Frame'], false);
 
         if ($request->headers->has('x-turbo-request-id') && $request->isMethodCacheable() && Response::HTTP_OK === $response->getStatusCode()) {
             $response->headers->set('Cache-Control', 'private, max-age='.$this->turboMaxAge.', must-revalidate');

--- a/core-bundle/tests/EventListener/BackendCacheResponseListenerTest.php
+++ b/core-bundle/tests/EventListener/BackendCacheResponseListenerTest.php
@@ -151,7 +151,7 @@ class BackendCacheResponseListenerTest extends TestCase
 
         (new BackendCacheResponseListener($this->createScopeMatcher(true)))($event);
 
-        $this->assertSame('Accept, Turbo-Frame', $response->headers->get('Vary'));
+        $this->assertSame(['Accept', 'Turbo-Frame'], $response->getVary());
     }
 
     private function createScopeMatcher(bool $isBackendMainRequest): ScopeMatcher

--- a/core-bundle/tests/EventListener/BackendCacheResponseListenerTest.php
+++ b/core-bundle/tests/EventListener/BackendCacheResponseListenerTest.php
@@ -138,6 +138,7 @@ class BackendCacheResponseListenerTest extends TestCase
     public function testSetsVaryHeader(): void
     {
         $response = new Response();
+        $response->setVary('Origin');
 
         $request = new Request();
         $request->setMethod(Request::METHOD_POST);
@@ -151,7 +152,7 @@ class BackendCacheResponseListenerTest extends TestCase
 
         (new BackendCacheResponseListener($this->createScopeMatcher(true)))($event);
 
-        $this->assertSame(['Accept', 'Turbo-Frame'], $response->getVary());
+        $this->assertSame(['Origin', 'Accept', 'Turbo-Frame'], $response->getVary());
     }
 
     private function createScopeMatcher(bool $isBackendMainRequest): ScopeMatcher


### PR DESCRIPTION
Follow up to #9131

If a custom back end controller set its own `Vary` header, our listener would currently overwrite that. This PR changes that by merging the header instead. It also makes use of the dedicated `setVary()` method.