### PR TITLE
Remove autoconfigured tags

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1347,6 +1347,8 @@ services:
         autoconfigure: false
         arguments:
             - '@contao.translation.data_collector_translator.inner'
+        tags:
+            - { name: kernel.reset, method: reset }
 
     contao.translation.legacy_locale_switcher:
         class: Contao\CoreBundle\Translation\LegacyLocaleSwitcher

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -276,8 +276,6 @@ services:
             - '@contao.framework'
             - '@database_connection'
             - '@translator'
-        tags:
-            - { name: kernel.reset, method: reset }
 
     contao.data_container.virtual_fields_handler:
         class: Contao\CoreBundle\DataContainer\VirtualFieldsHandler
@@ -1349,8 +1347,6 @@ services:
         autoconfigure: false
         arguments:
             - '@contao.translation.data_collector_translator.inner'
-        tags:
-            - { name: kernel.reset, method: reset }
 
     contao.translation.legacy_locale_switcher:
         class: Contao\CoreBundle\Translation\LegacyLocaleSwitcher


### PR DESCRIPTION
These are autoconfigured through the interface.

I wouldn't change this for 5.3, I remember some older symfony version required this. No need to change this in the LTS.