### PR TITLE
Allow READ access to the parent records of a page mount

### DIFF
--- a/core-bundle/src/Security/Voter/DataContainer/PagePermissionVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/PagePermissionVoter.php
@@ -34,8 +34,14 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 class PagePermissionVoter implements VoterInterface, CacheableVoterInterface, ResetInterface
 {
+    /**
+     * @var array<int, array<int>>
+     */
     private array $pagemountsCache = [];
 
+    /**
+     * @var array<int, array<int>>
+     */
     private array $pagemountTrailCache = [];
 
     /**

--- a/core-bundle/src/Security/Voter/DataContainer/PagePermissionVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/PagePermissionVoter.php
@@ -229,7 +229,7 @@ class PagePermissionVoter implements VoterInterface, CacheableVoterInterface, Re
             $trails[] = $database->getParentRecords($pageId, 'tl_page');
         }
 
-        return $this->pagemountTrailCache[$user->id] = array_map(intval(...), array_unique(array_merge($trails)));
+        return $this->pagemountTrailCache[$user->id] = array_map(intval(...), array_unique(array_merge(...$trails)));
     }
 
     private function getCurrentPageId(DeleteAction|ReadAction|UpdateAction $action): int

--- a/core-bundle/src/Security/Voter/DataContainer/PagePermissionVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/PagePermissionVoter.php
@@ -135,7 +135,7 @@ class PagePermissionVoter implements VoterInterface, CacheableVoterInterface, Re
         $pageId = $this->getCurrentPageId($action);
 
         return $this->canAccessPage($token, $pageId, false)
-            || \in_array($pageId, $this->getPagemountTrail($token), true);
+            || ('tl_page' === $action->getDataSource() && \in_array($pageId, $this->getPagemountTrail($token), true));
     }
 
     private function canUpdate(UpdateAction $action, TokenInterface $token): bool

--- a/core-bundle/tests/Security/Voter/DataContainer/PagePermissionVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/PagePermissionVoterTest.php
@@ -76,7 +76,7 @@ class PagePermissionVoterTest extends TestCase
     }
 
     #[DataProvider('voterProvider')]
-    public function testVoter(CreateAction|DeleteAction|ReadAction|UpdateAction $subject, array $decisions, bool $accessGranted, array|null $pagemounts = null): void
+    public function testVoter(CreateAction|DeleteAction|ReadAction|UpdateAction $subject, array $decisions, bool $accessGranted, array|null $pagemounts = null, array|null $pagemountTrail = null): void
     {
         array_unshift($decisions, [['ROLE_ADMIN'], null, false]);
 
@@ -89,7 +89,7 @@ class PagePermissionVoterTest extends TestCase
             },
         );
 
-        $framework = $this->mockContaoFrameworkWithDatabase($pagemounts);
+        $framework = $this->mockContaoFrameworkWithDatabase($pagemounts, $pagemountTrail);
 
         $decisionManager = $this->createMock(AccessDecisionManagerInterface::class);
         $decisionManager
@@ -540,12 +540,28 @@ class PagePermissionVoterTest extends TestCase
             true,
         ];
 
+        yield 'Can read trail page' => [
+            new ReadAction('tl_page', ['id' => 42]),
+            [
+                [[ContaoCorePermissions::USER_CAN_ACCESS_PAGE], 42, false],
+            ],
+            true,
+            [1, 2, 3],
+            [
+                [1, 'tl_page', [41]],
+                [2, 'tl_page', [42]],
+                [3, 'tl_page', [43]]
+            ],
+        ];
+
         yield 'Cannot read page' => [
             new ReadAction('tl_page', ['id' => 42]),
             [
                 [[ContaoCorePermissions::USER_CAN_ACCESS_PAGE], 42, false],
             ],
             false,
+            [1],
+            [[1, 'tl_page', [2]]]
         ];
 
         yield 'Can read article' => [
@@ -935,11 +951,11 @@ class PagePermissionVoterTest extends TestCase
         return $token;
     }
 
-    private function mockContaoFrameworkWithDatabase(array|null $pagemounts = null): ContaoFramework&Stub
+    private function mockContaoFrameworkWithDatabase(array|null $pagemounts = null, array|null $pagemountTrail = null): ContaoFramework&Stub
     {
         $database = $this->createMock(Database::class);
 
-        if (null === $pagemounts) {
+        if (null === $pagemounts || null !== $pagemountTrail) {
             $database
                 ->expects($this->never())
                 ->method('getChildRecords')
@@ -950,6 +966,19 @@ class PagePermissionVoterTest extends TestCase
                 ->method('getChildRecords')
                 ->with($pagemounts, 'tl_page', false, $pagemounts)
                 ->willReturn($pagemounts)
+            ;
+        }
+
+        if (null === $pagemountTrail) {
+            $database
+                ->expects($this->never())
+                ->method('getParentRecords')
+            ;
+        } else {
+            $database
+                ->expects($this->exactly(\count($pagemountTrail)))
+                ->method('getParentRecords')
+                ->willReturnMap($pagemountTrail)
             ;
         }
 

--- a/core-bundle/tests/Security/Voter/DataContainer/PagePermissionVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/PagePermissionVoterTest.php
@@ -550,7 +550,7 @@ class PagePermissionVoterTest extends TestCase
             [
                 [1, 'tl_page', [41]],
                 [2, 'tl_page', [42]],
-                [3, 'tl_page', [43]]
+                [3, 'tl_page', [43]],
             ],
         ];
 
@@ -561,7 +561,7 @@ class PagePermissionVoterTest extends TestCase
             ],
             false,
             [1],
-            [[1, 'tl_page', [2]]]
+            [[1, 'tl_page', [2]]],
         ];
 
         yield 'Can read article' => [


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/9335. Currently allows full READ access to the records. The voter cannot limit the allowed data. We could make the voter check that READ access is only given on `name` and `id` (for example), but then every service that votes would need to pass only this data to the `isGranted()` check.

This is currently also affected by https://github.com/contao/contao/issues/9347 – now the parent page appears in the trail with an edit link, even though the user does not have edit permissions.

<img width="470" height="171" alt="Bildschirmfoto 2026-02-04 um 08 51 27" src="https://github.com/user-attachments/assets/4a1b7157-7340-4039-8d0f-2372b4d991cd" />