### PR TITLE
Introduce a `$config['backendSearch']` DCA setting

### DIFF
--- a/core-bundle/src/Search/Backend/Provider/TableDataContainerProvider.php
+++ b/core-bundle/src/Search/Backend/Provider/TableDataContainerProvider.php
@@ -202,7 +202,13 @@ class TableDataContainerProvider implements ProviderInterface
 
         $searchableFields = array_filter(
             $fieldsConfig,
-            static fn (array $config): bool => isset($config['search']) && true === $config['search'],
+            static function (array $config): bool {
+                if (\array_key_exists('backendSearch', $config)) {
+                    return $config['backendSearch'];
+                }
+
+                return \array_key_exists('search', $config) && true === $config['search'];
+            },
         );
 
         // Only select the rows we need so we don't transfer the entire database when indexing

--- a/core-bundle/src/Search/Backend/Provider/TableDataContainerProvider.php
+++ b/core-bundle/src/Search/Backend/Provider/TableDataContainerProvider.php
@@ -204,10 +204,10 @@ class TableDataContainerProvider implements ProviderInterface
             $fieldsConfig,
             static function (array $config): bool {
                 if (\array_key_exists('backendSearch', $config)) {
-                    return $config['backendSearch'];
+                    return (bool) $config['backendSearch'];
                 }
 
-                return \array_key_exists('search', $config) && true === $config['search'];
+                return (bool) ($config['search'] ?? false);
             },
         );
 

--- a/core-bundle/tests/Fixtures/table-data-container-provider/dca/tl_content.php
+++ b/core-bundle/tests/Fixtures/table-data-container-provider/dca/tl_content.php
@@ -28,5 +28,12 @@ $GLOBALS['TL_DCA']['tl_content'] =
         'text' => [
             'search' => true,
         ],
+        'text_search_disabled' => [
+            'search' => false,
+        ],
+        'text_search_disabled_backend_search_enabled' => [
+            'search' => false,
+            'backendSearch' => true,
+        ],
     ],
 ];

--- a/core-bundle/tests/Search/Backend/Provider/TableDataContainerProviderTest.php
+++ b/core-bundle/tests/Search/Backend/Provider/TableDataContainerProviderTest.php
@@ -69,6 +69,8 @@ class TableDataContainerProviderTest extends AbstractProviderTestCase
                     new Column('id', Type::getType(Types::INTEGER)),
                     new Column('type', Type::getType(Types::STRING)),
                     new Column('text', Type::getType(Types::STRING)),
+                    new Column('text_search_disabled', Type::getType(Types::STRING)),
+                    new Column('text_search_disabled_backend_search_enabled', Type::getType(Types::STRING)),
                 ]),
                 new Table('tl_news', [
                     new Column('id', Type::getType(Types::INTEGER)),
@@ -85,7 +87,9 @@ class TableDataContainerProviderTest extends AbstractProviderTestCase
                     [
                         'id' => 1,
                         'type' => 'text',
-                        'text' => '<p>This is <em>some</em> content.',
+                        'text' => '<p>This is <em>some</em> content in "text".</p>',
+                        'text_search_disabled' => '<p>This is <em>some</em> content in "text_search_disabled".</p>',
+                        'text_search_disabled_backend_search_enabled' => '<p>This is <em>some</em> content in "text_search_disabled_backend_search_enabled".</p>',
                     ],
                 ],
                 'tl_news' => [
@@ -142,7 +146,7 @@ class TableDataContainerProviderTest extends AbstractProviderTestCase
         $this->assertSame('1', $documents[0]->getId());
         $this->assertSame('contao.db.tl_content', $documents[0]->getType());
         $this->assertSame('tl_content', $documents[0]->getMetadata()['table']);
-        $this->assertSame('<p>This is <em>some</em> content.', $documents[0]->getSearchableContent());
+        $this->assertSame('<p>This is <em>some</em> content in "text".</p> <p>This is <em>some</em> content in "text_search_disabled_backend_search_enabled".</p>', $documents[0]->getSearchableContent());
         $this->assertSame('2', $documents[1]->getId());
         $this->assertSame('contao.db.tl_news', $documents[1]->getType());
         $this->assertSame('tl_news', $documents[1]->getMetadata()['table']);


### PR DESCRIPTION
Currently, everything that has `search` set to `true` will be indexed also by the backend search.
There are cases where you want to enable search only for the DC view or only for the backend search. You can do this now using

```php
'eval' => [
    'search' => false, // or true
    'backendSearch' => true // or false
]
```

`backendSearch` always takes precedence over `search`.

This will also help improve the DX for the virtual fields, see discussions in https://github.com/contao/contao/pull/8838.
