### PR TITLE
Cast the column object in the legacy gallery to an array

### DIFF
--- a/core-bundle/contao/templates/twig/gallery_default.html.twig
+++ b/core-bundle/contao/templates/twig/gallery_default.html.twig
@@ -2,7 +2,7 @@
     {% for row in body %}
         {% for col in row %}
             {% if col.addImage %}
-                <li>{{ include('@Contao/image.html.twig', col) }}</li>
+                <li>{{ include('@Contao/image.html.twig', col|map(v => v)) }}</li>
             {% endif %}
         {% endfor %}
     {% endfor %}


### PR DESCRIPTION
### Description

This PR fixes an issue within the legacy content gallery when the twig surrogate (^5.7) is being used as rendering the image template within the gallery expects an array.
We do however provide an object / an anonymous class.

Reference:
https://github.com/contao/contao/blob/25e34c2d07ce2f33439597fccaadfacaa48a009b/core-bundle/contao/elements/ContentGallery.php#L259

(You can reproduce it by going back to the legacy template for the gallery)
```php
// contao/config/config.php
$GLOBALS['TL_CTE']['media']['gallery'] = \Contao\ContentGallery::class;
```