### PR TITLE
Always render the operations within the `tree view` even if no records exist

### DIFF
--- a/core-bundle/contao/templates/twig/backend/data_container/table/view/tree.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/view/tree.html.twig
@@ -54,6 +54,9 @@
 {% endblock %}
 
 {% block no_records %}
+    {% if has_clipboard_content %}
+        <div id="paste_hint"><p>{{ 'MSC.selectNewPosition'|trans }}</p></div>
+    {% endif %}
     <div class="tl_listing_container">
         {{ breadcrumb|default|raw }}
         {{ block('tree') }}

--- a/core-bundle/contao/templates/twig/backend/data_container/table/view/tree.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/view/tree.html.twig
@@ -16,6 +16,22 @@
     .set('data-contao--toggle-nodes-collapse-all-title-value', 'DCA.collapseNodes.1'|trans)
 %}
 
+{% block tree %}
+    {% set tree_attributes = attrs()
+        .addClass('tl_listing')
+        .addClass('tl_tree', not extended_mode)
+        .addClass('tl_tree_xtnd', extended_mode)
+        .addClass(['picker', 'unselectable'], as_picker)
+    %}
+    <ul{{ tree_attributes }}>
+        <li class="tl_folder_top cf" data-controller="contao--operations-menu" data-action="contextmenu->contao--operations-menu#open">
+            <div class="tl_left"></div>
+            <div class="tl_right">{{ operations|raw }}</div>
+        </li>
+        {{ records|join|raw }}
+    </ul>
+{% endblock %}
+
 {% block list %}
     {% if has_clipboard_content %}
         <div id="paste_hint"><p>{{ 'MSC.selectNewPosition'|trans }}</p></div>
@@ -31,28 +47,16 @@
         {{ breadcrumb|raw }}
         {{ include('@Contao/backend/data_container/table/view/_select_all_button.html.twig') }}
 
-        {% set tree_attributes = attrs()
-            .addClass('tl_listing')
-            .addClass('tl_tree', not extended_mode)
-            .addClass('tl_tree_xtnd', extended_mode)
-            .addClass(['picker', 'unselectable'], as_picker)
-        %}
-        <ul{{ tree_attributes }}>
-            <li class="tl_folder_top cf" data-controller="contao--operations-menu" data-action="contextmenu->contao--operations-menu#open">
-                <div class="tl_left"></div>
-                <div class="tl_right">{{ operations|raw }}</div>
-            </li>
-            {{ records|join|raw }}
-        </ul>
+        {{ block('tree') }}
 
         {{ include('@Contao/backend/data_container/table/view/_picker_reset_button.html.twig') }}
     </div>
 {% endblock %}
 
 {% block no_records %}
-    {% if breadcrumb %}
-        <div class="tl_listing_container">{{ breadcrumb|raw }}</div>
-    {% endif %}
-
+    <div class="tl_listing_container">
+        {{ breadcrumb|default|raw }}
+        {{ block('tree') }}
+    </div>
     {{ parent() }}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/backend/data_container/table/view/tree.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/view/tree.html.twig
@@ -26,7 +26,7 @@
     <ul{{ tree_attributes }}>
         <li class="tl_folder_top cf" data-controller="contao--operations-menu" data-action="contextmenu->contao--operations-menu#open">
             <div class="tl_left"></div>
-            <div class="tl_right">{{ operations|raw }}</div>
+            <div class="tl_right">{{ operations|default|raw }}</div>
         </li>
         {{ records|join|raw }}
     </ul>
@@ -54,12 +54,14 @@
 {% endblock %}
 
 {% block no_records %}
-    {% if has_clipboard_content %}
+    {% if has_clipboard_content|default %}
         <div id="paste_hint"><p>{{ 'MSC.selectNewPosition'|trans }}</p></div>
     {% endif %}
     <div class="tl_listing_container">
         {{ breadcrumb|default|raw }}
-        {{ block('tree') }}
+        {% if operations|default %}
+            {{ block('tree') }}
+        {% endif %}
     </div>
     {{ parent() }}
 {% endblock %}


### PR DESCRIPTION
### Description

Right now, we deliberately do not render operations if we have 0 records, thus not allowing to "paste" new elements.

So in an empty new installation, we currently can not create new pages or articles.
