### PR TITLE
Skip tree trail items without read permission in breadcrumbs

### DIFF
--- a/core-bundle/tests/Fixtures/Functional/DcaUrlAnalyzer/default.yaml
+++ b/core-bundle/tests/Fixtures/Functional/DcaUrlAnalyzer/default.yaml
@@ -5,12 +5,23 @@ tl_page:
     - id: 2
       pid: 1
       type: regular
+    - id: 3
+      type: root
+      language: en
+    - id: 4
+      pid: 3
+      type: regular
 
 tl_article:
     - id: 1
       tstamp: 1234567890
-      pid: 1
+      pid: 2
       title: Article 1
+      inColumn: main
+    - id: 2
+      tstamp: 1234567890
+      pid: 4
+      title: Article 2
       inColumn: main
 
 tl_content:

--- a/core-bundle/tests/Functional/DcaUrlAnalyzerTest.php
+++ b/core-bundle/tests/Functional/DcaUrlAnalyzerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Functional;
 
 use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
+use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\System;
 use Contao\TestCase\FunctionalTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -178,7 +179,8 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             new class() implements AuthorizationCheckerInterface {
                 public function isGranted(mixed $attribute, mixed $subject = null): bool
                 {
-                    return true;
+                    // Deny read access to root page ID 3
+                    return !($subject instanceof ReadAction && 'tl_page' === $subject->getDataSource() && 3 === (int) $subject->getCurrentId());
                 }
             },
         );
@@ -212,6 +214,10 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
                         [
                             'url' => '/contao?do=article&table=tl_article&pn=1&rt=RT',
                             'label' => 'Edit page ID 1',
+                        ],
+                        [
+                            'url' => '/contao?do=article&table=tl_article&pn=2&rt=RT',
+                            'label' => 'Edit page ID 2',
                         ],
                     ],
                     'treeSiblings' => [
@@ -251,6 +257,10 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
                             'url' => '/contao?do=article&table=tl_article&pn=1&rt=RT',
                             'label' => 'Edit page ID 1',
                         ],
+                        [
+                            'url' => '/contao?do=article&table=tl_article&pn=2&rt=RT',
+                            'label' => 'Edit page ID 2',
+                        ],
                     ],
                     'treeSiblings' => [
                         [
@@ -275,6 +285,10 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
                             'url' => '/contao?do=article&table=tl_article&pn=1&rt=RT',
                             'label' => 'Edit page ID 1',
                         ],
+                        [
+                            'url' => '/contao?do=article&table=tl_article&pn=2&rt=RT',
+                            'label' => 'Edit page ID 2',
+                        ],
                     ],
                     'treeSiblings' => [
                         [
@@ -298,6 +312,10 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
                         [
                             'url' => '/contao?do=article&table=tl_article&pn=1&rt=RT',
                             'label' => 'Edit page ID 1',
+                        ],
+                        [
+                            'url' => '/contao?do=article&table=tl_article&pn=2&rt=RT',
+                            'label' => 'Edit page ID 2',
                         ],
                     ],
                     'treeSiblings' => [
@@ -324,6 +342,10 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
                             'url' => '/contao?do=article&table=tl_article&pn=1&rt=RT',
                             'label' => 'Edit page ID 1',
                         ],
+                        [
+                            'url' => '/contao?do=article&table=tl_article&pn=2&rt=RT',
+                            'label' => 'Edit page ID 2',
+                        ],
                     ],
                     'treeSiblings' => [
                         [
@@ -348,6 +370,10 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
                         [
                             'url' => '/contao?do=article&table=tl_article&pn=1&rt=RT',
                             'label' => 'Edit page ID 1',
+                        ],
+                        [
+                            'url' => '/contao?do=article&table=tl_article&pn=2&rt=RT',
+                            'label' => 'Edit page ID 2',
                         ],
                     ],
                     'treeSiblings' => [
@@ -374,6 +400,10 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
                             'url' => '/contao?do=article&table=tl_article&pn=1&rt=RT',
                             'label' => 'Edit page ID 1',
                         ],
+                        [
+                            'url' => '/contao?do=article&table=tl_article&pn=2&rt=RT',
+                            'label' => 'Edit page ID 2',
+                        ],
                     ],
                     'treeSiblings' => [
                         [
@@ -399,6 +429,10 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
                         [
                             'url' => '/contao?do=article&table=tl_article&pn=1&rt=RT',
                             'label' => 'Edit page ID 1',
+                        ],
+                        [
+                            'url' => '/contao?do=article&table=tl_article&pn=2&rt=RT',
+                            'label' => 'Edit page ID 2',
                         ],
                     ],
                     'treeSiblings' => [
@@ -437,6 +471,30 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
                 ['url' => '/contao?do=themes&table=tl_theme', 'label' => 'Themes', 'treeTrail' => null, 'treeSiblings' => null],
                 ['url' => '/contao?do=themes&id=1&table=tl_layout', 'label' => 'Default Theme', 'treeTrail' => null, 'treeSiblings' => null],
                 ['url' => '/contao?do=themes&id=1&table=tl_layout&act=edit', 'label' => 'Default Layout', 'treeTrail' => null, 'treeSiblings' => null],
+            ],
+        ];
+
+        yield [
+            'do=article&act=edit&id=2',
+            [
+                ['url' => '/contao?do=article&table=tl_article', 'label' => 'Articles', 'treeTrail' => null, 'treeSiblings' => null],
+                [
+                    'url' => '/contao?do=article&id=2&table=tl_article&act=edit',
+                    'label' => 'Article 2',
+                    'treeTrail' => [
+                        [
+                            'url' => '/contao?do=article&table=tl_article&pn=4&rt=RT',
+                            'label' => 'Edit page ID 4',
+                        ],
+                    ],
+                    'treeSiblings' => [
+                        [
+                            'url' => '/contao?do=article&id=2&table=tl_article&act=edit',
+                            'label' => 'Article 2',
+                            'active' => true,
+                        ],
+                    ],
+                ],
             ],
         ];
     }


### PR DESCRIPTION
Fixes #9296

If we do not have read access to a page in the tree trail we skip the rest of the tree and just show the trail we are allowed to access.