### PR TITLE
Show the list of changed files in the Twig CS Fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -346,7 +346,7 @@
         "phpstan": "@php vendor-bin/phpstan/vendor/bin/phpstan analyze",
         "rector": "@php vendor-bin/rector/vendor/bin/rector",
         "service-linter": "@php vendor-bin/service-linter/bin/lint-service-ids",
-        "twig-cs-fixer": "@php vendor-bin/twig-cs-fixer/vendor/bin/twig-cs-fixer fix",
+        "twig-cs-fixer": "@php vendor-bin/twig-cs-fixer/vendor/bin/twig-cs-fixer fix -v",
         "unit-tests": "@php vendor/bin/phpunit"
     }
 }


### PR DESCRIPTION
I got annoyed, that the Twig CS Fixer did not output any changed files when running with `fix`, so I made the relevant changes over at https://github.com/VincentLanglet/Twig-CS-Fixer/pull/422. But turns out, this is already possible when increasing the verbosity level. :smile:  So this is what this PR is doing now.
