### PR TITLE
Rename the abstract form type to fit the Symfony naming schema

### DIFF
--- a/core-bundle/config/form.yaml
+++ b/core-bundle/config/form.yaml
@@ -3,7 +3,7 @@ services:
         autoconfigure: true
 
     _instanceof:
-        Contao\CoreBundle\Form\Type\AbstractContaoFormType:
+        Contao\CoreBundle\Form\Type\AbstractContaoType:
             calls:
                 - [ setContainer, [ '@Psr\Container\ContainerInterface' ] ]
 

--- a/core-bundle/src/Form/Type/AbstractContaoType.php
+++ b/core-bundle/src/Form/Type/AbstractContaoType.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
  *
  * @extends AbstractType<T>
  */
-abstract class AbstractContaoFormType extends AbstractType implements ServiceSubscriberInterface
+abstract class AbstractContaoType extends AbstractType implements ServiceSubscriberInterface
 {
     protected ContainerInterface $container;
 


### PR DESCRIPTION
Remove `Form` from class name.