### PR TITLE
Handle null values for `cssClass` in the modern page layout

### DIFF
--- a/core-bundle/contao/templates/twig/page/layout.html.twig
+++ b/core-bundle/contao/templates/twig/page/layout.html.twig
@@ -48,7 +48,7 @@
     {# Defer outputting the body tag so that extensions can still adjust the page's cssClass #}
     {%- set body_attributes = attrs()
         .set('id', 'top')
-        .addClass(contao.page.cssClass)
+        .addClass(contao.page.cssClass|default)
         .mergeWith(body_attributes|default)
     -%}
     <body{{ body_attributes|default }}>


### PR DESCRIPTION
### Description

Handles cssClass being null.

Without this change, it tries to look for the isCssClass function within the twig global.