### PR TITLE
Do not add the navigation toggle state controller in popup mode

### DIFF
--- a/core-bundle/contao/templates/backend/be_main.html5
+++ b/core-bundle/contao/templates/backend/be_main.html5
@@ -13,13 +13,20 @@ $this->bodyAttributes = $this
     ->set('id', 'top')
     ->addClass('be_main')
     ->addClass('popup', $this->isPopup)
-    ->set('data-controller', 'contao--tooltips contao--toggle-state', !$this->isPopup)
-    ->set('data-action', 'touchstart@document->contao--tooltips#touchStart click@document->contao--toggle-state#documentClick keydown.esc@document->contao--toggle-state#close')
-    ->set('data-contao--toggle-state-active-class', 'active', !$this->isPopup)
-    ->set('data-contao--toggle-state-active-title-value', $this->trans('MSC.hideMainNavigation', [], 'contao_default'), !$this->isPopup)
-    ->set('data-contao--toggle-state-inactive-title-value', $this->trans('MSC.showMainNavigation', [], 'contao_default'), !$this->isPopup)
+    ->set('data-controller', 'contao--tooltips')
+    ->set('data-action', 'touchstart@document->contao--tooltips#touchStart')
     ->mergeWith($this->bodyAttributes)
 ;
+
+if (!$this->isPopup) {
+    $this->bodyAttributes
+        ->set('data-controller', 'contao--tooltips contao--toggle-state')
+        ->set('data-action', 'touchstart@document->contao--tooltips#touchStart click@document->contao--toggle-state#documentClick keydown.esc@document->contao--toggle-state#close')
+        ->set('data-contao--toggle-state-active-class', 'active')
+        ->set('data-contao--toggle-state-active-title-value', $this->trans('MSC.hideMainNavigation', [], 'contao_default'))
+        ->set('data-contao--toggle-state-inactive-title-value', $this->trans('MSC.showMainNavigation', [], 'contao_default'))
+    ;
+}
 
 $this->containerAttributes = $this
     ->attrs()

--- a/core-bundle/contao/templates/backend/be_main.html5
+++ b/core-bundle/contao/templates/backend/be_main.html5
@@ -13,11 +13,11 @@ $this->bodyAttributes = $this
     ->set('id', 'top')
     ->addClass('be_main')
     ->addClass('popup', $this->isPopup)
-    ->set('data-controller', 'contao--tooltips contao--toggle-state')
+    ->set('data-controller', 'contao--tooltips contao--toggle-state', !$this->isPopup)
     ->set('data-action', 'touchstart@document->contao--tooltips#touchStart click@document->contao--toggle-state#documentClick keydown.esc@document->contao--toggle-state#close')
-    ->set('data-contao--toggle-state-active-class', 'active')
-    ->set('data-contao--toggle-state-active-title-value', $this->trans('MSC.hideMainNavigation', [], 'contao_default'))
-    ->set('data-contao--toggle-state-inactive-title-value', $this->trans('MSC.showMainNavigation', [], 'contao_default'))
+    ->set('data-contao--toggle-state-active-class', 'active', !$this->isPopup)
+    ->set('data-contao--toggle-state-active-title-value', $this->trans('MSC.hideMainNavigation', [], 'contao_default'), !$this->isPopup)
+    ->set('data-contao--toggle-state-inactive-title-value', $this->trans('MSC.showMainNavigation', [], 'contao_default'), !$this->isPopup)
     ->mergeWith($this->bodyAttributes)
 ;
 

--- a/core-bundle/contao/templates/twig/be_main.html.twig
+++ b/core-bundle/contao/templates/twig/be_main.html.twig
@@ -11,13 +11,21 @@
     .set('id', 'top')
     .addClass('be_main')
     .addClass('popup', isPopup)
-    .set('data-controller', 'contao--tooltips contao--toggle-state', not isPopup)
-    .set('data-action', 'touchstart@document->contao--tooltips#touchStart click@document->contao--toggle-state#documentClick keydown.esc@document->contao--toggle-state#close')
-    .set('data-contao--toggle-state-active-class', 'active', not isPopup)
-    .set('data-contao--toggle-state-active-title-value', 'MSC.hideMainNavigation'|trans, not isPopup)
-    .set('data-contao--toggle-state-inactive-title-value', 'MSC.showMainNavigation'|trans, not isPopup)
+    .set('data-controller', 'contao--tooltips')
+    .set('data-action', 'touchstart@document->contao--tooltips#touchStart')
     .mergeWith(bodyAttributes|default)
 -%}
+
+{% if not isPopup %}
+    {%- do bodyAttributes
+        .addClass('popup', isPopup)
+        .set('data-controller', 'contao--tooltips contao--toggle-state')
+        .set('data-action', 'touchstart@document->contao--tooltips#touchStart click@document->contao--toggle-state#documentClick keydown.esc@document->contao--toggle-state#close')
+        .set('data-contao--toggle-state-active-class', 'active')
+        .set('data-contao--toggle-state-active-title-value', 'MSC.hideMainNavigation'|trans)
+        .set('data-contao--toggle-state-inactive-title-value', 'MSC.showMainNavigation'|trans)
+    -%}
+{% endif %}
 
 {%- set containerAttributes = attrs()
     .addClass(containerClass)

--- a/core-bundle/contao/templates/twig/be_main.html.twig
+++ b/core-bundle/contao/templates/twig/be_main.html.twig
@@ -11,11 +11,11 @@
     .set('id', 'top')
     .addClass('be_main')
     .addClass('popup', isPopup)
-    .set('data-controller', 'contao--tooltips contao--toggle-state')
+    .set('data-controller', 'contao--tooltips contao--toggle-state', not isPopup)
     .set('data-action', 'touchstart@document->contao--tooltips#touchStart click@document->contao--toggle-state#documentClick keydown.esc@document->contao--toggle-state#close')
-    .set('data-contao--toggle-state-active-class', 'active')
-    .set('data-contao--toggle-state-active-title-value', 'MSC.hideMainNavigation'|trans)
-    .set('data-contao--toggle-state-inactive-title-value', 'MSC.showMainNavigation'|trans)
+    .set('data-contao--toggle-state-active-class', 'active', not isPopup)
+    .set('data-contao--toggle-state-active-title-value', 'MSC.hideMainNavigation'|trans, not isPopup)
+    .set('data-contao--toggle-state-inactive-title-value', 'MSC.showMainNavigation'|trans, not isPopup)
     .mergeWith(bodyAttributes|default)
 -%}
 


### PR DESCRIPTION
Currently there is an error that the `toggle-state` controller has no `controllerTarget`, because the navigation panel is missing.

Ideally, we would also remove the actions, but they seem to be ignored if the controller is missing.