### PR TITLE
Support using the asset component with VFS storages

### DIFF
--- a/core-bundle/src/Asset/Package/VirtualFilesystemStoragePackage.php
+++ b/core-bundle/src/Asset/Package/VirtualFilesystemStoragePackage.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Asset\Package;
+
+use Contao\CoreBundle\Filesystem\VirtualFilesystem;
+use Symfony\Component\Asset\PackageInterface;
+
+class VirtualFilesystemStoragePackage implements PackageInterface
+{
+    public function __construct(private readonly VirtualFilesystem $storage)
+    {
+    }
+
+    public function getVersion(string $path): string
+    {
+        // TODO: Once we have native checksum support (see #7630), we could use that for 
+        // the version hashes on and/or to directly generate the public URIs including
+        // the checksum/version hash.
+        return hash('xxh3', (string) $this->storage->getLastModified($path));
+    }
+
+    public function getUrl(string $path): string
+    {
+        return $this->storage
+            ->generatePublicUri($path)
+            ?->withQuery('v='.$this->getVersion($path))
+            ->__toString() ?? $path
+        ;
+    }
+}

--- a/core-bundle/src/Asset/Package/VirtualFilesystemStoragePackage.php
+++ b/core-bundle/src/Asset/Package/VirtualFilesystemStoragePackage.php
@@ -31,10 +31,10 @@ class VirtualFilesystemStoragePackage implements PackageInterface
 
     public function getUrl(string $path): string
     {
-        return $this->storage
-            ->generatePublicUri($path)
-            ?->withQuery('v='.$this->getVersion($path))
-            ->__toString() ?? $path
-        ;
+        if ($uri = $this->storage->generatePublicUri($path)) {
+            return (string) $uri->withQuery('v='.$this->getVersion($path));
+        }
+
+        return $path;
     }
 }

--- a/core-bundle/src/Asset/Package/VirtualFilesystemStoragePackage.php
+++ b/core-bundle/src/Asset/Package/VirtualFilesystemStoragePackage.php
@@ -23,7 +23,7 @@ class VirtualFilesystemStoragePackage implements PackageInterface
 
     public function getVersion(string $path): string
     {
-        // TODO: Once we have native checksum support (see #7630), we could use that for 
+        // TODO: Once we have native checksum support (see #7630), we could use that for
         // the version hashes on and/or to directly generate the public URIs including
         // the checksum/version hash.
         return hash('xxh3', (string) $this->storage->getLastModified($path));

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -229,23 +229,24 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
 
     public function configureFilesystem(FilesystemConfiguration $config): void
     {
-        // User uploads
-        $filesStorageName = 'files';
-
         // TODO: Deprecate the "contao.upload_path" config key. In the next major
         // version, $uploadPath can then be replaced with "files" and the redundant
         // "files" attribute removed when mounting the local adapter.
         $uploadPath = $config->getContainer()->getParameterBag()->resolveValue('%contao.upload_path%');
 
+        // User uploads
         $config
             ->mountLocalAdapter($uploadPath, $uploadPath, 'files')
-            ->addVirtualFilesystem($filesStorageName, $uploadPath)
+            ->addVirtualFilesystem($filesStorageName = 'files', $uploadPath)
         ;
 
         $config
             ->addDefaultDbafs($filesStorageName, 'tl_files')
             ->addMethodCall('setDatabasePathPrefix', [$uploadPath]) // Backwards compatibility
         ;
+
+        $config->addVirtualFilesystem($readonlyFilesStorageName = "$filesStorageName#readonly", $uploadPath, true);
+        $config->addAssetPackage($readonlyFilesStorageName, $filesStorageName);
 
         // Backups
         $config

--- a/core-bundle/tests/Asset/Package/VirtualFilesystemStoragePackageTest.php
+++ b/core-bundle/tests/Asset/Package/VirtualFilesystemStoragePackageTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Asset\Package;
+
+use Contao\CoreBundle\Asset\Package\VirtualFilesystemStoragePackage;
+use Contao\CoreBundle\Filesystem\VirtualFilesystem;
+use Contao\CoreBundle\Tests\TestCase;
+use Nyholm\Psr7\Uri;
+
+class VirtualFilesystemStoragePackageTest extends TestCase
+{
+    public function testGetVersion(): void
+    {
+        $package = $this->getPackage();
+
+        $this->assertSame(
+            '62e29b4cad9e2ef6',
+            $package->getVersion('some/path'),
+        );
+    }
+
+    public function testGetUrl(): void
+    {
+        $package = $this->getPackage();
+
+        $this->assertSame(
+            'https://base-url/some/path?v=62e29b4cad9e2ef6',
+            $package->getUrl('some/path'),
+        );
+    }
+
+    private function getPackage(): VirtualFilesystemStoragePackage
+    {
+        $storage = $this->createStub(VirtualFilesystem::class);
+        $storage
+            ->method('getLastModified')
+            ->with('some/path')
+            ->willReturn(12345678)
+        ;
+
+        $storage
+            ->method('generatePublicUri')
+            ->with('some/path')
+            ->willReturn(new Uri('https://base-url/some/path'))
+        ;
+
+        return new VirtualFilesystemStoragePackage($storage);
+    }
+}

--- a/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
@@ -268,8 +268,8 @@ class FilesystemConfigurationTest extends TestCase
         $config->addVirtualFilesystem('foo', 'some/prefix');
 
         $definition = $config->addAssetPackage('foo');
-
         $this->assertTrue($container->hasDefinition('contao.assets.package.vfs.foo'));
+
         $package = $container->getDefinition('contao.assets.package.vfs.foo');
         $this->assertSame(VirtualFilesystemStoragePackage::class, $package->getClass());
         $this->assertSame('contao.filesystem.virtual.foo', (string) $package->getArgument(0));

--- a/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\DependencyInjection\Filesystem;
 
+use Contao\CoreBundle\Asset\Package\VirtualFilesystemStoragePackage;
 use Contao\CoreBundle\DependencyInjection\Filesystem\FilesystemConfiguration;
 use Contao\CoreBundle\Filesystem\Dbafs\Dbafs;
 use Contao\CoreBundle\Filesystem\Dbafs\DbafsManager;
@@ -257,6 +258,23 @@ class FilesystemConfigurationTest extends TestCase
         $this->expectExceptionMessage('A virtual filesystem with the name "foo" does not exist.');
 
         $config->addDefaultDbafs('foo', 'tl_foo');
+    }
+
+    public function testAddAssetPackage(): void
+    {
+        $container = $this->getContainerBuilder();
+
+        $config = new FilesystemConfiguration($container);
+        $config->addVirtualFilesystem('foo', 'some/prefix');
+
+        $definition = $config->addAssetPackage('foo');
+
+        $this->assertTrue($container->hasDefinition('contao.assets.package.vfs.foo'));
+        $package = $container->getDefinition('contao.assets.package.vfs.foo');
+        $this->assertSame(VirtualFilesystemStoragePackage::class, $package->getClass());
+        $this->assertSame('contao.filesystem.virtual.foo', (string) $package->getArgument(0));
+        $this->assertTrue($definition->hasTag('assets.package'));
+        $this->assertSame('contao_vfs.foo', $definition->getTag('assets.package')[0]['package']);
     }
 
     private function getContainerBuilder(array $parameters = []): ContainerBuilder


### PR DESCRIPTION
Alternative to #9383 

This PR adds a service for VFS asset packages. By default we supply the `contao_vfs.files` package serving a readonly version of the `files` VFS storage.

Usage looks like this:

```twig
{% extends '@Contao/page/layout.html.twig' %}

{% block head %}
    {{ parent() }}
    <link rel="stylesheet" href="{{ asset('foo/bar.css', 'contao_vfs.files') }}">
    <script src="{{ asset('foo/bar.js', 'contao_vfs.files') }}"></script>
{% endblock %}
```

And it would output something like this (if public URIs can be generated):
```html
<link rel="stylesheet" href="https://127.0.0.1:8000/files/foo.css?v=a997c0980df043b9">
<script src="https://127.0.0.1:8000/files/foo.js?v=5f577b3cf143a584"></script>
```

Most of the PR is convenience setup in the `FilesystemConfiguration` class, that now has a `addAssetPackage()`, which makes it easily usable for others that want to make VFS available as assets. See the `ContaoExtension` code for the usage.

