### PR TITLE
Re-add the database fields for the login content element

### DIFF
--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -791,20 +791,26 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'inputType'               => 'pageTree',
 			'foreignKey'              => 'tl_page.title',
 			'eval'                    => array('fieldType'=>'radio'),
+			'sql'                     => array('type'=>'integer', 'unsigned'=>true, 'default'=>0),
+			'relation'                => array('type'=>'hasOne', 'load'=>'lazy')
 		),
 		'redirectBack' => array
 		(
 			'inputType'               => 'checkbox',
+			'sql'                     => array('type'=>'boolean', 'default'=>false),
 		),
 		'autologin' => array
 		(
 			'inputType'               => 'checkbox',
+			'sql'                     => array('type'=>'boolean', 'default' =>false),
 		),
 		'pwResetPage' => array
 		(
 			'inputType'               => 'pageTree',
 			'foreignKey'              => 'tl_page.title',
 			'eval'                    => array('fieldType'=>'radio'),
+			'sql'                     => array('type'=>'integer', 'unsigned'=>true, 'default'=>0),
+			'relation'                => array('type'=>'hasOne', 'load'=>'lazy')
 		),
 		'cssID' => array
 		(


### PR DESCRIPTION
This reverts almost all of https://github.com/contao/contao/pull/9227 - I mistakenly thought we introduced the `LoginController` content element only in `5.7` - but it was actually already present in `5.6` (https://github.com/contao/contao/pull/8011).

Thus anyone who already uses the new content element will currently lose their settings for this content element when updating to Contao 5.7.

We could still move the data to the JSON later on - but only with a proper migration.