### PR TITLE
Reverse the order of the filter submit buttons

### DIFF
--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -1157,8 +1157,8 @@ abstract class DataContainer extends Backend
 
 		$submit = '
 <div class="tl_submit_panel tl_subpanel" data-controller="contao--sticky-observer">
-  <button' . ($this->panelActive ? '' : ' disabled') . ' name="filter_reset" id="filter_reset" value="1" class="tl_submit filter_reset">' . $GLOBALS['TL_LANG']['MSC']['reset'] . '</button>
   <button name="filter" id="filter" class="tl_submit filter_apply">' . $GLOBALS['TL_LANG']['MSC']['apply'] . '</button>
+  <button' . ($this->panelActive ? '' : ' disabled') . ' name="filter_reset" id="filter_reset" value="1" class="tl_submit filter_reset">' . $GLOBALS['TL_LANG']['MSC']['reset'] . '</button>
 </div>';
 
 		$return = '


### PR DESCRIPTION
Fixes #9249 as mentioned in the issue. And I think we can simply leave the order _Apply_, _Reset_. I don't really see a need to reverse the order visually (via CSS).