### PR TITLE
Fix error pages not working in the Twig layout

### DIFF
--- a/core-bundle/contao/pages/PageError401.php
+++ b/core-bundle/contao/pages/PageError401.php
@@ -41,6 +41,8 @@ class PageError401 extends Frontend
 			$objPage->clientCache = 0;
 		}
 
+		$objPage->type = 'regular';
+
 		return System::getContainer()
 			->get(RegularPageController::class)($objPage)
 			->setStatusCode(Response::HTTP_UNAUTHORIZED)

--- a/core-bundle/contao/pages/PageError401.php
+++ b/core-bundle/contao/pages/PageError401.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\Page\RegularPageController;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
 use Symfony\Component\HttpFoundation\Response;
@@ -40,10 +41,10 @@ class PageError401 extends Frontend
 			$objPage->clientCache = 0;
 		}
 
-		/** @var PageRegular $objHandler */
-		$objHandler = new $GLOBALS['TL_PTY']['regular']();
-
-		return $objHandler->getResponse($objPage)->setStatusCode(401);
+		return System::getContainer()
+			->get(RegularPageController::class)($objPage)
+			->setStatusCode(Response::HTTP_UNAUTHORIZED)
+		;
 	}
 
 	/**

--- a/core-bundle/contao/pages/PageError403.php
+++ b/core-bundle/contao/pages/PageError403.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\Page\RegularPageController;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
@@ -40,10 +41,10 @@ class PageError403 extends Frontend
 			$objPage->clientCache = 0;
 		}
 
-		/** @var PageRegular $objHandler */
-		$objHandler = new $GLOBALS['TL_PTY']['regular']();
-
-		return $objHandler->getResponse($objPage)->setStatusCode(403);
+		return System::getContainer()
+			->get(RegularPageController::class)($objPage)
+			->setStatusCode(Response::HTTP_FORBIDDEN)
+		;
 	}
 
 	/**

--- a/core-bundle/contao/pages/PageError403.php
+++ b/core-bundle/contao/pages/PageError403.php
@@ -41,6 +41,8 @@ class PageError403 extends Frontend
 			$objPage->clientCache = 0;
 		}
 
+		$objPage->type = 'regular';
+
 		return System::getContainer()
 			->get(RegularPageController::class)($objPage)
 			->setStatusCode(Response::HTTP_FORBIDDEN)

--- a/core-bundle/contao/pages/PageError404.php
+++ b/core-bundle/contao/pages/PageError404.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\Page\RegularPageController;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
@@ -40,10 +41,10 @@ class PageError404 extends Frontend
 			$objPage->clientCache = 0;
 		}
 
-		/** @var PageRegular $objHandler */
-		$objHandler = new $GLOBALS['TL_PTY']['regular']();
-
-		return $objHandler->getResponse($objPage)->setStatusCode(404);
+		return System::getContainer()
+			->get(RegularPageController::class)($objPage)
+			->setStatusCode(Response::HTTP_NOT_FOUND)
+		;
 	}
 
 	/**

--- a/core-bundle/contao/pages/PageError404.php
+++ b/core-bundle/contao/pages/PageError404.php
@@ -41,6 +41,8 @@ class PageError404 extends Frontend
 			$objPage->clientCache = 0;
 		}
 
+		$objPage->type = 'regular';
+
 		return System::getContainer()
 			->get(RegularPageController::class)($objPage)
 			->setStatusCode(Response::HTTP_NOT_FOUND)


### PR DESCRIPTION
Fixes #9402, but does not implement error pages as proper page controllers, yet.

The issue with #9402 is, that the error pages currently directly call `PageRegular`, which cannot handle the modern layouts. To fix this, we now call the `RegularPageController` instead.

 This is an intermediate solution, because error pages should also become proper page controllers and reuse code, but

1) this is IMHO a separate feature for Contao 6/5.8 and
2) we would probably need to keep the classes for BC, so we would need the changes from this PR anyways.