### PR TITLE
Fix a syntax error in the `be_tinyMCE.html.twig` language setting

### DIFF
--- a/core-bundle/contao/templates/twig/be_tinyMCE.html.twig
+++ b/core-bundle/contao/templates/twig/be_tinyMCE.html.twig
@@ -3,7 +3,7 @@
         {
             const config = {
                 min_height: 336,
-                language: '{{ tinyMceLanguage|e('js') }}>',
+                language: '{{ tinyMceLanguage|e('js') }}',
                 element_format: 'html',
                 document_base_url: '{{ (app.request.schemeAndHttpHost ~ app.request.basePath ~ '/')|e('js') }}',
                 entities: '160,nbsp,60,lt,62,gt,173,shy',


### PR DESCRIPTION
This PR removes a left-over `>`, probably from the HTML5 -> Twig conversion, in the `be_tinyMCE.html.twig` template.