### PR TITLE
Use the drag handle label from the current table

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4338,7 +4338,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 					if ($record['allow_dragging'])
 					{
-						$labelCut = $GLOBALS['TL_LANG']['tl_content']['cut'] ?? $GLOBALS['TL_LANG']['DCA']['cut'];
+						$labelCut = $GLOBALS['TL_LANG'][$this->strTable]['cut'] ?? $GLOBALS['TL_LANG']['DCA']['cut'];
 						$record['drag_handle_label'] = \sprintf(\is_array($labelCut) ? $labelCut[1] : $labelCut, $row[$i]['id']);
 					}
 				}


### PR DESCRIPTION
Don't always use the label from `tl_content` but from the current table.