### PR TITLE
Use double-quoted strings for the Twig string interpolation

### DIFF
--- a/core-bundle/contao/templates/twig/backend/widget/key_value_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/key_value_wizard.html.twig
@@ -31,7 +31,7 @@
                     {% set key_attributes = attrs()
                         .set('type', 'text')
                         .set('name', "#{id}[#{loop.index0}][key]")
-                        .set('id', '#{id}_key_#{loop.index0}')
+                        .set('id', "#{id}_key_#{loop.index0}")
                         .set('value', row.key|default)
                         .addClass('tl_text')
                     %}
@@ -41,7 +41,7 @@
                     {% set value_attributes = attrs()
                         .set('type', 'text')
                         .set('name', "#{id}[#{loop.index0}][value]")
-                        .set('id', '#{id}_value_#{loop.index0}')
+                        .set('id', "#{id}_value_#{loop.index0}")
                         .set('value', row.value|default)
                         .addClass('tl_text')
                     %}

--- a/core-bundle/contao/templates/twig/backend/widget/option_wizard.html.twig
+++ b/core-bundle/contao/templates/twig/backend/widget/option_wizard.html.twig
@@ -33,7 +33,7 @@
                     {% set value_attributes = attrs()
                         .set('type', 'text')
                         .set('name', "#{id}[#{loop.index0}][value]")
-                        .set('id', '#{id}_value_#{loop.index0}')
+                        .set('id', "#{id}_value_#{loop.index0}")
                         .set('value', row.value|default)
                         .addClass('tl_text')
                     %}
@@ -43,7 +43,7 @@
                     {% set label_attributes = attrs()
                         .set('type', 'text')
                         .set('name', "#{id}[#{loop.index0}][label]")
-                        .set('id', '#{id}_label_#{loop.index0}')
+                        .set('id', "#{id}_label_#{loop.index0}")
                         .set('value', row.label|default)
                         .addClass('tl_text')
                     %}


### PR DESCRIPTION
### Description

Very minor issue that I noticed whilst working on #9367. As far as I checked, there were no other noticeable occurences.

<img width="389" height="204" alt="grafik" src="https://github.com/user-attachments/assets/546f233b-1aa2-4d79-a4a9-6d72ce179127" />



See https://twig.symfony.com/doc/3.x/templates.html#string-interpolation for reference.