### PR TITLE
Normalize the layout template

### DIFF
--- a/core-bundle/contao/templates/twig/page/layout.html.twig
+++ b/core-bundle/contao/templates/twig/page/layout.html.twig
@@ -25,14 +25,16 @@
              <title>{{ title }}</title>
         {%- endblock -%}
 
-        <meta name="robots" content="{{ response_context.head.metaRobots }}">
-        <meta name="description" content="{{ response_context.head.metaDescription|u.truncate(320, '…') }}">
-        {% for meta_tag in response_context.head.metaTags %}
-            <meta{{ meta_tag }}>
-        {% endfor %}
+        {% if response_context.head %}
+            <meta name="robots" content="{{ response_context.head.metaRobots }}">
+            <meta name="description" content="{{ response_context.head.metaDescription|u.truncate(320, '…') }}">
+            {% for meta_tag in response_context.head.metaTags %}
+                <meta{{ meta_tag }}>
+            {% endfor %}
 
-        {% if page['enableCanonical'] -%}
-            <link rel="canonical" href="{{ response_context.head.canonicalUriForRequest(app.request) }}">
+            {% if page['enableCanonical'] %}
+                <link rel="canonical" href="{{ response_context.head.canonicalUriForRequest(app.request)|default }}">
+            {% endif %}
         {% endif %}
 
         {%- block end_of_head -%}

--- a/core-bundle/contao/templates/twig/page/layout.html.twig
+++ b/core-bundle/contao/templates/twig/page/layout.html.twig
@@ -17,13 +17,13 @@
 
     {# Defer accessing the response context, so that elements coming after it can still affect it. #}
     {% defer %}
-        {%- block title %}
+        {% block title %}
             {% set title = response_context.head.title|default %}
             {% if title and contao.page.rootPageTitle|default %}
                 {% set title = title ~ ' - ' ~ contao.page.rootPageTitle %}
             {% endif %}
              <title>{{ title }}</title>
-        {%- endblock -%}
+        {% endblock %}
 
         {% if response_context.head %}
             <meta name="robots" content="{{ response_context.head.metaRobots }}">
@@ -37,24 +37,24 @@
             {% endif %}
         {% endif %}
 
-        {%- block end_of_head -%}
-            {% for element in response_context.end_of_head %}
+        {% block end_of_head %}
+            {% for element in response_context.end_of_head|default %}
                 {{ element|raw }}
             {% endfor %}
-        {%- endblock -%}
+        {% endblock %}
     {% enddefer %}
-{%- endblock -%}
+{% endblock %}
 </head>
 
-{%- defer %}
+{% defer %}
     {# Defer outputting the body tag so that extensions can still adjust the page's cssClass #}
-    {%- set body_attributes = attrs()
+    {% set body_attributes = attrs()
         .set('id', 'top')
         .addClass(contao.page.cssClass|default)
         .mergeWith(body_attributes|default)
-    -%}
+    %}
     <body{{ body_attributes|default }}>
-{% enddefer -%}
+{% enddefer %}
 {% block body %}
     {% block body_content %}
         {% slot header %}
@@ -73,7 +73,7 @@
     {# Access the response context inside a "defer" block, so that elements coming after it can still affect it. #}
     {% defer %}
         {% block end_of_body %}
-            {% for element in response_context.end_of_body %}
+            {% for element in response_context.end_of_body|default %}
                 {{ element|raw }}
             {% endfor %}
 


### PR DESCRIPTION
This PR normalizes the `page/layout` template by doing two things:

1) I removed all white-space control (`{%-`/`-%}`) where not technically necessary (we keep it before the `<!DOCTYPE …>` statement). Keeping it consistent, especially when overwriting blocks, would otherwise be unnecessarily complex and have no real benefit.

2) Setting a response context is optional in the `ContentCompositionBuilder`. If not set, the delegate `response_context` object, that is assigned to the layout template, will contain no data. I made access to these optional in the template as well, so that the default template is compatible with the minimal setup:

    ```php
    public function __invoke(PageModel $page): Response 
    {
        return $this->contentComposition
          ->createContentCompositionBuilder($page)
          ->buildLayoutTemplate()
          ->getResponse()
        ;
    }
      ```

Changes can probably more easily be reviewed by looking at the individual commits.