### PR TITLE
Cache the root parent calls for trail calculation

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3463,7 +3463,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				while ($objFound->next())
 				{
-					if (\count(array_intersect($this->root, $this->getParentRecords(array($objFound->id), $table))) > 0)
+					if (\count(array_intersect($this->root, $this->getParentRecordIds(array($objFound->id), $table))) > 0)
 					{
 						$arrFound[] = $objFound->id;
 					}
@@ -5642,7 +5642,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 	 * @param  array<int> $ids
 	 * @return array<int>
 	 */
-	private function getParentRecords(array $ids, string $table): array
+	private function getParentRecordIds(array $ids, string $table): array
 	{
 		if (!$ids)
 		{
@@ -5689,7 +5689,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			// Fetch visible root trails if enabled
 			if ($GLOBALS['TL_DCA'][$table]['list']['sorting']['showRootTrails'] ?? null)
 			{
-				$this->visibleRootTrails = $this->getParentRecords($this->root, $table);
+				$this->visibleRootTrails = $this->getParentRecordIds($this->root, $table);
 			}
 
 			// Fetch all children of the root
@@ -5697,7 +5697,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 			if ($isSearch)
 			{
-				$this->rootChildren = array_intersect($this->rootChildren, $this->getParentRecords($root, $table));
+				$this->rootChildren = array_intersect($this->rootChildren, $this->getParentRecordIds($root, $table));
 				$this->visibleRootTrails = array_merge($this->visibleRootTrails, array_diff($this->rootChildren, $root));
 			}
 

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -5660,7 +5660,10 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				$this->parentPagesCache[$table][$id] = $parents;
 
 				// Get all IDs on that level, they all have the same parents
-				$siblingsOnThisLevel = $db->prepare("SELECT id FROM $table WHERE id != ? AND pid=(SELECT pid FROM $table WHERE id = ?)")->execute($id, $id)->fetchEach('id');
+				$siblingsOnThisLevel = $db
+					->prepare("SELECT id FROM $table WHERE id != ? AND pid = (SELECT pid FROM $table WHERE id = ?)")
+					->execute($id, $id)
+					->fetchEach('id');
 
 				foreach ($siblingsOnThisLevel as $siblingId)
 				{
@@ -5674,7 +5677,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 		}
 
-		// Our cache does never include the IDs, so we add them to the result unless $skipIds was set to true
+		// Our cache never includes the IDs, so we add them to the result unless $skipIds was set to true
 		if (!$skipIds)
 		{
 			foreach ($ids as $id)

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -110,6 +110,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 	protected $arrSubmit = array();
 
 	/**
+	 * Cache for the getParentRecords() calls for root trail calculation.
+	 * @var array<string, array<<int, array<int>>
+	 */
+	private $parentPagesCache = array();
+
+	/**
 	 * Initialize the object
 	 *
 	 * @param string $strTable
@@ -3457,7 +3463,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				while ($objFound->next())
 				{
-					if (\count(array_intersect($this->root, $db->getParentRecords($objFound->id, $table))) > 0)
+					if (\count(array_intersect($this->root, $this->getParentRecords(array($objFound->id), $table))) > 0)
 					{
 						$arrFound[] = $objFound->id;
 					}
@@ -5630,6 +5636,46 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 	}
 
+	/**
+	 * Optimized function for common tree view calls in DC_Table to reduce the amount of database queries.
+	 *
+	 * @param  array<int> $ids
+	 * @return array<int>
+	 */
+	private function getParentRecords(array $ids, string $table): array
+	{
+		if (!$ids)
+		{
+			return array();
+		}
+
+		$db = Database::getInstance();
+		$allParents = array();
+
+		foreach ($ids as $id)
+		{
+			if (!isset($this->parentPagesCache[$table][$id]))
+			{
+				$parents = $db->getParentRecords($id, $table);
+
+				// Get all IDs on that level, they all have the same parents
+				$idsOnThisLevel = $db->prepare("SELECT id FROM $table WHERE pid=(SELECT pid FROM $table WHERE id = ?)")->execute($id)->fetchEach('id');
+
+				foreach ($idsOnThisLevel as $levelId)
+				{
+					$this->parentPagesCache[$table][$levelId] = $parents;
+				}
+			}
+
+			foreach ($this->parentPagesCache[$table][$id] as $parent)
+			{
+				$allParents[$parent] = true;
+			}
+		}
+
+		return array_keys($allParents);
+	}
+
 	protected function updateRoot(array $root, bool $isSearch = false)
 	{
 		$db = Database::getInstance();
@@ -5643,12 +5689,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			// Fetch visible root trails if enabled
 			if ($GLOBALS['TL_DCA'][$table]['list']['sorting']['showRootTrails'] ?? null)
 			{
-				foreach ($this->root as $id)
-				{
-					$this->visibleRootTrails[] = $db->getParentRecords($id, $table, true);
-				}
-
-				$this->visibleRootTrails = array_unique(array_merge(...$this->visibleRootTrails));
+				$this->visibleRootTrails = $this->getParentRecords($this->root, $table);
 			}
 
 			// Fetch all children of the root
@@ -5656,14 +5697,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 			if ($isSearch)
 			{
-				$parents = array();
-
-				foreach ($root as $id)
-				{
-					$parents[] = $db->getParentRecords($id, $table);
-				}
-
-				$this->rootChildren = array_intersect($this->rootChildren, array_merge(...$parents));
+				$this->rootChildren = array_intersect($this->rootChildren, $this->getParentRecords($root, $table));
 				$this->visibleRootTrails = array_merge($this->visibleRootTrails, array_diff($this->rootChildren, $root));
 			}
 


### PR DESCRIPTION
This can be best checked when looking at the database queries executed in DC mode 6 (MODE_TREE_EXTENDED). So in the core, the articles view. It's especially noticeable if you have a lot of articles.
There are two problems:

1. `updateRoot()` queries the database for the parents of `$this->root` every time its called. Which in the core happens always twice if you search for example. It's initialized with an initial set of root nodes and only then checks if there's a filter set. This is improved by using a simple lookup cache - are we allowed to do that with reloadable DCs? @ausi - might cause issues but then also, there's probably a ton that's cached. At least I did not make it static.

2. If you have 50 pages or articles on the same level, every single one of them calls asks for their parents in the tree view. This can be easily optimized by also caching the siblings right away (because they always have the same parents).

Before (could get way, way worse if you have more articles or pages, I only had a few causing 83 queries):
<img width="966" height="296" alt="Bildschirmfoto 2026-01-20 um 16 10 27" src="https://github.com/user-attachments/assets/2c5b5a9a-e94c-45d6-8d09-ccb0dc954c7a" />

After:
<img width="979" height="258" alt="Bildschirmfoto 2026-01-20 um 16 49 30" src="https://github.com/user-attachments/assets/4d89c67e-7a59-4b42-abfe-d70305da0259" />


