### PR TITLE
Fix the syntax in `news_short.html.twig` for the news archive ID CSS class

### DIFF
--- a/news-bundle/contao/templates/twig/news_short.html.twig
+++ b/news-bundle/contao/templates/twig/news_short.html.twig
@@ -1,4 +1,4 @@
-<div class="layout_short arc_<?= archive->id ?> block{{ class }}">
+<div class="layout_short arc_{{ archive.id }}  block{{ class }}">
 
     {% block info %}
         <p class="info"><time datetime="{{ datetime }}">{{ date }}</time> {{ author }}</p>


### PR DESCRIPTION
This was probably overlooked when converting the template from HTML5 to Twig.
I have also searched through all `.html.twig` templates and it seems like this is the only error like this, except #9276. 🙂