### PR TITLE
Do not always add the `multiple` attribute to the upload field

### DIFF
--- a/core-bundle/contao/templates/twig/form_upload.html.twig
+++ b/core-bundle/contao/templates/twig/form_upload.html.twig
@@ -24,7 +24,7 @@
         .addClass('upload')
         .addClass(this.class|default)
         .set('aria-describedby', "help_ctrl_#{this.id}", this.help|default)
-        .set('multiple', this.multipleFiles|default)
+        .set('multiple', true, this.multipleFiles|default)
         .mergeWith(getAttributes.invoke())
     }}>
 


### PR DESCRIPTION
Stumbled upon this while debugging #9370.
The multiple attribute is always added to the `<input>` if the Twig template for form_upload is used as, when multipleFiles is not enabled, `this.multipleFiles|default` equals an empty string, which seems to be enough for the attribute to be added. Explicitly setting `true` when `this.multipleFiles|default` is truthy solves the problem.