### PR TITLE
Allow to enable basic entities for the `MetaWizard`

### DIFF
--- a/core-bundle/config/migrations.yaml
+++ b/core-bundle/config/migrations.yaml
@@ -68,6 +68,12 @@ services:
         arguments:
             - '@database_connection'
 
+    contao.migration.version_503.caption_basic_entities:
+        class: Contao\CoreBundle\Migration\Version503\CaptionBasicEntitiesMigration
+        arguments:
+            - '@database_connection'
+            - '@contao.framework'
+
     contao.migration.version_503.file_extension:
         class: Contao\CoreBundle\Migration\Version503\FileExtensionMigration
         arguments:

--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -258,7 +258,7 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 					'title'           => 'maxlength="255"',
 					'alt'             => 'maxlength="255"',
 					'link'            => array('attributes'=>'maxlength="2048"', 'dcaPicker'=>true),
-					'caption'         => array('type'=>'textarea'),
+					'caption'         => array('type'=>'textarea', 'basicEntities'=>true),
 					'license'         => array(
 						'attributes'  => 'maxlength="255"',
 						'dcaPicker'   => true,

--- a/core-bundle/contao/widgets/MetaWizard.php
+++ b/core-bundle/contao/widgets/MetaWizard.php
@@ -107,6 +107,11 @@ class MetaWizard extends Widget
 						$this->addError($errorMsg);
 						$this->arrFieldErrors[$lang][$kk] = true;
 					}
+
+					if ($this->metaFields[$kk]['basicEntities'] ?? false)
+					{
+						$v[$kk] = StringUtil::restoreBasicEntities($vv);
+					}
 				}
 
 				$varInput[$k] = array_map('trim', $v);
@@ -177,6 +182,11 @@ class MetaWizard extends Widget
 			foreach ($this->metaFields as $field=>$fieldConfig)
 			{
 				$item .= '<label' . (isset($this->arrFieldErrors[$lang][$field]) ? ' class="error"' : '') . ' for="ctrl_' . $this->strId . '_' . $field . '_' . $count . '">' . $GLOBALS['TL_LANG']['MSC']['aw_' . $field] . '</label>';
+
+				if (($meta[$field] ?? null) && ($fieldConfig['basicEntities'] ?? false))
+				{
+					$meta[$field] = StringUtil::convertBasicEntities($meta[$field]);
+				}
 
 				if (isset($fieldConfig['type']) && 'textarea' === $fieldConfig['type'])
 				{

--- a/core-bundle/src/Migration/Version503/CaptionBasicEntitiesMigration.php
+++ b/core-bundle/src/Migration/Version503/CaptionBasicEntitiesMigration.php
@@ -47,7 +47,7 @@ class CaptionBasicEntitiesMigration extends AbstractMigration
             $meta = StringUtil::deserialize($meta, true);
 
             foreach ($meta as $data) {
-                if (!($data['caption'] ?? null)) {
+                if (!isset($data['caption'])) {
                     continue;
                 }
 
@@ -66,7 +66,7 @@ class CaptionBasicEntitiesMigration extends AbstractMigration
             $meta = StringUtil::deserialize($meta, true);
 
             foreach ($meta as $lang => $data) {
-                if (!($data['caption'] ?? null)) {
+                if (!isset($data['caption'])) {
                     continue;
                 }
 

--- a/core-bundle/src/Migration/Version503/CaptionBasicEntitiesMigration.php
+++ b/core-bundle/src/Migration/Version503/CaptionBasicEntitiesMigration.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Migration\Version503;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Contao\StringUtil;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @internal
+ */
+class CaptionBasicEntitiesMigration extends AbstractMigration
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly ContaoFramework $framework,
+    ) {
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        if (!$schemaManager->tablesExist(['tl_files'])) {
+            return false;
+        }
+
+        if (!$records = $this->getAffectedRecords()) {
+            return false;
+        }
+
+        $this->framework->initialize();
+
+        foreach ($records as $meta) {
+            $meta = StringUtil::deserialize($meta, true);
+
+            foreach ($meta as $data) {
+                if (!($data['caption'] ?? null)) {
+                    continue;
+                }
+
+                if ($data['caption'] !== StringUtil::restoreBasicEntities($data['caption'])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function run(): MigrationResult
+    {
+        foreach ($this->getAffectedRecords() as $id => $meta) {
+            $meta = StringUtil::deserialize($meta, true);
+
+            foreach ($meta as $lang => $data) {
+                if (!($data['caption'] ?? null)) {
+                    continue;
+                }
+
+                $meta[$lang]['caption'] = StringUtil::restoreBasicEntities($data['caption']);
+            }
+
+            $this->connection->update('tl_files', ['meta' => serialize($meta)], ['id' => $id]);
+        }
+
+        return $this->createResult(true);
+    }
+
+    private function getAffectedRecords(): array
+    {
+        return $this->connection->fetchAllKeyValue("
+                SELECT id, meta
+                FROM tl_files
+                WHERE meta IS NOT NULL AND CAST(`meta` AS BINARY) REGEXP CAST('\\\\[(&|&amp;|lt|gt|nbsp|-)\\\\]' AS BINARY)
+            ");
+    }
+}


### PR DESCRIPTION
Fixes #8874 by allowing to configure `'basicEntities' => true` for `MetaWizard` fields. This PR also adds said setting to the `caption` field by default and thus also introduces a migration specifically for this field.