### PR TITLE
Fix the popup for wildcard links

### DIFF
--- a/core-bundle/contao/templates/twig/be_wildcard.html.twig
+++ b/core-bundle/contao/templates/twig/be_wildcard.html.twig
@@ -7,7 +7,7 @@
         <span class="upper">{{ wildcard }}</span>
         {% if link|default %}
             <br>
-            {{ link }} (<a href="{{ href ~ '&rt=' ~ contao.request_token }}" class="tl_gray">ID: {{ id }}</a>)
+            {{ link }} (<a href="{{ href ~ '&rt=' ~ contao.request_token }}" onclick="Backend.openModalIframe({ title: '{{ link|e('js') }}', url:this.href + '&amp;popup=1&amp;nb=1' });return false" class="tl_gray">ID: {{ id }}</a>)
         {% endif %}
     </div>
 {% endif %}


### PR DESCRIPTION
This was added in #8817 but got lost on the Twig migration.