### PR TITLE
Always use the deferred renderer for the layout template

### DIFF
--- a/core-bundle/config/controller.yaml
+++ b/core-bundle/config/controller.yaml
@@ -248,7 +248,6 @@ services:
             - '@contao.content_composition'
             - '@contao.routing.response_context_factory'
             - '@contao.routing.response_context_accessor'
-            - '@contao.twig.deferred_renderer'
             - '@contao.framework'
 
     Contao\CoreBundle\Controller\Page\RootPageController:

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -80,6 +80,7 @@ services:
             - '@contao.image.preview_factory'
             - '@contao.assets.assets_context'
             - '@contao.twig.default_renderer'
+            - '@contao.twig.deferred_renderer'
             - '@request_stack'
             - '@translator'
             - '@contao.routing.page_registry'

--- a/core-bundle/src/ContentComposition/ContentComposition.php
+++ b/core-bundle/src/ContentComposition/ContentComposition.php
@@ -35,6 +35,7 @@ class ContentComposition
         private readonly PreviewFactory $previewFactory,
         private readonly ContaoContext $assetsContext,
         private readonly RendererInterface $defaultRenderer,
+        private readonly RendererInterface $deferredRenderer,
         private readonly RequestStack $requestStack,
         private readonly LocaleAwareInterface $translator,
         private readonly PageRegistry $pageRegistry,
@@ -54,6 +55,9 @@ class ContentComposition
             $this->translator,
             $page,
         );
+
+        // Always use the deferred renderer for the layout template
+        $builder->setRenderer($this->deferredRenderer);
 
         if ($template = $this->pageRegistry->getRoute($page)->getDefault('_template')) {
             $builder->useCustomLayoutTemplate($template);

--- a/core-bundle/src/ContentComposition/ContentCompositionBuilder.php
+++ b/core-bundle/src/ContentComposition/ContentCompositionBuilder.php
@@ -40,6 +40,14 @@ class ContentCompositionBuilder
 
     private string|null $defaultImageDensities = null;
 
+    /**
+     * Renderer used for the main layout template.
+     */
+    private RendererInterface $renderer;
+
+    /**
+     * Renderer used to compose individual slots.
+     */
     private RendererInterface $slotRenderer;
 
     /**
@@ -58,12 +66,12 @@ class ContentCompositionBuilder
         private readonly PictureFactory $pictureFactory,
         private readonly PreviewFactory $previewFactory,
         private readonly ContaoContext $assetsContext,
-        private RendererInterface $renderer,
+        RendererInterface $renderer,
         private readonly RequestStack $requestStack,
         private readonly LocaleAwareInterface $translator,
         private readonly PageModel $page,
     ) {
-        $this->slotRenderer = $this->renderer;
+        $this->slotRenderer = $this->renderer = $renderer;
     }
 
     /**

--- a/core-bundle/src/Controller/Page/RegularPageController.php
+++ b/core-bundle/src/Controller/Page/RegularPageController.php
@@ -19,7 +19,6 @@ use Contao\CoreBundle\EventListener\SubrequestCacheSubscriber;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
-use Contao\CoreBundle\Twig\Renderer\RendererInterface;
 use Contao\FrontendIndex;
 use Contao\LayoutModel;
 use Contao\PageModel;
@@ -32,7 +31,6 @@ class RegularPageController extends AbstractController
         private readonly ContentComposition $contentComposition,
         private readonly CoreResponseContextFactory $responseContextFactory,
         private readonly ResponseContextAccessor $responseContextAccessor,
-        private readonly RendererInterface $deferredRenderer,
         private readonly ContaoFramework $framework,
         private \Closure|null $handleNonModernLayoutType = null,
     ) {
@@ -52,7 +50,6 @@ class RegularPageController extends AbstractController
         $layoutTemplate = $this->contentComposition
             ->createContentCompositionBuilder($page)
             ->setResponseContext($responseContext)
-            ->setSlotRenderer($this->deferredRenderer)
             ->buildLayoutTemplate()
         ;
 

--- a/core-bundle/tests/ContentComposition/ContentCompositionTest.php
+++ b/core-bundle/tests/ContentComposition/ContentCompositionTest.php
@@ -67,6 +67,7 @@ class ContentCompositionTest extends TestCase
             $this->createStub(PreviewFactory::class),
             $this->createStub(ContaoContext::class),
             $this->createStub(RendererInterface::class),
+            $this->createStub(RendererInterface::class),
             $this->createStub(RequestStack::class),
             $this->createStub(LocaleAwareInterface::class),
             $pageRegistry,

--- a/core-bundle/tests/Controller/Page/RegularPageControllerTest.php
+++ b/core-bundle/tests/Controller/Page/RegularPageControllerTest.php
@@ -15,7 +15,6 @@ use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\LayoutTemplate;
-use Contao\CoreBundle\Twig\Renderer\RendererInterface;
 use Contao\LayoutModel;
 use Contao\PageModel;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -96,18 +95,6 @@ class RegularPageControllerTest extends TestCase
         $this->assertSame($response, $finalizedResponse);
     }
 
-    public function testSetsDeferredRenderer(): void
-    {
-        $deferredRenderer = $this->createStub(RendererInterface::class);
-
-        $controller = $this->getRegularPageController(
-            contentComposition: $this->getContentComposition(expectedFragmentRenderer: $deferredRenderer),
-            deferredRenderer: $deferredRenderer,
-        );
-
-        $controller($this->createClassWithPropertiesStub(PageModel::class));
-    }
-
     public static function providePageCacheSettings(): iterable
     {
         yield 'disabled' => [
@@ -126,7 +113,7 @@ class RegularPageControllerTest extends TestCase
         ];
     }
 
-    private function getRegularPageController(ContaoFramework|null $framework = null, \Closure|null $handler = null, ContentComposition|null $contentComposition = null, CoreResponseContextFactory|null $responseContextFactory = null, ResponseContextAccessor|null $responseContextAccessor = null, RendererInterface|null $deferredRenderer = null): RegularPageController
+    private function getRegularPageController(ContaoFramework|null $framework = null, \Closure|null $handler = null, ContentComposition|null $contentComposition = null, CoreResponseContextFactory|null $responseContextFactory = null, ResponseContextAccessor|null $responseContextAccessor = null): RegularPageController
     {
         if (!$framework) {
             $layoutAdapter = $this->createAdapterStub(['findById']);
@@ -152,7 +139,6 @@ class RegularPageControllerTest extends TestCase
             $contentComposition ?? $this->getContentComposition(),
             $responseContextFactory,
             $responseContextAccessor ?? $this->createStub(ResponseContextAccessor::class),
-            $deferredRenderer ?? $this->createStub(RendererInterface::class),
             $framework,
             $handler,
         );
@@ -165,7 +151,7 @@ class RegularPageControllerTest extends TestCase
         return $controller;
     }
 
-    private function getContentComposition(bool $build = true, ResponseContext|null $expectedResponseContext = null, RendererInterface|null $expectedFragmentRenderer = null): ContentComposition
+    private function getContentComposition(bool $build = true, ResponseContext|null $expectedResponseContext = null): ContentComposition
     {
         $contentCompositionBuilder = $this->createMock(ContentCompositionBuilder::class);
 
@@ -179,20 +165,6 @@ class RegularPageControllerTest extends TestCase
         } else {
             $contentCompositionBuilder
                 ->method('setResponseContext')
-                ->willReturnSelf()
-            ;
-        }
-
-        if ($expectedFragmentRenderer) {
-            $contentCompositionBuilder
-                ->expects($this->once())
-                ->method('setSlotRenderer')
-                ->with($expectedFragmentRenderer)
-                ->willReturnSelf()
-            ;
-        } else {
-            $contentCompositionBuilder
-                ->method('setSlotRenderer')
                 ->willReturnSelf()
             ;
         }

--- a/core-bundle/tests/Fixtures/Functional/PageController/TestFragmentController.php
+++ b/core-bundle/tests/Fixtures/Functional/PageController/TestFragmentController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Fixtures\Functional\PageController;
+
+use Contao\ContentModel;
+
+class TestFragmentController
+{
+    public function __construct(
+        private readonly ContentModel $contentModel,
+        private readonly string $column,
+    ) {
+    }
+
+    public function generate(): string
+    {
+        $GLOBALS['TL_BODY'][] = '<script id="test-fragment-script"></script>';
+        $GLOBALS['TL_STYLE_SHEETS'][] = '<link rel="stylesheet" href="test-fragment-styles.css">';
+
+        return "[content from test fragment controller for tl_content.{$this->contentModel->id} in $this->column]";
+    }
+}

--- a/core-bundle/tests/Fixtures/Functional/PageController/page-with-layout-and-content.yaml
+++ b/core-bundle/tests/Fixtures/Functional/PageController/page-with-layout-and-content.yaml
@@ -1,0 +1,32 @@
+tl_page:
+    - id: 2
+      pid: 1
+      sorting: 128
+      tstamp: 1539698035
+      title: Layout Test Page
+      alias: layout-test
+      type: regular
+      includeLayout: 1
+      layout: 1
+      published: 1
+
+tl_layout:
+    - id: 1
+      pid: 1
+      template: page/layout
+      type: modern
+      modules: a:1:{i:0;a:3:{s:3:"mod";s:1:"0";s:3:"col";s:4:"main";s:6:"enable";s:1:"1";}}
+
+tl_article:
+    - id: 1
+      pid: 2
+      inColumn: main
+      published: 1
+
+tl_content:
+    - id: 1
+      pid: 1
+      ptable: tl_article
+      tstamp: 12345678
+      type: test
+      invisible: 0

--- a/core-bundle/tests/Functional/RegularPageControllerTest.php
+++ b/core-bundle/tests/Functional/RegularPageControllerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Functional;
+
+use Contao\CoreBundle\Controller\Page\RegularPageController;
+use Contao\CoreBundle\Tests\Fixtures\Functional\PageController\TestFragmentController;
+use Contao\PageModel;
+use Contao\System;
+use Contao\TestCase\FunctionalTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RegularPageControllerTest extends FunctionalTestCase
+{
+    public function testRendersLayoutTemplate(): void
+    {
+        $container = self::createClient()->getContainer();
+        System::setContainer($container);
+
+        static::loadFixtures([__DIR__.'/../Fixtures/Functional/PageController/page-with-layout-and-content.yaml']);
+
+        $page = PageModel::findOneByAlias('layout-test');
+        $container->get('request_stack')->push(new Request(attributes: ['pageModel' => $page]));
+
+        $GLOBALS['TL_CTE']['miscellaneous']['test'] = TestFragmentController::class;
+
+        $response = $container->get(RegularPageController::class)($page);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $crawler = new Crawler($response->getContent());
+
+        // Ensure article is rendered with the test fragment in it
+        $articleNode = $crawler->filterXPath('//body//main//*[1]');
+
+        $this->assertSame('article-1', $articleNode->attr('id'));
+        $this->assertSame('mod_article block', $articleNode->attr('class'));
+        $this->assertSame(
+            '[content from test fragment controller for tl_content.1 in main]',
+            $articleNode->innerText(),
+        );
+
+        // Ensure deferred rendering of additional head/body tags
+        $this->assertCount(
+            1,
+            $crawler->filterXPath('//head//link[@href="test-fragment-styles.css"]'),
+        );
+
+        $this->assertCount(
+            1,
+            $crawler->filterXPath('//body//script[@id="test-fragment-script"]'),
+        );
+    }
+}

--- a/core-bundle/tests/Functional/RegularPageControllerTest.php
+++ b/core-bundle/tests/Functional/RegularPageControllerTest.php
@@ -46,6 +46,7 @@ class RegularPageControllerTest extends FunctionalTestCase
 
         $this->assertSame('article-1', $articleNode->attr('id'));
         $this->assertSame('mod_article block', $articleNode->attr('class'));
+
         $this->assertSame(
             '[content from test fragment controller for tl_content.1 in main]',
             $articleNode->innerText(),


### PR DESCRIPTION
Fixes #9401

We now always use the deferred renderer for the `LayoutTemplate` as that is something you'll also want for your custom controllers (if not - you can still use the setters to set another one).

I added a functional test that validates the behavior by rendering a page with the `RegularPageController`, that outputs an article with a content element that ultimately adds styles and scripts to the head/body.