### PR TITLE
Always use the `contao.listener.image_size_options` service

### DIFF
--- a/calendar-bundle/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/contao/dca/tl_calendar_events.php
@@ -327,9 +327,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 			'inputType'               => 'imageSize',
 			'reference'               => &$GLOBALS['TL_LANG']['MSC'],
 			'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50 clr'),
-			'options_callback' => static function () {
-				return System::getContainer()->get('contao.image.sizes')->getOptionsForUser(BackendUser::getInstance());
-			},
+			'options_callback'        => array('contao.listener.image_size_options', '__invoke'),
 			'sql'                     => array('type'=>'string', 'length'=>255, 'default'=>'', 'customSchemaOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'imageUrl' => array

--- a/faq-bundle/contao/dca/tl_faq.php
+++ b/faq-bundle/contao/dca/tl_faq.php
@@ -209,9 +209,7 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 			'inputType'               => 'imageSize',
 			'reference'               => &$GLOBALS['TL_LANG']['MSC'],
 			'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50 clr'),
-			'options_callback' => static function () {
-				return System::getContainer()->get('contao.image.sizes')->getOptionsForUser(BackendUser::getInstance());
-			},
+			'options_callback'        => array('contao.listener.image_size_options', '__invoke'),
 			'sql'                     => array('type'=>'string', 'length'=>255, 'default'=>'', 'customSchemaOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'imageUrl' => array

--- a/news-bundle/contao/dca/tl_news.php
+++ b/news-bundle/contao/dca/tl_news.php
@@ -285,9 +285,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			'inputType'               => 'imageSize',
 			'reference'               => &$GLOBALS['TL_LANG']['MSC'],
 			'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50 clr'),
-			'options_callback' => static function () {
-				return System::getContainer()->get('contao.image.sizes')->getOptionsForUser(BackendUser::getInstance());
-			},
+			'options_callback'        => array('contao.listener.image_size_options', '__invoke'),
 			'sql'                     => array('type'=>'string', 'length'=>255, 'default'=>'', 'customSchemaOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'imageUrl' => array


### PR DESCRIPTION
Within the `contao/core-bundle` we have the `contao.listener.image_size_options` service for the `options_callback` for all the `imageSize` fields. The callbacks are registered via the `AsCallback` PHP attribute.

The other bundles cannot register the `options_callback` on their `imageSize` fields via the PHP attribute and must instead define the callback manually. However, currently some of those fields use the service while others just have a callable.

This PR normalizes that.
