### PR TITLE
Fix the legacy template editor

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -198,6 +198,7 @@ services:
             - '@contao.framework'
             - '@translator'
             - '@router'
+            - '%contao.template_studio.enabled%'
 
     contao.listener.data_container.logout_page_redirect:
         class: Contao\CoreBundle\EventListener\DataContainer\LogoutPageRedirectListener

--- a/core-bundle/contao/dca/tl_templates.php
+++ b/core-bundle/contao/dca/tl_templates.php
@@ -38,7 +38,7 @@ $GLOBALS['TL_DCA']['tl_templates'] = array
 		'dataContainer'               => DC_Folder::class,
 		'uploadPath'                  => 'templates',
 		'editableFileTypes'           => 'html5',
-		'closed'                      => true,
+		'notCreatable'                => true,
 		'onload_callback' => array
 		(
 			array('tl_templates', 'addBreadcrumb'),
@@ -313,7 +313,7 @@ class tl_templates extends Backend
 
 			if (!$strError)
 			{
-				$this->redirect($this->getReferer());
+				$this->redirect(System::getContainer()->get('router')->generate('contao_backend', ['do' => 'tpl_editor']));
 			}
 		}
 

--- a/core-bundle/contao/dca/tl_templates.php
+++ b/core-bundle/contao/dca/tl_templates.php
@@ -313,7 +313,7 @@ class tl_templates extends Backend
 
 			if (!$strError)
 			{
-				$this->redirect(System::getContainer()->get('router')->generate('contao_backend', ['do' => 'tpl_editor']));
+				$this->redirect(System::getContainer()->get('router')->generate('contao_backend', array('do' => 'tpl_editor')));
 			}
 		}
 

--- a/core-bundle/contao/languages/en/tl_files.xlf
+++ b/core-bundle/contao/languages/en/tl_files.xlf
@@ -209,6 +209,9 @@
       <trans-unit id="tl_files.dragFile.1">
         <source>Drag file "%s"</source>
       </trans-unit>
+      <trans-unit id="tl_files.source.0">
+        <source>Edit source</source>
+      </trans-unit>
       <trans-unit id="tl_files.source.1">
         <source>Edit the source text of file "%s"</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_templates.xlf
+++ b/core-bundle/contao/languages/en/tl_templates.xlf
@@ -53,6 +53,9 @@
       <trans-unit id="tl_templates.pasteinto.1">
         <source>Paste into folder "%s"</source>
       </trans-unit>
+      <trans-unit id="tl_templates.compare.0">
+        <source>Compare</source>
+      </trans-unit>
       <trans-unit id="tl_templates.compare.1">
         <source>Compare "%s" with another template</source>
       </trans-unit>

--- a/core-bundle/src/EventListener/DataContainer/LegacyTemplatesListener.php
+++ b/core-bundle/src/EventListener/DataContainer/LegacyTemplatesListener.php
@@ -24,15 +24,21 @@ class LegacyTemplatesListener
         private readonly ContaoFramework $framework,
         private readonly TranslatorInterface $translator,
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly bool $templateStudioEnabled = true,
     ) {
     }
 
     #[AsCallback(table: 'tl_templates', target: 'config.onload')]
     public function addInfoMessage(): void
     {
+        if (!$this->templateStudioEnabled) {
+            return;
+        }
+
         $reference = \sprintf(
-            '<a href="%s">Template Studio</a>',
+            '<a href="%s">%s</a>',
             $this->urlGenerator->generate('contao_template_studio'),
+            $this->translator->trans('MOD.template_studio.0', [], 'contao_default'),
         );
 
         $message = $this->translator->trans('tl_templates.twig_studio_hint', [$reference], 'contao_templates');

--- a/core-bundle/src/Security/Voter/DataContainer/DcaPermissionVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/DcaPermissionVoter.php
@@ -102,8 +102,8 @@ class DcaPermissionVoter implements CacheableVoterInterface
     private function canOperate(TokenInterface $token, string $table, string $permission): bool
     {
         if (
-            \is_array($GLOBALS['TL_DCA'][$table]['config']['permissions'] ?? null)
-            && !\in_array($permission, $GLOBALS['TL_DCA'][$table]['config']['permissions'], true)
+            !\is_array($GLOBALS['TL_DCA'][$table]['config']['permissions'] ?? null)
+            || !\in_array($permission, $GLOBALS['TL_DCA'][$table]['config']['permissions'], true)
         ) {
             return true;
         }

--- a/core-bundle/tests/EventListener/DataContainer/LegacyTemplatesListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/LegacyTemplatesListenerTest.php
@@ -34,8 +34,10 @@ class LegacyTemplatesListenerTest extends TestCase
         $translator = $this->createStub(TranslatorInterface::class);
         $translator
             ->method('trans')
-            ->with('tl_templates.twig_studio_hint', ['<a href="contao_template_studio">Template Studio</a>'], 'contao_templates')
-            ->willReturn('<message>')
+            ->willReturnMap([
+                ['MOD.template_studio.0', [], 'contao_default', null, 'Template Studio'],
+                ['tl_templates.twig_studio_hint', ['<a href="contao_template_studio">Template Studio</a>'], 'contao_templates', null, '<message>'],
+            ])
         ;
 
         $urlGenerator = $this->createStub(UrlGeneratorInterface::class);


### PR DESCRIPTION
Fixes #9231 by using `notCreatable` instead of `closed` in `tl_templates` DCA, since `closed` means it should also not be editable.

Also fixes several minor issues I noticed:
 - There is a _use the template studio_ hint, even if the template studio has been disabled in the bundle configuration
 - The `Template Studio` label was not translated in said hint
 - Adding a new template would return to the home screen due to `getReferer()` not working
 - The permission voter would vote instead of abstain even if no permissions are defined on a DCA

Some of these _could_ be fixed in 5.6 (e.g. the missing translation) but I don't think that's worth it …