### PR TITLE
Add `|raw` to `recurring` in `event_full.html.twig` as it might contain HTML

### DIFF
--- a/calendar-bundle/contao/templates/twig/event_full.html.twig
+++ b/calendar-bundle/contao/templates/twig/event_full.html.twig
@@ -3,7 +3,7 @@
     <h1>{{ title }}</h1>
 
     {% if recurring %}
-        <p class="info recurring">{{ recurring }}</p>
+        <p class="info recurring">{{ recurring|raw }}</p>
     {% else %}
         <p class="info"><time datetime="{{ datetime }}">{{ date }}{% if time %} {{ time }}{% endif %}</time></p>
     {% endif %}


### PR DESCRIPTION
`recurring` might contain HTML, as `MSC.cal_repeat` has the date of the next occurrence wrapped in a `<time>` element. So `|raw` is required here, or else the escaped HTML will be output.