### PR TITLE
Fix an error in the profiler

### DIFF
--- a/core-bundle/templates/Collector/contao.html.twig
+++ b/core-bundle/templates/Collector/contao.html.twig
@@ -42,7 +42,7 @@
 
 {% block menu %}
     <span class="label">
-        <span class="icon">{{ include('@ContaoCore/Collector/contao.svg') }}</span>
+        <span class="icon">{{ include('@ContaoCore/Collector/contao.svg.twig') }}</span>
         <strong>Contao</strong>
     </span>
 {% endblock %}


### PR DESCRIPTION
Follow-up to #9213 - fixes the following error:

```
Twig\Error\LoaderError:
Template "@ContaoCore/Collector/contao.svg" is not defined in "@ContaoCore/Collector/contao.html.twig" at line 45.

  at vendor\contao\contao\core-bundle\templates\Collector\contao.html.twig:45v
```
