### PR TITLE
Do not pass the context when including Twig templates with specified data

### DIFF
--- a/core-bundle/contao/templates/twig/be_popup.html.twig
+++ b/core-bundle/contao/templates/twig/be_popup.html.twig
@@ -127,7 +127,7 @@
                         },
                         picture.img.width|default and picture.img.height|default,
                     ) }}>
-                        {{ include('@Contao/picture_default.html.twig', picture) }}
+                        {{ include('@Contao/picture_default.html.twig', picture, with_context: false) }}
                     </div>
                 {% endfor %}
             </div>

--- a/core-bundle/contao/templates/twig/be_popup.html.twig
+++ b/core-bundle/contao/templates/twig/be_popup.html.twig
@@ -127,7 +127,7 @@
                         },
                         picture.img.width|default and picture.img.height|default,
                     ) }}>
-                        {{ include('@Contao/picture_default.html.twig', picture, with_context: false) }}
+                        {{ include('@Contao/picture_default.html.twig', picture, false) }}
                     </div>
                 {% endfor %}
             </div>

--- a/core-bundle/contao/templates/twig/ce_download.html.twig
+++ b/core-bundle/contao/templates/twig/ce_download.html.twig
@@ -4,7 +4,7 @@
 
     {% if previews %}
         {% for preview in previews %}
-            {{ include('@Contao/image.html.twig', preview.getLegacyTemplateData(), with_context: false) }}
+            {{ include('@Contao/image.html.twig', preview.getLegacyTemplateData(), false) }}
         {% endfor %}
     {% endif %}
 

--- a/core-bundle/contao/templates/twig/ce_download.html.twig
+++ b/core-bundle/contao/templates/twig/ce_download.html.twig
@@ -4,7 +4,7 @@
 
     {% if previews %}
         {% for preview in previews %}
-            {{ include('@Contao/image.html.twig', preview.getLegacyTemplateData()) }}
+            {{ include('@Contao/image.html.twig', preview.getLegacyTemplateData(), with_context: false) }}
         {% endfor %}
     {% endif %}
 

--- a/core-bundle/contao/templates/twig/ce_downloads.html.twig
+++ b/core-bundle/contao/templates/twig/ce_downloads.html.twig
@@ -7,7 +7,7 @@
             <li class="download-element ext-{{ file.extension }}">
                 {% if file.previews %}
                     {% for preview in file.previews %}
-                        {{ include('@Contao/image.html.twig', preview.getLegacyTemplateData(), with_context: false) }}
+                        {{ include('@Contao/image.html.twig', preview.getLegacyTemplateData(), false) }}
                     {% endfor %}
                 {% endif %}
                 <a href="{{ file.href }}" title="{{ file.title|insert_tag }}" type="{{ file.mime }}">{{ file.link|insert_tag }} <span class="size">({{ file.filesize }})</span></a>

--- a/core-bundle/contao/templates/twig/ce_downloads.html.twig
+++ b/core-bundle/contao/templates/twig/ce_downloads.html.twig
@@ -7,7 +7,7 @@
             <li class="download-element ext-{{ file.extension }}">
                 {% if file.previews %}
                     {% for preview in file.previews %}
-                        {{ include('@Contao/image.html.twig', preview.getLegacyTemplateData()) }}
+                        {{ include('@Contao/image.html.twig', preview.getLegacyTemplateData(), with_context: false) }}
                     {% endfor %}
                 {% endif %}
                 <a href="{{ file.href }}" title="{{ file.title|insert_tag }}" type="{{ file.mime }}">{{ file.link|insert_tag }} <span class="size">({{ file.filesize }})</span></a>

--- a/core-bundle/contao/templates/twig/ce_hyperlink.html.twig
+++ b/core-bundle/contao/templates/twig/ce_hyperlink.html.twig
@@ -13,7 +13,7 @@
                 .mergeWith(target)
                 .mergeWith(rel)
             }}>
-                {{ include('@Contao/picture_default', picture, with_context: false) }}
+                {{ include('@Contao/picture_default', picture, false) }}
             </a>
             {{ embed_post|insert_tag_raw }}
             {% if caption|default %}

--- a/core-bundle/contao/templates/twig/ce_hyperlink.html.twig
+++ b/core-bundle/contao/templates/twig/ce_hyperlink.html.twig
@@ -13,7 +13,7 @@
                 .mergeWith(target)
                 .mergeWith(rel)
             }}>
-                {{ include('@Contao/picture_default', picture) }}
+                {{ include('@Contao/picture_default', picture, with_context: false) }}
             </a>
             {{ embed_post|insert_tag_raw }}
             {% if caption|default %}

--- a/core-bundle/contao/templates/twig/ce_vimeo.html.twig
+++ b/core-bundle/contao/templates/twig/ce_vimeo.html.twig
@@ -9,7 +9,7 @@
 
         {% if splashImage|default %}
             <a id="splashImage_{{ id }}" href="{{ src }}">
-                {{ include('@Contao/picture_default.html.twig', splashImage.picture, with_context: false) }}
+                {{ include('@Contao/picture_default.html.twig', splashImage.picture, false) }}
             </a>
             <script{{ attrs().setIfExists('nonce', csp_nonce('script-src')) }}>
                 document.getElementById('splashImage_{{ id|e('js') }}').addEventListener('click', function(e) {

--- a/core-bundle/contao/templates/twig/ce_vimeo.html.twig
+++ b/core-bundle/contao/templates/twig/ce_vimeo.html.twig
@@ -9,7 +9,7 @@
 
         {% if splashImage|default %}
             <a id="splashImage_{{ id }}" href="{{ src }}">
-                {{ include('@Contao/picture_default.html.twig', splashImage.picture) }}
+                {{ include('@Contao/picture_default.html.twig', splashImage.picture, with_context: false) }}
             </a>
             <script{{ attrs().setIfExists('nonce', csp_nonce('script-src')) }}>
                 document.getElementById('splashImage_{{ id|e('js') }}').addEventListener('click', function(e) {

--- a/core-bundle/contao/templates/twig/ce_youtube.html.twig
+++ b/core-bundle/contao/templates/twig/ce_youtube.html.twig
@@ -9,7 +9,7 @@
 
         {% if splashImage|default %}
             <a id="splashImage_{{ id }}" href="{{ src }}">
-                {{ include('@Contao/picture_default.html.twig', splashImage.picture, with_context: false) }}
+                {{ include('@Contao/picture_default.html.twig', splashImage.picture, false) }}
             </a>
             <script{{ attrs().setIfExists('nonce', csp_nonce('script-src')) }}>
                 document.getElementById('splashImage_{{ id|e('js') }}').addEventListener('click', function(e) {

--- a/core-bundle/contao/templates/twig/ce_youtube.html.twig
+++ b/core-bundle/contao/templates/twig/ce_youtube.html.twig
@@ -9,7 +9,7 @@
 
         {% if splashImage|default %}
             <a id="splashImage_{{ id }}" href="{{ src }}">
-                {{ include('@Contao/picture_default.html.twig', splashImage.picture) }}
+                {{ include('@Contao/picture_default.html.twig', splashImage.picture, with_context: false) }}
             </a>
             <script{{ attrs().setIfExists('nonce', csp_nonce('script-src')) }}>
                 document.getElementById('splashImage_{{ id|e('js') }}').addEventListener('click', function(e) {

--- a/core-bundle/contao/templates/twig/gallery_default.html.twig
+++ b/core-bundle/contao/templates/twig/gallery_default.html.twig
@@ -2,7 +2,7 @@
     {% for row in body %}
         {% for col in row %}
             {% if col.addImage %}
-                <li>{{ include('@Contao/image.html.twig', col|map(v => v)) }}</li>
+                <li>{{ include('@Contao/image.html.twig', col|map(v => v), with_context: false) }}</li>
             {% endif %}
         {% endfor %}
     {% endfor %}

--- a/core-bundle/contao/templates/twig/gallery_default.html.twig
+++ b/core-bundle/contao/templates/twig/gallery_default.html.twig
@@ -2,7 +2,7 @@
     {% for row in body %}
         {% for col in row %}
             {% if col.addImage %}
-                <li>{{ include('@Contao/image.html.twig', col|map(v => v), with_context: false) }}</li>
+                <li>{{ include('@Contao/image.html.twig', col|map(v => v), false) }}</li>
             {% endif %}
         {% endfor %}
     {% endfor %}

--- a/core-bundle/contao/templates/twig/image.html.twig
+++ b/core-bundle/contao/templates/twig/image.html.twig
@@ -7,7 +7,7 @@
         }}>
     {% endif %}
 
-    {{ include('@Contao/picture_default.html.twig', picture) }}
+    {{ include('@Contao/picture_default.html.twig', picture, with_context: false) }}
 
     {% if imageHref|default or href|default %}
         </a>

--- a/core-bundle/contao/templates/twig/image.html.twig
+++ b/core-bundle/contao/templates/twig/image.html.twig
@@ -7,7 +7,7 @@
         }}>
     {% endif %}
 
-    {{ include('@Contao/picture_default.html.twig', picture, with_context: false) }}
+    {{ include('@Contao/picture_default.html.twig', picture, false) }}
 
     {% if imageHref|default or href|default %}
         </a>

--- a/core-bundle/contao/templates/twig/search_default.html.twig
+++ b/core-bundle/contao/templates/twig/search_default.html.twig
@@ -1,7 +1,7 @@
 <div class="search_default">
 
     {% if hasImage %}
-        {{ include('@Contao/image.html.twig', image, with_context: false) }}
+        {{ include('@Contao/image.html.twig', image, false) }}
     {% endif %}
 
     <h3><a href="{{ href }}">{{ link }}</a></h3>

--- a/core-bundle/contao/templates/twig/search_default.html.twig
+++ b/core-bundle/contao/templates/twig/search_default.html.twig
@@ -1,7 +1,7 @@
 <div class="search_default">
 
     {% if hasImage %}
-        {{ include('@Contao/image.html.twig', image) }}
+        {{ include('@Contao/image.html.twig', image, with_context: false) }}
     {% endif %}
 
     <h3><a href="{{ href }}">{{ link }}</a></h3>

--- a/faq-bundle/contao/templates/twig/mod_faqpage.html.twig
+++ b/faq-bundle/contao/templates/twig/mod_faqpage.html.twig
@@ -16,7 +16,7 @@
                         {% endif %}
 
                         {% if faq.addImage %}
-                            {{ include('@Contao/image.html.twig', faq, with_context: false) }}
+                            {{ include('@Contao/image.html.twig', faq|map(v => v), with_context: false) }}
                         {% endif %}
 
                         {% if faq.addBefore %}

--- a/faq-bundle/contao/templates/twig/mod_faqpage.html.twig
+++ b/faq-bundle/contao/templates/twig/mod_faqpage.html.twig
@@ -16,7 +16,7 @@
                         {% endif %}
 
                         {% if faq.addImage %}
-                            {{ include('@Contao/image.html.twig', faq) }}
+                            {{ include('@Contao/image.html.twig', faq, with_context: false) }}
                         {% endif %}
 
                         {% if faq.addBefore %}

--- a/faq-bundle/contao/templates/twig/mod_faqpage.html.twig
+++ b/faq-bundle/contao/templates/twig/mod_faqpage.html.twig
@@ -16,7 +16,7 @@
                         {% endif %}
 
                         {% if faq.addImage %}
-                            {{ include('@Contao/image.html.twig', faq|map(v => v), with_context: false) }}
+                            {{ include('@Contao/image.html.twig', faq|map(v => v), false) }}
                         {% endif %}
 
                         {% if faq.addBefore %}


### PR DESCRIPTION
### Description

Whilst using the image legacy template, I noticed that some stylings were off, this was due to passing the whole context to t the picture_default template, thus rendering the `ce_image` class on the <img>:

<img width="522" height="138" alt="grafik" src="https://github.com/user-attachments/assets/23c1cbf3-9045-45a1-bde4-acbb6d0f9a44" />

This PR prevents passing the whole context.

_Unsure if this needs to be done in multiple places_ /cc @m-vo 