### PR TITLE
Allow HTML messages in the security view

### DIFF
--- a/core-bundle/contao/templates/twig/be_two_factor.html.twig
+++ b/core-bundle/contao/templates/twig/be_two_factor.html.twig
@@ -2,7 +2,7 @@
 
 <div class="two-factor">
     <h2 class="sub_headline">{{ 'MSC.twoFactorAuthentication'|trans }}</h2>
-    {{ messages }}
+    {{ messages|raw }}
 
     {% if enable|default %}
         <p>{{ 'MSC.twoFactorScan'|trans }}</p>


### PR DESCRIPTION
### Description

Fixes:
<img width="573" height="305" alt="grafik" src="https://github.com/user-attachments/assets/b852da47-c5dd-416a-8601-de85359b554f" />

Bug can be reproduced by enforcing two factor auth:
```yaml
#config/config.yaml
contao:
    security:
        two_factor:
            enforce_backend: true
```