### PR TITLE
Cache the module access in the `TableAccessVoter`

### DIFF
--- a/core-bundle/src/Security/Voter/DataContainer/TableAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/TableAccessVoter.php
@@ -31,6 +31,7 @@ use Symfony\Contracts\Service\ResetInterface;
 class TableAccessVoter implements CacheableVoterInterface, ResetInterface
 {
     private array $canAccessTable = [];
+
     private array $canReadAccessTable = [];
 
     public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)

--- a/core-bundle/src/Security/Voter/DataContainer/TableAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/TableAccessVoter.php
@@ -98,7 +98,7 @@ class TableAccessVoter implements CacheableVoterInterface, ResetInterface
 
     private function hasAccessToModule(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $subject): bool
     {
-        $tokenHash = ContainerBuilder::hash($token);
+        $tokenHash = hash('xxh128', serialize($token));
 
         if (isset($this->canAccessTable[$tokenHash]) || ($subject instanceof ReadAction && isset($this->canReadAccessTable[$tokenHash]))) {
             return $this->canAccessTable[$tokenHash] ?? $this->canReadAccessTable[$tokenHash];

--- a/core-bundle/src/Security/Voter/DataContainer/TableAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/TableAccessVoter.php
@@ -19,7 +19,6 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\DataContainer;
 use Contao\DC_File;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/9203

I decided to handle this as a fix of the latest version instead of the old LTS, since it isnt' really a but but an optimization.