### PR TITLE
Force identical UX for `panelLayout`

### DIFF
--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -1037,9 +1037,22 @@ abstract class DataContainer extends Backend
 	 */
 	protected function panel()
 	{
-		if (!($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout'] ?? null))
+		$panelLayout = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout'] ?? '';
+
+		if (!$panelLayout)
 		{
 			return '';
+		}
+
+		$panels = StringUtil::trimsplit('[;,]', $panelLayout);
+
+		// Force consistent order in Contao 5.7+ because the filter panel has moved from the top to the right.
+		// Separating into rows using ";" has no meaning anymore and for UX purposes, we want consistency so
+		// the order should always be search,filter,sort,limit.
+		// But if any custom panels have been used, we do not interfere with the settings.
+		if (empty(array_diff($panels, array('search', 'filter', 'sort', 'limit'))))
+		{
+			$panelLayout = implode(',', array_values(array_intersect(array('search', 'filter', 'sort', 'limit'), $panels)));
 		}
 
 		// Reset all filters
@@ -1062,7 +1075,7 @@ abstract class DataContainer extends Backend
 
 		$intFilterPanel = 0;
 		$arrPanels = array();
-		$arrPanes = StringUtil::trimsplit(';', $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout'] ?? '');
+		$arrPanes = StringUtil::trimsplit(';', $panelLayout);
 
 		foreach ($arrPanes as $strPanel)
 		{
@@ -1148,8 +1161,6 @@ abstract class DataContainer extends Backend
 			'panels' => $arrPanels,
 			'active' => $this->panelActive,
 		));
-
-		return $return;
 	}
 
 	/**


### PR DESCRIPTION
Now that our filter panel has moved to the right, all extensions that define a `panelLayout` need to be adjusted in order to match the UX of Contao 5.7 where the search input field is now always on the very top.
This means that either

- we end up in UX hell because the order is different all over the backend
- or we force all extension developers to register some callback to update the `panelLayout` depending on the Contao version

I don't think either one of those options are good so I would prefer solving this in the Core.
This change means that when using only the core panel options (any of `['search', 'filter', 'sort', 'limit']`) you can no longer specify the order. Contao decides for you to guarantee identical UX.
You can, however, still define which ones to show (if you write `filter,search` you'll end up having `search,filter`).

As soon as you specified a custom panel, we do not interfere with it so you are still in control then.