### PR TITLE
Improve the slot tag DX

### DIFF
--- a/core-bundle/src/Twig/Slots/SlotTokenParser.php
+++ b/core-bundle/src/Twig/Slots/SlotTokenParser.php
@@ -42,7 +42,7 @@ final class SlotTokenParser extends AbstractTokenParser
         $body = $this->parser->subparse($this->decideForFork(...));
 
         $throwMissingSlotFunctionError = static function () use ($nameToken, $token, $stream): void {
-            throw new SyntaxError(\sprintf('Slot "%s" defines template content but is missing a call to the "slot()" function.', $nameToken->getValue()), $token->getLine(), $stream->getSourceContext());
+            throw new SyntaxError(\sprintf('Slot "%s" adds template content but does not call the "slot()" function.', $nameToken->getValue()), $token->getLine(), $stream->getSourceContext());
         };
 
         if ($body->count()) {

--- a/core-bundle/src/Twig/Slots/SlotTokenParser.php
+++ b/core-bundle/src/Twig/Slots/SlotTokenParser.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\Slots;
 
+use Twig\Error\SyntaxError;
 use Twig\Node\EmptyNode;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\ConstantExpression;
@@ -40,8 +41,16 @@ final class SlotTokenParser extends AbstractTokenParser
 
         $body = $this->parser->subparse($this->decideForFork(...));
 
+        $throwMissingSlotFunctionError = static function () use ($nameToken, $token, $stream): void {
+            throw new SyntaxError(\sprintf('Slot "%s" defines template content but is missing a call to the "slot()" function.', $nameToken->getValue()), $token->getLine(), $stream->getSourceContext());
+        };
+
         if ($body->count()) {
-            $this->traverseAndReplaceSlotFunction($nameToken->getValue(), $body);
+            if (0 === $this->traverseAndReplaceSlotFunction($nameToken->getValue(), $body)) {
+                $throwMissingSlotFunctionError();
+            }
+        } elseif ($body->hasAttribute('data') && $body->getAttribute('data')) {
+            $throwMissingSlotFunctionError();
         } else {
             $line = $stream->getCurrent()->getLine();
             $body->setNode('body', new PrintNode($this->getSlotReferenceExpression($nameToken->getValue(), $line), $line));
@@ -81,7 +90,10 @@ final class SlotTokenParser extends AbstractTokenParser
         return 'slot';
     }
 
-    private function traverseAndReplaceSlotFunction(string $name, Node $node, Node|null $parent = null): void
+    /**
+     * Returns the number of slot function expressions that were replaced.
+     */
+    private function traverseAndReplaceSlotFunction(string $name, Node $node, Node|null $parent = null): int
     {
         if ($node instanceof FunctionExpression && 'slot' === $node->getAttribute('name')) {
             /** @var Node $target */
@@ -93,12 +105,16 @@ final class SlotTokenParser extends AbstractTokenParser
 
             $target->setNode('expr', $this->getSlotReferenceExpression($name, $target->getTemplateLine()));
 
-            return;
+            return 1;
         }
 
+        $count = 0;
+
         foreach ($node as $child) {
-            $this->traverseAndReplaceSlotFunction($name, $child, $node);
+            $count += $this->traverseAndReplaceSlotFunction($name, $child, $node);
         }
+
+        return $count;
     }
 
     /**

--- a/core-bundle/tests/Twig/Inspector/InspectorTest.php
+++ b/core-bundle/tests/Twig/Inspector/InspectorTest.php
@@ -94,7 +94,7 @@ class InspectorTest extends TestCase
                     {% slot A %}{% endslot %}
 
                     {# Slot with content #}
-                    {% slot B %}…{% endslot %}
+                    {% slot B %}…{{ slot() }}…{% endslot %}
                     SOURCE,
             ],
             [

--- a/core-bundle/tests/Twig/Slots/SlotTokenParserTest.php
+++ b/core-bundle/tests/Twig/Slots/SlotTokenParserTest.php
@@ -106,7 +106,7 @@ class SlotTokenParserTest extends TestCase
         $environment = $this->getConfiguredEnvironment($code);
 
         $this->expectException(SyntaxError::class);
-        $this->expectExceptionMessageMatches('/Slot "foo" defines template content but is missing a call to the "slot\(\)" function/');
+        $this->expectExceptionMessageMatches('/Slot "foo" adds template content but does not call the "slot\(\)" function/');
 
         $environment->render('template.html.twig', []);
     }

--- a/core-bundle/tests/Twig/Slots/SlotTokenParserTest.php
+++ b/core-bundle/tests/Twig/Slots/SlotTokenParserTest.php
@@ -22,6 +22,7 @@ use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\Slots\SlotTokenParser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Twig\Environment;
+use Twig\Error\SyntaxError;
 use Twig\Loader\ArrayLoader;
 use Twig\Loader\LoaderInterface;
 
@@ -37,20 +38,7 @@ class SlotTokenParserTest extends TestCase
     #[DataProvider('provideSources')]
     public function testOutputsSlots(array $context, string $code, string $expectedOutput): void
     {
-        $environment = new Environment($this->createStub(LoaderInterface::class));
-
-        $environment->addExtension(
-            new ContaoExtension(
-                $environment,
-                $this->createStub(ContaoFilesystemLoader::class),
-                $this->createStub(ContaoCsrfTokenManager::class),
-                $this->createStub(ContaoVariable::class),
-                new InspectorNodeVisitor($this->createStub(Storage::class), $environment),
-            ),
-        );
-
-        $environment->addTokenParser(new SlotTokenParser());
-        $environment->setLoader(new ArrayLoader(['template.html.twig' => $code]));
+        $environment = $this->getConfiguredEnvironment($code);
 
         $this->assertSame($expectedOutput, $environment->render('template.html.twig', $context));
     }
@@ -101,8 +89,8 @@ class SlotTokenParserTest extends TestCase
 
         yield 'slot inside slot with recursion' => [
             ['_slots' => ['a' => 'A', 'b' => 'B']],
-            '{% slot a %}<a>{{ slot() }}{% slot b %}<b>{% slot a %}{% endslot %}</b>{% endslot %}</a>{% endslot %}',
-            '<a>A<b>A</b></a>',
+            '{% slot a %}<a>{{ slot() }}{% slot b %}<b>{% slot a %}{% endslot %}{{ slot() }}</b>{% endslot %}</a>{% endslot %}',
+            '<a>A<b>AB</b></a>',
         ];
 
         yield 'assigning virtual slot function' => [
@@ -110,5 +98,47 @@ class SlotTokenParserTest extends TestCase
             '{% slot foo %}{% set var = slot() %}<main>{{ var ~ " baz" }}</main>{% endslot %}',
             '<main>bar baz</main>',
         ];
+    }
+
+    #[DataProvider('provideInvalidSources')]
+    public function testThrowsSyntaxErrorIfSlotWithContentDoesNotUseSlotFunction(string $code): void
+    {
+        $environment = $this->getConfiguredEnvironment($code);
+
+        $this->expectException(SyntaxError::class);
+        $this->expectExceptionMessageMatches('/Slot "foo" defines template content but is missing a call to the "slot\(\)" function/');
+
+        $environment->render('template.html.twig', []);
+    }
+
+    public static function provideInvalidSources(): iterable
+    {
+        yield 'content without slot function' => [
+            '{% slot foo %}some content{% endslot %}',
+        ];
+
+        yield 'content with nodes without slot function' => [
+            '{% slot foo %}some content with some {{ nodes|default }}{% endslot %}',
+        ];
+    }
+
+    protected function getConfiguredEnvironment(string $templateCode): Environment
+    {
+        $environment = new Environment($this->createStub(LoaderInterface::class));
+
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $this->createStub(ContaoFilesystemLoader::class),
+                $this->createStub(ContaoCsrfTokenManager::class),
+                $this->createStub(ContaoVariable::class),
+                new InspectorNodeVisitor($this->createStub(Storage::class), $environment),
+            ),
+        );
+
+        $environment->addTokenParser(new SlotTokenParser());
+        $environment->setLoader(new ArrayLoader(['template.html.twig' => $templateCode]));
+
+        return $environment;
     }
 }


### PR DESCRIPTION
Implements #8987

This PR improves the slot tag DX by outputting a syntax error if template content for a slot was defined but the `slot()` function was not used, which, according to our discussion in #8987, is always a mistake.

Because we're now outputting a compile-time Twig error, the Template Studio will also automatically display it :sunglasses:.

<img width="534" height="184" alt="image" src="https://github.com/user-attachments/assets/939bc625-7ee2-494d-9ef7-638908584ed0" />