### PR TITLE
Fix the missing virtual fields handler service argument

### DIFF
--- a/core-bundle/config/backend_search.yaml
+++ b/core-bundle/config/backend_search.yaml
@@ -68,6 +68,7 @@ services:
             - '@event_dispatcher'
             - '@contao.data_container.dca_url_analyzer'
             - '@translator'
+            - '@contao.data_container.virtual_fields_handler'
 
     contao.search.backend.trigger_reindex_on_files_storage_update_listener:
         class: Contao\CoreBundle\Search\Backend\EventListener\TriggerReindexOnFilesStorageUpdateListener


### PR DESCRIPTION
This was missed in https://github.com/contao/contao/pull/8838.