### PR TITLE
Check for the theme slug when rendering Twig surrogate templates

### DIFF
--- a/core-bundle/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/contao/library/Contao/TemplateInheritance.php
@@ -380,7 +380,7 @@ trait TemplateInheritance
 		$templateCandidate = "@Contao/$this->strTemplate.html.twig";
 		$loader = $container->get('contao.twig.filesystem_loader');
 
-		if (!$loader->exists($templateCandidate) || 'html5' === ContaoTwigUtil::getExtension($loader->getFirst($this->strTemplate)))
+		if (!$loader->exists($templateCandidate) || 'html5' === ContaoTwigUtil::getExtension($loader->getFirst($this->strTemplate, $loader->getCurrentThemeSlug())))
 		{
 			return null;
 		}


### PR DESCRIPTION
### Description

We introduced a twig surrogate template for each html5 template, this however breaks existing installations that may have templates within a theme subfolder (It will only render the template if it's within the root).

This PR fixes it by additionally checking for the theme slug (Solution from @m-vo)
