### PR TITLE
Remove empty chains when filtering the hierarchy in the `ContaoFilesystemLoader`

### DIFF
--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -339,6 +339,11 @@ class ContaoFilesystemLoader implements LoaderInterface, ResetInterface
                     unset($chains[$identifier][$path]);
                 }
             }
+
+            // Remove empty chains completely
+            if (empty($chains[$identifier])) {
+                unset($chains[$identifier]);
+            }
         }
 
         return $chains;


### PR DESCRIPTION
I think we must remove empty chains when filtering them. If in an app, there are theme-only templates, that do not otherwise exist, empty chains could occur. If you then for instance called `getFirst()` on them, this would fail.

Related: https://github.com/madeyourday/contao-rocksolid-custom-elements/issues/189