### PR TITLE
Ignore DCAs whose tables are defined via a Doctrine entity

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -645,6 +645,8 @@ services:
 
     contao.listener.virtual_fields_mapping:
         class: Contao\CoreBundle\EventListener\VirtualFieldsMappingListener
+        arguments:
+            - '@doctrine.orm.entity_manager'
 
     contao.listener.webauthn_route_backend:
         class: Contao\CoreBundle\EventListener\WebauthnRouteListener

--- a/core-bundle/tests/EventListener/VirtualFieldsMappingListenerTest.php
+++ b/core-bundle/tests/EventListener/VirtualFieldsMappingListenerTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener;
 
 use Contao\CoreBundle\EventListener\VirtualFieldsMappingListener;
-use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Tests\Doctrine\DoctrineTestCase;
 use Contao\DC_File;
 use Contao\DC_Table;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class VirtualFieldsMappingListenerTest extends TestCase
+class VirtualFieldsMappingListenerTest extends DoctrineTestCase
 {
     #[DataProvider('virtualFieldsMappingProvider')]
     public function testVirtualFieldsMapping(array $fields, array $expected, string $dc = DC_Table::class): void
@@ -32,7 +32,7 @@ class VirtualFieldsMappingListenerTest extends TestCase
             'palettes' => ['default' => 'foobar'],
         ];
 
-        (new VirtualFieldsMappingListener())('tl_foobar');
+        (new VirtualFieldsMappingListener($this->getTestEntityManager()))('tl_foobar');
 
         $this->assertSame($expected, $GLOBALS['TL_DCA']['tl_foobar']['fields']);
 
@@ -129,7 +129,7 @@ class VirtualFieldsMappingListenerTest extends TestCase
             'palettes' => ['default' => 'foobar'],
         ];
 
-        (new VirtualFieldsMappingListener())('tl_foobar');
+        (new VirtualFieldsMappingListener($this->getTestEntityManager()))('tl_foobar');
 
         $this->assertSame(['foobar' => ['inputType' => 'text']], $GLOBALS['TL_DCA']['tl_foobar']['fields']);
 
@@ -150,7 +150,7 @@ class VirtualFieldsMappingListenerTest extends TestCase
             ],
         ];
 
-        (new VirtualFieldsMappingListener())('tl_foobar');
+        (new VirtualFieldsMappingListener($this->getTestEntityManager()))('tl_foobar');
 
         $this->assertSame(['foobar' => ['inputType' => 'text']], $GLOBALS['TL_DCA']['tl_foobar']['fields']);
 

--- a/core-bundle/tests/EventListener/VirtualFieldsMappingListenerTest.php
+++ b/core-bundle/tests/EventListener/VirtualFieldsMappingListenerTest.php
@@ -13,13 +13,16 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener;
 
 use Contao\CoreBundle\EventListener\VirtualFieldsMappingListener;
-use Contao\CoreBundle\Tests\Doctrine\DoctrineTestCase;
+use Contao\CoreBundle\Tests\TestCase;
 use Contao\DC_File;
 use Contao\DC_Table;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class VirtualFieldsMappingListenerTest extends DoctrineTestCase
+class VirtualFieldsMappingListenerTest extends TestCase
 {
     #[DataProvider('virtualFieldsMappingProvider')]
     public function testVirtualFieldsMapping(array $fields, array $expected, string $dc = DC_Table::class): void
@@ -27,12 +30,13 @@ class VirtualFieldsMappingListenerTest extends DoctrineTestCase
         $GLOBALS['TL_DCA']['tl_foobar'] = [
             'config' => [
                 'dataContainer' => $dc,
+                'sql' => true,
             ],
             'fields' => $fields,
             'palettes' => ['default' => 'foobar'],
         ];
 
-        (new VirtualFieldsMappingListener($this->getTestEntityManager()))('tl_foobar');
+        (new VirtualFieldsMappingListener())('tl_foobar');
 
         $this->assertSame($expected, $GLOBALS['TL_DCA']['tl_foobar']['fields']);
 
@@ -120,6 +124,7 @@ class VirtualFieldsMappingListenerTest extends DoctrineTestCase
             'config' => [
                 'dataContainer' => DC_Table::class,
                 'notEditable' => true,
+                'sql' => true,
             ],
             'fields' => [
                 'foobar' => [
@@ -129,7 +134,7 @@ class VirtualFieldsMappingListenerTest extends DoctrineTestCase
             'palettes' => ['default' => 'foobar'],
         ];
 
-        (new VirtualFieldsMappingListener($this->getTestEntityManager()))('tl_foobar');
+        (new VirtualFieldsMappingListener())('tl_foobar');
 
         $this->assertSame(['foobar' => ['inputType' => 'text']], $GLOBALS['TL_DCA']['tl_foobar']['fields']);
 
@@ -142,6 +147,7 @@ class VirtualFieldsMappingListenerTest extends DoctrineTestCase
         $GLOBALS['TL_DCA']['tl_foobar'] = [
             'config' => [
                 'dataContainer' => DC_Table::class,
+                'sql' => true,
             ],
             'fields' => [
                 'foobar' => [
@@ -150,7 +156,73 @@ class VirtualFieldsMappingListenerTest extends DoctrineTestCase
             ],
         ];
 
-        (new VirtualFieldsMappingListener($this->getTestEntityManager()))('tl_foobar');
+        (new VirtualFieldsMappingListener())('tl_foobar');
+
+        $this->assertSame(['foobar' => ['inputType' => 'text']], $GLOBALS['TL_DCA']['tl_foobar']['fields']);
+
+        unset($GLOBALS['TL_DCA']);
+    }
+
+    public function testDoesNotMapForDcasDefinedByDoctrineEntity(): void
+    {
+        /** @phpstan-var array $GLOBALS (signals PHPStan that the array shape may change) */
+        $GLOBALS['TL_DCA']['tl_foobar'] = [
+            'config' => [
+                'dataContainer' => DC_Table::class,
+                'sql' => true,
+            ],
+            'fields' => [
+                'foobar' => [
+                    'inputType' => 'text',
+                ],
+            ],
+            'palettes' => ['default' => 'foobar'],
+        ];
+
+        $classMetaData = $this->createMock(ClassMetadata::class);
+        $classMetaData
+            ->expects($this->once())
+            ->method('getTableName')
+            ->willReturn('tl_foobar')
+        ;
+
+        $classMetaDataFactory = $this->createMock(ClassMetadataFactory::class);
+        $classMetaDataFactory
+            ->expects($this->once())
+            ->method('getAllMetadata')
+            ->willReturn([$classMetaData])
+        ;
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects($this->once())
+            ->method('getMetadataFactory')
+            ->willReturn($classMetaDataFactory)
+        ;
+
+        (new VirtualFieldsMappingListener($entityManager))('tl_foobar');
+
+        $this->assertSame(['foobar' => ['inputType' => 'text']], $GLOBALS['TL_DCA']['tl_foobar']['fields']);
+
+        unset($GLOBALS['TL_DCA']);
+    }
+
+    public function testDoesNotMapForDcasWithoutSqlConfig(): void
+    {
+        /** @phpstan-var array $GLOBALS (signals PHPStan that the array shape may change) */
+        $GLOBALS['TL_DCA']['tl_foobar'] = [
+            'config' => [
+                'dataContainer' => DC_Table::class,
+            ],
+            'fields' => [
+                'foobar' => [
+                    'inputType' => 'text',
+                ],
+            ],
+            'palettes' => ['default' => 'foobar'],
+        ];
+
+        (new VirtualFieldsMappingListener())('tl_foobar');
 
         $this->assertSame(['foobar' => ['inputType' => 'text']], $GLOBALS['TL_DCA']['tl_foobar']['fields']);
 


### PR DESCRIPTION
This PR fixes an issue with DCAs whose fields are missing the `sql` definition, as they are defined via a Doctrine entity, while also having, for example, `search` set to true. I stumbled upon this because of `terminal42/contao-shortlink`.

The following exception will be thrown on cache warmup if such a DCA is present
```
In DcaExtractor.php line 480:

  [Contao\CoreBundle\DataContainer\InvalidConfigException]
  Enabling "search" on virtual field tl_terminal42_shortlink.target is not supported.


Exception trace:
  at .../vendor/contao/core-bundle/contao/library/Contao/DcaExtractor.php:480
 Contao\DcaExtractor->createExtract() at .../vendor/contao/core-bundle/contao/library/Contao/DcaExtractor.php:132
 Contao\DcaExtractor->__construct() at .../vendor/contao/core-bundle/contao/library/Contao/DcaExtractor.php:154
 Contao\DcaExtractor::getInstance() at .../vendor/contao/core-bundle/src/Cache/ContaoCacheWarmer.php:201
 Contao\CoreBundle\Cache\ContaoCacheWarmer->generateDcaExtracts() at .../vendor/contao/core-bundle/src/Cache/ContaoCacheWarmer.php:67
 Contao\CoreBundle\Cache\ContaoCacheWarmer->warmUp() at .../vendor/symfony/http-kernel/CacheWarmer/CacheWarmerAggregate.php:96
 Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate->warmUp() at .../vendor/symfony/framework-bundle/Command/CacheClearCommand.php:248
 Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->warmupOptionals() at .../vendor/symfony/framework-bundle/Command/CacheClearCommand.php:147
 Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->execute() at .../vendor/symfony/console/Command/Command.php:341
 Symfony\Component\Console\Command\Command->run() at .../vendor/symfony/console/Application.php:1102
 Symfony\Component\Console\Application->doRunCommand() at .../vendor/symfony/framework-bundle/Console/Application.php:123
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at .../vendor/symfony/console/Application.php:356
 Symfony\Component\Console\Application->doRun() at .../vendor/symfony/framework-bundle/Console/Application.php:77
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at .../vendor/symfony/console/Application.php:195
 Symfony\Component\Console\Application->run() at .../bin/console:33
```

A test for this probably should be added, but I think I might need a little help here. 😅 