### PR TITLE
Always render favorites from the templates

### DIFF
--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -11,11 +11,9 @@
 namespace Contao;
 
 use Contao\CoreBundle\ContaoCoreBundle;
-use Contao\CoreBundle\Controller\Backend\FavoriteController;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Knp\Bundle\TimeBundle\DateTimeFormatter;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 /**
  * Main back end controller.

--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -104,9 +104,6 @@ class BackendMain extends Backend
 
 		$this->Template->main = '';
 
-		$request = System::getContainer()->get('request_stack')->getMainRequest();
-		$this->Template->toggleFavorites = System::getContainer()->get('fragment.handler')->render(new ControllerReference(FavoriteController::class, array('target_path' => $request->getRequestUri())));
-
 		// Ajax request
 		if (Input::post('action') && Environment::get('isAjaxRequest'))
 		{
@@ -257,9 +254,6 @@ class BackendMain extends Backend
 
 		$data['menu'] = !$renderMainOnly ? $twig->render('@Contao/backend/chrome/main_menu.html.twig') : '';
 		$data['headerMenu'] = !$renderMainOnly ? $twig->render('@Contao/backend/chrome/header_menu.html.twig', array('searchEnabled' => $searchEnabled)) : '';
-
-		$request = $container->get('request_stack')->getMainRequest();
-		$data['toggleFavorites'] = $container->get('fragment.handler')->render(new ControllerReference(FavoriteController::class, array('target_path' => $request->getRequestUri())));
 
 		return $data;
 	}

--- a/core-bundle/contao/templates/backend/be_main.html5
+++ b/core-bundle/contao/templates/backend/be_main.html5
@@ -123,7 +123,7 @@ $this->mainAttributes = $this
             <?php $this->block('main_headline'); ?>
               <h1 id="main_headline">
                 <?= $this->headline ?>
-                <?= $this->toggleFavorites ?>
+                <?php $this->insert('@Contao/backend/component/_favorites.html.twig') ?>
               </h1>
             <?php $this->endblock(); ?>
             <div class="content" data-contao--toggle-state-target="controls">

--- a/core-bundle/contao/templates/twig/backend/component/_favorites.html.twig
+++ b/core-bundle/contao/templates/twig/backend/component/_favorites.html.twig
@@ -1,0 +1,1 @@
+{{ render(path('contao_backend_favorites', {target_path: app.request.requestUri})) }}

--- a/core-bundle/contao/templates/twig/backend/template_studio/index.html.twig
+++ b/core-bundle/contao/templates/twig/backend/template_studio/index.html.twig
@@ -19,7 +19,7 @@
         {# Headline #}
         <h1 id="main_headline">
             {{ headline }}
-            {{ render(path('contao_backend_favorites', {target_path: app.request.requestUri})) }}
+            {{ include('@Contao/backend/component/_favorites.html.twig') }}
         </h1>
 
         <section id="template-studio" class="content chrome">

--- a/core-bundle/contao/templates/twig/be_main.html.twig
+++ b/core-bundle/contao/templates/twig/be_main.html.twig
@@ -117,7 +117,7 @@
                     {% block main_headline %}
                         <h1 id="main_headline">
                             {{ headline|raw }}
-                            {{ toggleFavorites|default|raw }}
+                            {{ include('@Contao/backend/component/_favorites.html.twig') }}
                         </h1>
                     {% endblock %}
                     <div class="content" data-contao--toggle-state-target="controls">

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -36,7 +36,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
-use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -112,7 +111,6 @@ class AbstractBackendControllerTest extends TestCase
             'getLocaleString' => $this->anything(),
             'getDateString' => $this->anything(),
             'as_editor_view' => true,
-            'toggleFavorites' => '#fragment',
         ];
 
         $container = $this->getContainerWithDefaultConfiguration($expectedContext);
@@ -189,7 +187,6 @@ class AbstractBackendControllerTest extends TestCase
             'getLocaleString' => self::anything(),
             'getDateString' => self::anything(),
             'as_editor_view' => true,
-            'toggleFavorites' => '#fragment',
         ];
 
         $customContext = [
@@ -377,12 +374,6 @@ class AbstractBackendControllerTest extends TestCase
         $scopeMatcher
             ->method('isBackendRequest')
             ->willReturn(true)
-        ;
-
-        $fragmentHandler = $this->createStub(FragmentHandler::class);
-        $fragmentHandler
-            ->method('render')
-            ->willReturn('#fragment')
         ;
 
         $container->set('security.authorization_checker', $authorizationChecker);

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -386,7 +386,6 @@ class AbstractBackendControllerTest extends TestCase
         $container->set('router', $this->createStub(RouterInterface::class));
         $container->set('request_stack', $requestStack);
         $container->set('contao.routing.scope_matcher', $scopeMatcher);
-        $container->set('fragment.handler', $fragmentHandler);
 
         $container->setParameter('contao.resources_paths', $this->getTempDir());
 


### PR DESCRIPTION
Fixes #9133

You can insert a Twig template in a PHP Template - we already did that for the message and dialog outlets for instance. I therefore created a single `backend/component/_favorites.html.twig` template that is used anywhere and that abstracts the call to the controller away. 

If you are now using a custom back end controller, favorites will not be generated unless they are output.