### PR TITLE
Do not show an error for unexpected subsequent migrations

### DIFF
--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -283,6 +283,10 @@ class MigrateCommand extends Command
                         }
                     }
                 }
+
+                if (!$asJson) {
+                    $this->io->success("Executed $count migrations.");
+                }
             } catch (UnexpectedPendingMigrationException $exception) {
                 if ($asJson) {
                     $this->writeNdjson('migration-result', [
@@ -290,12 +294,9 @@ class MigrateCommand extends Command
                         'isSuccessful' => false,
                     ]);
                 } else {
-                    $this->io->error($exception->getMessage());
+                    $this->io->success("Executed $count migrations.");
+                    $this->io->error("{$exception->getMessage()}\nRestarting migration process...");
                 }
-            }
-
-            if (!$asJson) {
-                $this->io->success('Executed '.$count.' migrations.');
             }
 
             if (null !== $specifiedHash) {

--- a/core-bundle/src/Migration/MigrationCollection.php
+++ b/core-bundle/src/Migration/MigrationCollection.php
@@ -67,11 +67,17 @@ class MigrationCollection
 
         foreach ($this->getPending() as $migration) {
             if (null !== $pendingNames) {
+                if (!$pendingNames) {
+                    // If no more migrations are pending we return without an exception as new
+                    // migrations will be discovered in the next execution of the migration process.
+                    return;
+                }
+
                 $expected = array_shift($pendingNames);
                 $actual = $migration->getName();
 
                 if ($expected !== $actual) {
-                    throw new UnexpectedPendingMigrationException(\sprintf('Expected %s got "%s".', $expected ? "\"$expected\"" : 'no migration', $actual));
+                    throw new UnexpectedPendingMigrationException(\sprintf('Expected "%s" got "%s".', $expected, $actual));
                 }
             }
 

--- a/core-bundle/tests/Migration/MigrationCollectionTest.php
+++ b/core-bundle/tests/Migration/MigrationCollectionTest.php
@@ -66,18 +66,22 @@ class MigrationCollectionTest extends TestCase
     /**
      * @dataProvider getUnexpectedPendingMigrations
      */
-    public function testRunMigrationsUnexpectedPending(array $pendingNames, string $expectedExceptionMessage): void
+    public function testRunMigrationsUnexpectedPending(array $pendingNames, string|null $expectedExceptionMessage): void
     {
         $migrations = new MigrationCollection($this->getMigrationServices());
 
-        $this->expectException(UnexpectedPendingMigrationException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
+        if (null !== $expectedExceptionMessage) {
+            $this->expectException(UnexpectedPendingMigrationException::class);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
 
         $results = $migrations->run($pendingNames);
 
         if ($results instanceof \Traversable) {
             iterator_to_array($results);
         }
+
+        $this->assertNull($expectedExceptionMessage);
     }
 
     public static function getUnexpectedPendingMigrations(): iterable
@@ -89,7 +93,7 @@ class MigrationCollectionTest extends TestCase
 
         yield [
             ['Successful Migration'],
-            'Expected no migration got "Failing Migration".',
+            null,
         ];
 
         yield [
@@ -100,6 +104,11 @@ class MigrationCollectionTest extends TestCase
         yield [
             ['Successful Migration', 'Different Migration'],
             'Expected "Different Migration" got "Failing Migration".',
+        ];
+
+        yield [
+            [],
+            null,
         ];
     }
 


### PR DESCRIPTION
Fixes an issue if new migrations are discovered after the expected ones are finished. This case does not show an error anymore.

For the error case the output got improved. The number of executed migrations is now printed first, before the error message.

Artificial example that does now longer show an error: 
<img width="679" height="576" alt="Bildschirmfoto 2026-02-11 um 15 17 25" src="https://github.com/user-attachments/assets/88cd18bd-b56d-4c46-afc7-4459ebc953ef" />

Artificial example still showing an error: 
<img width="635" height="734" alt="Bildschirmfoto 2026-02-11 um 15 15 47" src="https://github.com/user-attachments/assets/001770a7-554c-4db8-859a-0e9dea4ab894" />
