### PR TITLE
Autosubmit the filters in the back end

### DIFF
--- a/core-bundle/contao/templates/twig/backend/data_container/table/menu/_select.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/menu/_select.html.twig
@@ -11,6 +11,7 @@
         .set('id', name)
         .addClass('tl_select')
         .addClass('active', active|default)
+        .set('onchange', 'this.form.requestSubmit()', auto_submit|default(false))
         .mergeWith(select_attributes|default)
     %}
     <select{{ select_attributes }}>

--- a/core-bundle/contao/templates/twig/backend/data_container/table/menu/filter.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/menu/filter.html.twig
@@ -10,7 +10,7 @@
             active: filter.active,
             title: filter.placeholder,
             select_wrapper_attributes: attrs().set('data-contao--filter-target', 'filter'),
-            select_attributes: attrs().set('data-action', 'contao--filter#updateCount'),
+            select_attributes: attrs().set('data-action', 'contao--filter#updateCount').set('onchange', 'this.form.requestSubmit()'),
         }) }}
     {% endfor %}
 </fieldset>

--- a/core-bundle/contao/templates/twig/backend/data_container/table/menu/filter.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/menu/filter.html.twig
@@ -10,7 +10,8 @@
             active: filter.active,
             title: filter.placeholder,
             select_wrapper_attributes: attrs().set('data-contao--filter-target', 'filter'),
-            select_attributes: attrs().set('data-action', 'contao--filter#updateCount').set('onchange', 'this.form.requestSubmit()'),
+            select_attributes: attrs().set('data-action', 'contao--filter#updateCount'),
+            auto_submit: true,
         }) }}
     {% endfor %}
 </fieldset>

--- a/core-bundle/contao/templates/twig/backend/data_container/table/menu/limit.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/menu/limit.html.twig
@@ -4,6 +4,6 @@
     {{ include('@Contao/backend/data_container/table/menu/_select.html.twig', {
         name: 'tl_limit',
         title: 'MSC.showOnly'|trans,
-        select_attributes: attrs().set('onchange', 'this.form.requestSubmit()'),
+        auto_submit: true,
     }) }}
 </div>

--- a/core-bundle/contao/templates/twig/backend/data_container/table/menu/sort.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/menu/sort.html.twig
@@ -4,6 +4,7 @@
     {% embed '@Contao/backend/data_container/table/menu/_select.html.twig' with {
         name: 'tl_sort',
         title: 'MSC.sortBy'|trans,
+        auto_submit: true,
     } %}
         {% trans_default_domain 'contao_default' %}
 


### PR DESCRIPTION
Now that we have a Turbo `contao-main` frame request and we don't render the navigation and header menu on every request anymore, should we autosubmit the filters?

Submitting this as a PR so you can quickly test this with `gh pr checkout 9154` to see if you like it or not 😊 