### PR TITLE
Render the header even if no records exists

### DIFF
--- a/core-bundle/contao/templates/twig/backend/data_container/table/view/_record_listing.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/view/_record_listing.html.twig
@@ -4,22 +4,21 @@
     {{ message|raw }}
     {{ global_operations|raw }}
 
-    {% if records|length %}
-        {% if not as_select %}
-            {% block list %}{% endblock %}
-        {% else %}
-            {# Wrap listing in a form for select mode #}
-            <form id="tl_select" class="tl_form unselectable" method="post" novalidate>
-                <div class="tl_formbody_edit">
-                    <input type="hidden" name="FORM_SUBMIT" value="tl_select">
-                    <input type="hidden" name="REQUEST_TOKEN" value="{{ contao.request_token }}">
-                    {{ block('list') }}
-                </div>
-
-                {{ buttons|default|raw }}
-            </form>
-        {% endif %}
+    {% if not as_select %}
+        {% block list %}{% endblock %}
     {% else %}
+        {# Wrap listing in a form for select mode #}
+        <form id="tl_select" class="tl_form unselectable" method="post" novalidate>
+            <div class="tl_formbody_edit">
+                <input type="hidden" name="FORM_SUBMIT" value="tl_select">
+                <input type="hidden" name="REQUEST_TOKEN" value="{{ contao.request_token }}">
+                {{ block('list') }}
+            </div>
+
+            {{ buttons|default|raw }}
+        </form>
+    {% endif %}
+    {% if records|length < 1 %}
         {% block no_records %}
             <p class="tl_empty">{{ 'MSC.noResult'|trans }}</p>
         {% endblock %}


### PR DESCRIPTION
### Description

- fixes #9226 

This fixes a regression caused by #9170 where the header would never be output if no records exist (which is wrong as the children don't have anything to do with their parents' settings)