### PR TITLE
Use ellipsis for `MSC.searchResultsLoading`

### DIFF
--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -2280,7 +2280,7 @@
         <source>Please enter at least %s characters</source>
       </trans-unit>
       <trans-unit id="MSC.searchResultsLoading">
-        <source>Loading results...</source>
+        <source>Loading results …</source>
       </trans-unit>
       <trans-unit id="MSC.searchHitView">
         <source>View %s</source>


### PR DESCRIPTION
We use the ellipsis character `…` in all other places (e.g. `MSC.loading`, `MSC.more`, `MSC.passkeyNameInput`, `MSC.altchaWaitAlert`, etc.) thus I think we should use it here too.
