### PR TITLE
Reuse PHPStan type and refactor for readability

### DIFF
--- a/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
@@ -19,7 +19,7 @@ use Contao\Input;
 use Contao\System;
 
 /**
- * @phpstan-type HtmlOperation array{html: string, primary?: bool}
+ * @phpstan-type LegacyOperation array{html: string, primary?: bool}
  * @phpstan-type ParametricOperation array{
  *     label: string,
  *     title?: string,
@@ -32,7 +32,7 @@ use Contao\System;
  *     primary?: bool|null,
  * }
  * @phpstan-type Separator array{separator: true}
- * @phpstan-type Operation HtmlOperation|ParametricOperation|Separator
+ * @phpstan-type Operation LegacyOperation|ParametricOperation|Separator
  *
  * @internal
  */

--- a/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
@@ -20,7 +20,17 @@ use Contao\System;
 
 /**
  * @phpstan-type HtmlOperation array{html: string, primary?: bool}
- * @phpstan-type ParametricOperation array{label: string, title?: string, attributes?: HtmlAttributes, listAttributes?: HtmlAttributes, icon?: string, iconAttributes?: HtmlAttributes, href?: string, method?: string, primary?: bool|null}
+ * @phpstan-type ParametricOperation array{
+ *     label: string,
+ *     title?: string,
+ *     attributes?: HtmlAttributes,
+ *     listAttributes?: HtmlAttributes,
+ *     icon?: string,
+ *     iconAttributes?: HtmlAttributes,
+ *     href?: string,
+ *     method?: string,
+ *     primary?: bool|null,
+ * }
  * @phpstan-type Separator array{separator: true}
  * @phpstan-type Operation HtmlOperation|ParametricOperation|Separator
  *

--- a/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/AbstractDataContainerOperationsBuilder.php
@@ -19,6 +19,11 @@ use Contao\Input;
 use Contao\System;
 
 /**
+ * @phpstan-type HtmlOperation array{html: string, primary?: bool}
+ * @phpstan-type ParametricOperation array{label: string, title?: string, attributes?: HtmlAttributes, listAttributes?: HtmlAttributes, icon?: string, iconAttributes?: HtmlAttributes, href?: string, method?: string, primary?: bool|null}
+ * @phpstan-type Separator array{separator: true}
+ * @phpstan-type Operation HtmlOperation|ParametricOperation|Separator
+ *
  * @internal
  */
 abstract class AbstractDataContainerOperationsBuilder implements \Stringable
@@ -34,17 +39,7 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
     public const CREATE_TOP = 'top';
 
     /**
-     * @var list<array{html: string, primary?: bool}|array{separator: true}|array{
-     *     label: string,
-     *     title?: string,
-     *     attributes?: HtmlAttributes,
-     *     listAttributes?: HtmlAttributes,
-     *     icon?: string,
-     *     iconAttributes?: HtmlAttributes,
-     *     href?: string,
-     *     method?: string,
-     *     primary?: bool|null,
-     * }>
+     * @var list<Operation>
      */
     protected array|null $operations = null;
 
@@ -53,17 +48,7 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
     }
 
     /**
-     * @param array{html: string, primary?: bool}|array{separator: true}|array{
-     *     label: string,
-     *     title?: string,
-     *     attributes?: HtmlAttributes,
-     *     listAttributes?: HtmlAttributes,
-     *     icon?: string,
-     *     iconAttributes?: HtmlAttributes,
-     *     href?: string,
-     *     method?: string,
-     *     primary?: bool|null
-     * } $operation
+     * @param Operation $operation
      */
     public function prepend(array $operation, bool $parseHtml = false): self
     {
@@ -79,17 +64,7 @@ abstract class AbstractDataContainerOperationsBuilder implements \Stringable
     }
 
     /**
-     * @param array{html: string, primary?: bool}|array{separator: true}|array{
-     *     label: string,
-     *     title?: string,
-     *     attributes?: HtmlAttributes,
-     *     listAttributes?: HtmlAttributes,
-     *     icon?: string,
-     *     iconAttributes?: HtmlAttributes,
-     *     href?: string,
-     *     method?: string,
-     *     primary?: bool|null
-     * } $operation
+     * @param Operation $operation
      */
     public function append(array $operation, bool $parseHtml = false): self
     {


### PR DESCRIPTION
This improves the type hinting in the `AbstractDataContainerOperationsBuilder` and also makes sure PHPStorm can correctly infer the array shapes.