### PR TITLE
Do not assign `data-label` and `data-title` to the toggle operation

### DIFF
--- a/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
@@ -336,6 +336,8 @@ class DataContainerOperationsBuilder extends AbstractDataContainerOperationsBuil
         }
 
         $attributes = $config['attributes']
+            ->set('data-label', $labelEnabled)
+            ->set('data-label-disabled', $labelDisabled)
             ->set('data-action', 'contao--scroll-offset#store')
             ->set('onclick', 'return AjaxRequest.toggleField(this,'.('visible.svg' === $icon ? 'true' : 'false').')')
         ;

--- a/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
@@ -336,10 +336,6 @@ class DataContainerOperationsBuilder extends AbstractDataContainerOperationsBuil
         }
 
         $attributes = $config['attributes']
-            ->set('data-label', $labelEnabled)
-            ->set('data-label-disabled', $labelDisabled)
-            ->set('data-title', $config['title'])
-            ->set('data-title-disabled', $titleDisabled)
             ->set('data-action', 'contao--scroll-offset#store')
             ->set('onclick', 'return AjaxRequest.toggleField(this,'.('visible.svg' === $icon ? 'true' : 'false').')')
         ;


### PR DESCRIPTION
Fixes #9206

Since the toggle operation has an icon, the title is set on the `<img>` tag and must not be set on the outer `<a>` tag as well.