### PR TITLE
Allow HTML in search headers

### DIFF
--- a/core-bundle/contao/templates/twig/mod_search.html.twig
+++ b/core-bundle/contao/templates/twig/mod_search.html.twig
@@ -24,7 +24,7 @@
     </form>
 
     {% if header|default %}
-        <p class="header">{{ header }}</p>
+        <p class="header">{{ header|raw }}</p>
         {% if keywordHint|default %}
             <p class="info">{{ keywordHint }}</p>
         {% endif %}


### PR DESCRIPTION
The search header is generated by the controller and contains HTML from the language files.

<img width="700" height="70" alt="Bildschirmfoto 2026-01-09 um 09 34 34" src="https://github.com/user-attachments/assets/5328a7d6-3c1d-40fe-a4fd-1840e22e19c9" />
