### PR TITLE
Fix copying records with virtual fields

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -1084,12 +1084,18 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 			$objInsertStmt = null;
 
+			// Combine virtual fields
+			$this->set = System::getContainer()->get('contao.data_container.virtual_fields_handler')->combineFields($this->set, $this->strTable);
+
+			// Ensure JSON data type for virtual field targets when saving to database
+			$arrTypes = array_map(fn (string $k) => \in_array($k, DcaExtractor::getInstance($this->strTable)->getVirtualTargets()) ? Types::JSON : null, array_keys($this->set));
+
 			try
 			{
 				$objInsertStmt = Database::getInstance()
 					->prepare("INSERT INTO " . $this->strTable . " %s")
 					->set($this->set)
-					->execute();
+					->query('', array_values($this->set), array_values($arrTypes));
 			}
 			catch (UniqueConstraintViolationException $e)
 			{


### PR DESCRIPTION
If you copy a record with virtual field data, the following error might occur:

```
PDOException:
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'serverPagination' in 'INSERT INTO'

  at vendor\doctrine\dbal\src\Driver\PDO\Statement.php:55
  at PDOStatement->execute()
     (vendor\doctrine\dbal\src\Driver\PDO\Statement.php:55)
  at Doctrine\DBAL\Driver\PDO\Statement->execute()
     (vendor\doctrine\dbal\src\Driver\Middleware\AbstractStatementMiddleware.php:24)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute()
     (vendor\doctrine\dbal\src\Logging\Statement.php:46)
  at Doctrine\DBAL\Logging\Statement->execute()
     (vendor\doctrine\dbal\src\Driver\Middleware\AbstractStatementMiddleware.php:24)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute()
     (vendor\symfony\doctrine-bridge\Middleware\Debug\Statement.php:58)
  at Symfony\Bridge\Doctrine\Middleware\Debug\Statement->execute()
     (vendor\doctrine\dbal\src\Connection.php:802)
  at Doctrine\DBAL\Connection->executeQuery('INSERT INTO tl_content (`type`, `addImage`, `showPreview`, `inline`, `overwriteMeta`, `fullsize`, `thead`, `tfoot`, `tleft`, `sortable`, `closeSections`, `target`, `overwriteLink`, `useImage`, `useHomeDir`, `metaIgnore`, `splashImage`, `sliderContinuous`, `protected`, `invisible`, `com_moderate`, `com_bbcode`, `com_disableCaptcha`, `com_requireLogin`, `pid`, `ptable`, `sorting`, `tstamp`, `headline`, `sectionHeadline`, `text`, `singleSRC`, `alt`, `imageTitle`, `size`, `imageUrl`, `caption`, `floating`, `html`, `unfilteredHtml`, `listtype`, `listitems`, `tableitems`, `summary`, `sortIndex`, `sortOrder`, `mooHeadline`, `mooStyle`, `mooClasses`, `highlight`, `markdownSource`, `code`, `url`, `titleText`, `linkTitle`, `embed`, `rel`, `multiSRC`, `perRow`, `perPage`, `numberOfItems`, `sortBy`, `galleryTpl`, `customTpl`, `playerSRC`, `youtube`, `vimeo`, `posterSRC`, `playerSize`, `playerOptions`, `playerStart`, `playerStop`, `playerCaption`, `playerAspect`, `playerPreload`, `playerColor`, `youtubeOptions`, `vimeoOptions`, `sliderDelay`, `sliderSpeed`, `sliderStartSlide`, `data`, `cteAlias`, `articleAlias`, `article`, `form`, `module`, `groups`, `cssID`, `start`, `stop`, `com_order`, `com_perPage`, `com_template`, `playerTitle`, `textTrackSRC`, `title`, `jumpTo`, `redirectBack`, `autologin`, `pwResetPage`, `serverPagination`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', array('gallery', 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '6', 'tl_article', 176, 0, 'a:2:{s:4:"unit";s:2:"h2";s:5:"value";s:0:"";}', 'a:2:{s:5:"value";s:0:"";s:4:"unit";s:2:"h2";}', '<p>Test 2</p><p>Lorem Ipsum dolor.</p>', binary string, null, null, 'a:3:{i:0;s:0:"";i:1;s:0:"";i:2;s:0:"";}', null, null, 'above', null, null, '', null, null, '', 0, 'ascending', '', '', '', '', 'sourceText', null, null, '', '', '', '', binary string, 4, 0, 0, 'custom', '', '', null, '', '', null, '', null, '', '', '', '', '', '', null, null, 0, 300, 0, null, 0, 0, 0, 0, 0, null, 'a:2:{i:0;s:0:"";i:1;s:0:"";}', '', '', 'ascending', 0, '', '', null, '', 0, 0, 0, 0, '1'), array(object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType), object(ParameterType)))
     (vendor\contao\contao\core-bundle\contao\library\Contao\Database\Statement.php:268)
  at Contao\Database\Statement->query('', array('gallery', 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '6', 'tl_article', 176, 0, 'a:2:{s:4:"unit";s:2:"h2";s:5:"value";s:0:"";}', 'a:2:{s:5:"value";s:0:"";s:4:"unit";s:2:"h2";}', '<p>Test 2</p><p>Lorem Ipsum dolor.</p>', binary string, null, null, 'a:3:{i:0;s:0:"";i:1;s:0:"";i:2;s:0:"";}', null, null, 'above', null, null, '', null, null, '', 0, 'ascending', '', '', '', '', 'sourceText', null, null, '', '', '', '', binary string, 4, 0, 0, 'custom', '', '', null, '', '', null, '', null, '', '', '', '', '', '', null, null, 0, 300, 0, null, 0, 0, 0, 0, 0, null, 'a:2:{i:0;s:0:"";i:1;s:0:"";}', '', '', 'ascending', 0, '', '', null, '', 0, 0, 0, 0, '1'))
     (vendor\contao\contao\core-bundle\contao\library\Contao\Database\Statement.php:219)
  at Contao\Database\Statement->execute()
     (vendor\contao\contao\core-bundle\contao\drivers\DC_Table.php:1092)
  at Contao\DC_Table->copy()
     (vendor\contao\contao\core-bundle\contao\classes\Backend.php:459)
  at Contao\Backend->getBackendModule('article', null)
     (vendor\contao\contao\core-bundle\contao\controllers\BackendMain.php:143)
  at Contao\BackendMain->run()
     (vendor\contao\contao\core-bundle\src\Controller\Backend\BackendController.php:45)
  at Contao\CoreBundle\Controller\Backend\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\http-kernel\HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\http-kernel\Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public\index.php:42) 
```