### PR TITLE
Delete old XML files when migrating news feeds

### DIFF
--- a/news-bundle/config/services.yaml
+++ b/news-bundle/config/services.yaml
@@ -94,6 +94,8 @@ services:
         class: Contao\NewsBundle\Migration\FeedMigration
         arguments:
             - '@database_connection'
+            - '@filesystem'
+            - '%contao.web_dir%'
 
     contao_news.picker.news_provider:
         class: Contao\NewsBundle\Picker\NewsPickerProvider

--- a/news-bundle/src/Migration/FeedMigration.php
+++ b/news-bundle/src/Migration/FeedMigration.php
@@ -16,11 +16,16 @@ use Contao\CoreBundle\Migration\AbstractMigration;
 use Contao\CoreBundle\Migration\MigrationResult;
 use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 
 class FeedMigration extends AbstractMigration
 {
-    public function __construct(private readonly Connection $connection)
-    {
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly Filesystem $filesystem,
+        private readonly string $webDir,
+    ) {
     }
 
     public function shouldRun(): bool
@@ -87,6 +92,8 @@ class FeedMigration extends AbstractMigration
             $mapping[$feed['id']] = $this->connection->lastInsertId();
 
             $this->connection->delete('tl_news_feed', ['id' => $feed['id']]);
+
+            $this->filesystem->remove(Path::join($this->webDir, 'share', $feed['alias'].'.xml'));
         }
 
         foreach ($layouts as $layoutId => $newsfeeds) {

--- a/news-bundle/tests/Migration/FeedMigrationTest.php
+++ b/news-bundle/tests/Migration/FeedMigrationTest.php
@@ -17,6 +17,7 @@ use Contao\NewsBundle\Migration\FeedMigration;
 use Contao\TestCase\ContaoTestCase;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
+use Symfony\Component\Filesystem\Filesystem;
 
 class FeedMigrationTest extends ContaoTestCase
 {
@@ -37,7 +38,13 @@ class FeedMigrationTest extends ContaoTestCase
             ->willReturn($schemaManager)
         ;
 
-        $migration = new FeedMigration($connection);
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem
+            ->expects($this->never())
+            ->method('remove')
+        ;
+
+        $migration = new FeedMigration($connection, $filesystem, 'public');
 
         $this->assertFalse($migration->shouldRun());
     }
@@ -65,7 +72,13 @@ class FeedMigrationTest extends ContaoTestCase
             ->willReturn(0)
         ;
 
-        $migration = new FeedMigration($connection);
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem
+            ->expects($this->never())
+            ->method('remove')
+        ;
+
+        $migration = new FeedMigration($connection, $filesystem, 'public');
 
         $this->assertFalse($migration->shouldRun());
     }
@@ -172,7 +185,14 @@ class FeedMigrationTest extends ContaoTestCase
             ->with('tl_layout', ['newsfeeds' => serialize([42])], ['id' => 21])
         ;
 
-        $migration = new FeedMigration($connection);
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem
+            ->expects($this->once())
+            ->method('remove')
+            ->with('public/share/latest-news.xml')
+        ;
+
+        $migration = new FeedMigration($connection, $filesystem, 'public');
 
         $this->assertTrue($migration->shouldRun());
         $this->assertEquals(new MigrationResult(true, 'Contao\NewsBundle\Migration\FeedMigration executed successfully'), $migration->run());
@@ -279,7 +299,14 @@ class FeedMigrationTest extends ContaoTestCase
             )
         ;
 
-        $migration = new FeedMigration($connection);
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem
+            ->expects($this->once())
+            ->method('remove')
+            ->with('public/share/latest-news.xml')
+        ;
+
+        $migration = new FeedMigration($connection, $filesystem, 'public');
 
         $this->assertTrue($migration->shouldRun());
         $this->assertEquals(new MigrationResult(true, 'Contao\NewsBundle\Migration\FeedMigration executed successfully'), $migration->run());


### PR DESCRIPTION
Fixes #8591 for the news feeds in Contao 5.3.