### PR TITLE
Purge `tl_cron_job` records older than 1 year

### DIFF
--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -172,7 +172,7 @@ class Cron
             }
 
             $entityManager->flush();
-            $repository->purgeOldRecords();
+            $repository->purgeOldRecords(array_map(static fn (CronJob $cronJob): string => $cronJob->getName(), $cronJobs));
         } finally {
             $repository->unlockTable();
         }

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -172,6 +172,7 @@ class Cron
             }
 
             $entityManager->flush();
+            $repository->purgeOldRecords();
         } finally {
             $repository->unlockTable();
         }

--- a/core-bundle/src/Repository/CronJobRepository.php
+++ b/core-bundle/src/Repository/CronJobRepository.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Repository;
 
 use Contao\CoreBundle\Entity\CronJob;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\DBAL\Types\Types;
@@ -82,15 +83,18 @@ class CronJobRepository extends ServiceEntityRepository
         $qb
             ->delete()
             ->where('c.lastRun < :date')
+            // Use a grace period of 1 month, so that a yearly cronjob is not deleted immediately
+            ->setParameter('date', new \DateTimeImmutable('-1 year -1 month'))
         ;
 
         if ($keepByName) {
-            $qb->andWhere($qb->expr()->notIn('c.name', $keepByName));
+            $qb
+                ->andWhere($qb->expr()->notIn('c.name', ':keepByName'))
+                ->setParameter('keepByName', $keepByName, ArrayParameterType::STRING)
+            ;
         }
 
         $qb
-            // Use a grace period of 1 month, so that a yearly cronjob is not deleted immediately
-            ->setParameter('date', new \DateTime('-1 year -1 month'))
             ->getQuery()
             ->execute()
         ;

--- a/core-bundle/src/Repository/CronJobRepository.php
+++ b/core-bundle/src/Repository/CronJobRepository.php
@@ -94,9 +94,6 @@ class CronJobRepository extends ServiceEntityRepository
             ;
         }
 
-        $qb
-            ->getQuery()
-            ->execute()
-        ;
+        $qb->getQuery()->execute();
     }
 }

--- a/core-bundle/src/Repository/CronJobRepository.php
+++ b/core-bundle/src/Repository/CronJobRepository.php
@@ -70,4 +70,19 @@ class CronJobRepository extends ServiceEntityRepository
     {
         $this->connection->executeStatement('UNLOCK TABLES');
     }
+
+    /**
+     * Purges cron job entries where lastRun is older than 1 year.
+     */
+    public function purgeOldRecords(): void
+    {
+        $this->createQueryBuilder('c')
+            ->delete()
+            ->where('c.lastRun < :date')
+            // Use a grace period of 1 day, so that a yearly cronjob is not deleted immediately
+            ->setParameter('date', new \DateTime('-1 year -1 day'))
+            ->getQuery()
+            ->execute()
+        ;
+    }
 }

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -132,6 +132,11 @@ class CronTest extends TestCase
             ->willReturn($entity)
         ;
 
+        $repository
+            ->expects($this->once())
+            ->method('purgeOldRecords')
+        ;
+
         $cronjob = $this
             ->getMockBuilder(TestCronJob::class)
             ->setMockClassName('UpdateEntitiesCron')
@@ -240,6 +245,11 @@ class CronTest extends TestCase
             ->willReturn($entity)
         ;
 
+        $repository
+            ->expects($this->once())
+            ->method('purgeOldRecords')
+        ;
+
         $cronjob = $this
             ->getMockBuilder(TestCronJob::class)
             ->setMockClassName('UpdateEntitiesCron')
@@ -285,6 +295,11 @@ class CronTest extends TestCase
             ->method('__call')
             ->with($this->equalTo('findOneByName'), $this->equalTo(['UpdateEntitiesCron::onHourly']))
             ->willReturn($entity)
+        ;
+
+        $repository
+            ->expects($this->once())
+            ->method('purgeOldRecords')
         ;
 
         $cronjob = $this
@@ -335,6 +350,11 @@ class CronTest extends TestCase
             ->method('__call')
             ->with($this->equalTo('findOneByName'), $this->equalTo(['Contao\CoreBundle\Cron\Cron::updateMinutelyCliCron']))
             ->willReturn($entity)
+        ;
+
+        $repository
+            ->expects($this->once())
+            ->method('purgeOldRecords')
         ;
 
         $logger = $this->createMock(LoggerInterface::class);
@@ -400,6 +420,11 @@ class CronTest extends TestCase
             ->willReturn($entity)
         ;
 
+        $repository
+            ->expects($this->once())
+            ->method('purgeOldRecords')
+        ;
+
         $cache = new ArrayAdapter();
 
         $cron = new Cron(
@@ -442,6 +467,11 @@ class CronTest extends TestCase
                 $this->equalTo(['Contao\CoreBundle\Fixtures\Cron\TestCronJob::skippingMethod']),
             )
             ->willReturn($entity)
+        ;
+
+        $repository
+            ->expects($this->once())
+            ->method('purgeOldRecords')
         ;
 
         $cronjob = new TestCronJob();
@@ -494,6 +524,11 @@ class CronTest extends TestCase
             ->willReturn($entity)
         ;
 
+        $repository
+            ->expects($this->once())
+            ->method('purgeOldRecords')
+        ;
+
         $cronjob = new TestCronJob();
 
         $manager = $this->createEntityManagerMock(true);
@@ -524,6 +559,11 @@ class CronTest extends TestCase
         $repository
             ->expects($this->never())
             ->method('__call')
+        ;
+
+        $repository
+            ->expects($this->never())
+            ->method('purgeOldRecords')
         ;
 
         $cron = new Cron(

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -135,6 +135,7 @@ class CronTest extends TestCase
         $repository
             ->expects($this->once())
             ->method('purgeOldRecords')
+            ->with(['UpdateEntitiesCron::onHourly'])
         ;
 
         $cronjob = $this
@@ -248,6 +249,7 @@ class CronTest extends TestCase
         $repository
             ->expects($this->once())
             ->method('purgeOldRecords')
+            ->with(['UpdateEntitiesCron::onHourly'])
         ;
 
         $cronjob = $this
@@ -300,6 +302,7 @@ class CronTest extends TestCase
         $repository
             ->expects($this->once())
             ->method('purgeOldRecords')
+            ->with(['UpdateEntitiesCron::onHourly'])
         ;
 
         $cronjob = $this
@@ -355,6 +358,7 @@ class CronTest extends TestCase
         $repository
             ->expects($this->once())
             ->method('purgeOldRecords')
+            ->with(['Contao\CoreBundle\Cron\Cron::updateMinutelyCliCron'])
         ;
 
         $logger = $this->createMock(LoggerInterface::class);
@@ -423,6 +427,7 @@ class CronTest extends TestCase
         $repository
             ->expects($this->once())
             ->method('purgeOldRecords')
+            ->with(['Contao\CoreBundle\Cron\Cron::updateMinutelyCliCron'])
         ;
 
         $cache = new ArrayAdapter();
@@ -472,6 +477,7 @@ class CronTest extends TestCase
         $repository
             ->expects($this->once())
             ->method('purgeOldRecords')
+            ->with(['Contao\CoreBundle\Fixtures\Cron\TestCronJob::skippingMethod'])
         ;
 
         $cronjob = new TestCronJob();
@@ -527,6 +533,7 @@ class CronTest extends TestCase
         $repository
             ->expects($this->once())
             ->method('purgeOldRecords')
+            ->with(['Contao\CoreBundle\Fixtures\Cron\TestCronJob::skippingAsyncMethod'])
         ;
 
         $cronjob = new TestCronJob();


### PR DESCRIPTION
You cannot define a cronjob that is executed less frequent than yearly. Thus we can purge entries in the `tl_cron_job` table that are older than 1 year - thus getting rid of cronjob records that do not exist anymore in your Contao instance (because you removed the cronjob or you uninstalled an extension or you updated Contao where the cronjob does not exist anymore).