### PR TITLE
Filter empty entries during validation for multi-file upload fields

### DIFF
--- a/core-bundle/contao/forms/FormUpload.php
+++ b/core-bundle/contao/forms/FormUpload.php
@@ -116,7 +116,7 @@ class FormUpload extends Widget implements UploadableWidgetInterface
 	public function validate()
 	{
 		// No file specified
-		if (!isset($_FILES[$this->strName]) || empty($_FILES[$this->strName]['name']))
+		if (!isset($_FILES[$this->strName]) || (\is_array($_FILES[$this->strName]['name']) ? empty(array_filter($_FILES[$this->strName]['name'])) : empty($_FILES[$this->strName]['name'])))
 		{
 			if ($this->mandatory)
 			{
@@ -135,7 +135,7 @@ class FormUpload extends Widget implements UploadableWidgetInterface
 
 		$files = $_FILES[$this->strName];
 		$uploadedFiles = array();
-		$fileCount = \is_array($files['name']) ? \count($files['name']) : 1;
+		$fileCount = \is_array($files['name']) ? \count(array_filter($files['name'])) : 1;
 		$maxlength_kb = $this->getMaximumUploadSize();
 		$maxlength_kb_readable = $this->getReadableSize($maxlength_kb);
 

--- a/core-bundle/contao/forms/FormUpload.php
+++ b/core-bundle/contao/forms/FormUpload.php
@@ -116,7 +116,7 @@ class FormUpload extends Widget implements UploadableWidgetInterface
 	public function validate()
 	{
 		// No file specified
-		if (!isset($_FILES[$this->strName]) || (\is_array($_FILES[$this->strName]['name']) ? empty(array_filter($_FILES[$this->strName]['name'])) : empty($_FILES[$this->strName]['name'])))
+		if (!isset($_FILES[$this->strName]) || empty(array_filter((array) $_FILES[$this->strName]['name'])))
 		{
 			if ($this->mandatory)
 			{
@@ -135,7 +135,7 @@ class FormUpload extends Widget implements UploadableWidgetInterface
 
 		$files = $_FILES[$this->strName];
 		$uploadedFiles = array();
-		$fileCount = \is_array($files['name']) ? \count(array_filter($files['name'])) : 1;
+		$fileCount = \count(array_filter((array) $files['name']));
 		$maxlength_kb = $this->getMaximumUploadSize();
 		$maxlength_kb_readable = $this->getReadableSize($maxlength_kb);
 


### PR DESCRIPTION
Fixes #9370 

Before checking if the `name` array of `$_FILES` is empty, it has to be passed through `array_filter` to remove empty entries, which are present if no files are selected and the field is not mandatory.