### PR TITLE
Normalize the URL field length

### DIFF
--- a/core-bundle/contao/dca/tl_favorites.php
+++ b/core-bundle/contao/dca/tl_favorites.php
@@ -92,7 +92,7 @@ $GLOBALS['TL_DCA']['tl_favorites'] = array
 			'search'                  => true,
 			'inputType'               => 'text',
 			'eval'                    => array('mandatory'=>true, 'readonly'=>true, 'rgxp'=>'url', 'decodeEntities'=>true, 'maxlength'=>1022, 'tl_class'=>'w50'),
-			'sql'                     => "varchar(1022) NOT NULL default ''"
+			'sql'                     => "varchar(2048) NOT NULL default ''"
 		)
 	)
 );


### PR DESCRIPTION
All our `url` fields have a length of `2048` - except in `tl_favorites`.
