### PR TITLE
Check for `FORM_SUBMIT` in `ModuleLogin::generate()`

### DIFF
--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -71,7 +71,7 @@ class ModuleLogin extends Module
 
 		// If the form was submitted and the credentials were wrong, take the target
 		// path from the submitted data as otherwise it would take the current page
-		if ($request?->isMethod('POST') && 'tl_login_' . $this->id === $request->request->get('FORM_SUBMIT'))
+		if ($request?->isMethod('POST') && $request->request->get('FORM_SUBMIT') === 'tl_login_' . $this->id)
 		{
 			$this->targetPath = base64_decode($request->request->get('_target_path'));
 		}

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -71,7 +71,7 @@ class ModuleLogin extends Module
 
 		// If the form was submitted and the credentials were wrong, take the target
 		// path from the submitted data as otherwise it would take the current page
-		if ($request?->isMethod('POST'))
+		if ($request?->isMethod('POST') && 'tl_login_' . $this->id === $request->request->get('FORM_SUBMIT'))
 		{
 			$this->targetPath = base64_decode($request->request->get('_target_path'));
 		}


### PR DESCRIPTION
Same as #9284 for `ModuleLogin`. The `TypeError` actually does not occur here because we do not have

```php
declare(strict_types=1);
```

in our legacy classes. Nevertheless, it makes sense to add this check anyway, otherwise the logic for retrieving the target path will be wrong during a `POST` request that re-renders the same page (e.g. when a different form on the same page does not validate).