### PR TITLE
Fix the breadcrumb in the tree view

### DIFF
--- a/core-bundle/contao/templates/twig/backend/data_container/table/view/tree.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/view/tree.html.twig
@@ -51,7 +51,7 @@
 
 {% block no_records %}
     {% if breadcrumb %}
-        <div class="tl_listing_container">{{ breadcrumb }}</div>
+        <div class="tl_listing_container">{{ breadcrumb|raw }}</div>
     {% endif %}
 
     {{ parent() }}

--- a/core-bundle/contao/templates/twig/backend/data_container/table/view/tree.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/view/tree.html.twig
@@ -28,7 +28,7 @@
         .set('data-picker-value', picker.value|default, as_picker)
     %}
     <div{{ listing_attributes }}>
-        {{ breadcrumb }}
+        {{ breadcrumb|raw }}
         {{ include('@Contao/backend/data_container/table/view/_select_all_button.html.twig') }}
 
         {% set tree_attributes = attrs()


### PR DESCRIPTION
Fixes a regression caused by #9130 (tree view only)

<img width="1604" height="1244" alt="grafik" src="https://github.com/user-attachments/assets/c8974271-9fb9-45e7-b3db-faee7a00f96c" />
