### PR TITLE
Return early in the `ModuleCustomnav::generate()` method if there are no pages

### DIFF
--- a/core-bundle/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/contao/modules/ModuleCustomnav.php
@@ -53,6 +53,15 @@ class ModuleCustomnav extends Module
 			return '';
 		}
 
+		// Get all active pages and also include root pages if the language is added to the URL (see #72)
+		$this->objPages = PageModel::findPublishedRegularByIds($this->pages, array('includeRoot'=>true));
+
+		// Return if there are no pages
+		if ($this->objPages === null)
+		{
+			return '';
+		}
+
 		$strBuffer = parent::generate();
 
 		return $this->Template->items ? $strBuffer : '';
@@ -67,15 +76,6 @@ class ModuleCustomnav extends Module
 
 		$items = array();
 
-		// Get all active pages and also include root pages if the language is added to the URL (see #72)
-		$objPages = PageModel::findPublishedRegularByIds($this->pages, array('includeRoot'=>true));
-
-		// Return if there are no pages
-		if ($objPages === null)
-		{
-			return;
-		}
-
 		$objTemplate = new FrontendTemplate($this->navigationTpl ?: 'nav_default');
 		$objTemplate->type = static::class;
 		$objTemplate->cssID = $this->cssID; // see #4897 and 6129
@@ -87,7 +87,7 @@ class ModuleCustomnav extends Module
 		$isMember = $security->isGranted('ROLE_MEMBER');
 		$urlGenerator = $container->get('contao.routing.content_url_generator');
 
-		foreach ($objPages as $objModel)
+		foreach ($this->objPages as $objModel)
 		{
 			$objModel->loadDetails();
 

--- a/core-bundle/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/contao/modules/ModuleCustomnav.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Model\Collection;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
@@ -25,9 +26,9 @@ class ModuleCustomnav extends Module
 	protected $strTemplate = 'mod_customnav';
 
 	/**
-	 * @var Model\Collection|null
+	 * @var Collection|null
 	 */
-	protected $objPages = null;
+	protected $objPages;
 
 	/**
 	 * Redirect to the selected page
@@ -92,7 +93,7 @@ class ModuleCustomnav extends Module
 		$isMember = $security->isGranted('ROLE_MEMBER');
 		$urlGenerator = $container->get('contao.routing.content_url_generator');
 
-		foreach ($this->objPages ?? [] as $objModel)
+		foreach ($this->objPages ?? array() as $objModel)
 		{
 			$objModel->loadDetails();
 

--- a/core-bundle/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/contao/modules/ModuleCustomnav.php
@@ -25,6 +25,11 @@ class ModuleCustomnav extends Module
 	protected $strTemplate = 'mod_customnav';
 
 	/**
+	 * @var Model\Collection|null
+	 */
+	protected $objPages = null;
+
+	/**
 	 * Redirect to the selected page
 	 *
 	 * @return string
@@ -87,7 +92,7 @@ class ModuleCustomnav extends Module
 		$isMember = $security->isGranted('ROLE_MEMBER');
 		$urlGenerator = $container->get('contao.routing.content_url_generator');
 
-		foreach ($this->objPages as $objModel)
+		foreach ($this->objPages ?? [] as $objModel)
 		{
 			$objModel->loadDetails();
 


### PR DESCRIPTION
1. Create a `customnav` module.
2. Select a page.
3. Unpublish the page.
4. Add the module to the front end.
5. Open the front end on the page where you added the module.

The following error will occur in `dev`:

<details>
<summary>Stack Trace</summary>

```
Twig\Error\RuntimeError:
Variable "request" does not exist in "@Contao_ContaoCoreBundle/mod_navigation.html.twig" at line 15.

  at vendor/contao/contao/core-bundle/contao/templates/twig/mod_navigation.html.twig:15
  at __TwigTemplate_480d796bb532acd1125ceacd2dcbc286->{closure:__TwigTemplate_480d796bb532acd1125ceacd2dcbc286::doDisplay():78}()
     (var\cache\dev\twig\7a\7ae31e20689cc0cc665123db40d8a522.php:78)
  at __TwigTemplate_480d796bb532acd1125ceacd2dcbc286->doDisplay(…
     (vendor\twig\twig\src\Template.php:402)
  at Twig\Template->yield(…
     (var\cache\dev\twig\3f\3fc4d31bc3fcc28bd4b2fab26ef6c073.php:50)
  at __TwigTemplate_d93319526404891d4b8f1025395b96bb->doDisplay(…
     (vendor\twig\twig\src\Template.php:402)
  at Twig\Template->yield(…
     (vendor\twig\twig\src\Template.php:358)
  at Twig\Template->display(…
     (vendor\twig\twig\src\Template.php:373)
  at Twig\Template->render(…
     (vendor\twig\twig\src\TemplateWrapper.php:51)
  at Twig\TemplateWrapper->render(…
     (vendor\twig\twig\src\Environment.php:333)
  at Twig\Environment->render('@Contao/mod_customnav.html.twig', …
     (vendor\contao\contao\core-bundle\contao\library\Contao\TemplateInheritance.php:394)
  at Contao\Template->renderTwigSurrogateIfExists()
     (vendor\contao\contao\core-bundle\contao\library\Contao\TemplateInheritance.php:83)
  at Contao\Template->inherit()
     (vendor\contao\contao\core-bundle\contao\library\Contao\Template.php:326)
  at Contao\Template->parse()
     (vendor\contao\contao\core-bundle\contao\classes\FrontendTemplate.php:43)
  at Contao\FrontendTemplate->parse()
     (vendor\contao\contao\core-bundle\contao\modules\Module.php:246)
  at Contao\Module->generate()
     (vendor\contao\contao\core-bundle\contao\modules\ModuleCustomnav.php:56)
  at Contao\ModuleCustomnav->generate()
     (vendor\contao\contao\core-bundle\contao\library\Contao\Controller.php:404)
  at Contao\Controller::getFrontendModule(object(ModuleModel), 'main')
     (vendor\contao\contao\core-bundle\contao\elements\ContentModule.php:59)
  at Contao\ContentModule->generate()
     (vendor\contao\contao\core-bundle\contao\library\Contao\Controller.php:622)
  at Contao\Controller::getContentElement(object(ContentModel), 'main')
     (vendor\contao\contao\core-bundle\contao\modules\ModuleArticle.php:205)
  at Contao\ModuleArticle->compile()
     (vendor\contao\contao\core-bundle\contao\modules\Module.php:215)
  at Contao\Module->generate()
     (vendor\contao\contao\core-bundle\contao\modules\ModuleArticle.php:71)
  at Contao\ModuleArticle->generate(false)
     (vendor\contao\contao\core-bundle\contao\library\Contao\Controller.php:497)
  at Contao\Controller::getArticle(object(ArticleModel), true, false, 'main', array())
     (vendor\contao\contao\core-bundle\contao\library\Contao\Controller.php:357)
  at Contao\Controller::getFrontendModule(0, 'main')
     (vendor\contao\contao\core-bundle\src\Framework\Adapter.php:38)
  at Contao\CoreBundle\Framework\Adapter->__call('getFrontendModule', array(0, 'main'))
     (vendor\contao\contao\core-bundle\src\Twig\Runtime\FragmentRuntime.php:40)
  at Contao\CoreBundle\Twig\Runtime\FragmentRuntime->renderModule(…
     (var\cache\dev\twig\51\51b211c02b610f04ff98bb955f0fdc09.php:103)
  at __TwigTemplate_41508cde0cdaa2a2ab794c1a1aee3700->block_element(…
     (vendor\twig\twig\src\Template.php:446)
  at Twig\Template->yieldBlock('element', …
     (var\cache\dev\twig\51\51b211c02b610f04ff98bb955f0fdc09.php:67)
  at __TwigTemplate_41508cde0cdaa2a2ab794c1a1aee3700->doDisplay(…
     (vendor\twig\twig\src\Template.php:402)
  at Twig\Template->yield(…
     (vendor\twig\twig\src\Template.php:358)
  at Twig\Template->display(…
     (vendor\twig\twig\src\Template.php:373)
  at Twig\Template->render(…
     (vendor\twig\twig\src\TemplateWrapper.php:51)
  at Twig\TemplateWrapper->render(…
     (vendor\twig\twig\src\Environment.php:333)
  at Twig\Environment->render('@Contao/page/_element_group.html.twig', …
     (vendor\symfony\framework-bundle\Controller\AbstractController.php:467)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->doRenderView('@Contao/page/_element_group.html.twig', null, …
     (vendor\symfony\framework-bundle\Controller\AbstractController.php:263)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->renderView('@Contao/page/_element_group.html.twig', …
     (vendor\contao\contao\core-bundle\src\Controller\Page\AbstractLayoutPageController.php:258)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->renderSlot('main', array(array('type' => 'frontend_module', 'id' => 35), array('type' => 'frontend_module', 'id' => 0)))
     (vendor\contao\contao\core-bundle\src\Controller\Page\AbstractLayoutPageController.php:183)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->{closure:Contao\CoreBundle\Controller\Page\AbstractLayoutPageController::addDefaultDataToTemplate():183}()
     (vendor\contao\contao\core-bundle\src\Controller\Page\AbstractLayoutPageController.php:191)
  at class@anonymousvendor\contao\contao\core-bundle\src\Controller\Page\AbstractLayoutPageController.php:183$9af3->__toString()
     (var\cache\dev\twig\eb\eb65a2ba8ebbef51c9737571edaf2e56.php:111)
  at __TwigTemplate_86689120d9eb40e5524203244bcb3f76->block_body_content(…
     (vendor\twig\twig\src\Template.php:446)
  at Twig\Template->yieldBlock('body_content', …
     (var\cache\dev\twig\4e\4e833ad86bc37e8a7973c0aee4ccb805.php:331)
  at __TwigTemplate_b30f86231f99302efb6c3ca6b27626aa->block_body(…
     (vendor\twig\twig\src\Template.php:446)
  at Twig\Template->yieldBlock('body', …
     (var\cache\dev\twig\4e\4e833ad86bc37e8a7973c0aee4ccb805.php:77)
  at __TwigTemplate_b30f86231f99302efb6c3ca6b27626aa->doDisplay(…
     (vendor\twig\twig\src\Template.php:402)
  at Twig\Template->yield(…
     (var\cache\dev\twig\eb\eb65a2ba8ebbef51c9737571edaf2e56.php:53)
  at __TwigTemplate_86689120d9eb40e5524203244bcb3f76->doDisplay(…
     (vendor\twig\twig\src\Template.php:402)
  at Twig\Template->yield(…
     (vendor\twig\twig\src\TemplateWrapper.php:38)
  at Twig\TemplateWrapper->stream(…
     (vendor\contao\contao\core-bundle\src\Twig\Defer\Renderer.php:24)
  at Contao\CoreBundle\Twig\Defer\Renderer->render('@Contao/page/layout.html.twig', …
     (vendor\contao\contao\core-bundle\src\Controller\Page\AbstractLayoutPageController.php:248)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->render('@Contao/page/layout.html.twig', …
     (vendor\contao\contao\core-bundle\src\Controller\Page\AbstractLayoutPageController.php:108)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->{closure:Contao\CoreBundle\Controller\Page\AbstractLayoutPageController::createTemplate():108}(object(LayoutTemplate), null)
     (vendor\contao\contao\core-bundle\src\Twig\LayoutTemplate.php:85)
  at Contao\CoreBundle\Twig\LayoutTemplate->getResponse()
     (vendor\contao\contao\core-bundle\src\Controller\Page\RegularPageController.php:24)
  at Contao\CoreBundle\Controller\Page\RegularPageController->getResponse(object(LayoutTemplate), object(LayoutModel), object(Request))
     (vendor\contao\contao\core-bundle\src\Controller\Page\AbstractLayoutPageController.php:65)
  at Contao\CoreBundle\Controller\Page\AbstractLayoutPageController->__invoke(object(Request))
     (vendor\contao\contao\core-bundle\contao\controllers\FrontendIndex.php:68)
  at Contao\FrontendIndex->renderPage(object(PageModel))
     (vendor\symfony\http-kernel\HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\http-kernel\HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\http-kernel\Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public\index.php:42)
```
</details>

This is because `ModuleCustomnav` has an early out in its `compile()` method:

https://github.com/contao/contao/blob/5c134580e4fa3c607385055cc98d216dcadc9671/core-bundle/contao/modules/ModuleCustomnav.php#L70-L77

Which means the template will still be rendered in full - but with all template data missing. This was not a problem for the `.html5` templates, since in the legacy templates, all template variables are inherently optional. But causes the aforementioned error in `dev` for the new Twig templates.

This PR moves the early out to the `generate()` method, so that the template will not be rendered at all in the first place.