### PR TITLE
Remove obsolete `>` in the `be_login_two_factor` template

### DIFF
--- a/core-bundle/contao/templates/twig/be_login_two_factor.html.twig
+++ b/core-bundle/contao/templates/twig/be_login_two_factor.html.twig
@@ -27,7 +27,7 @@
     {% endblock %}
 
 </head>
-<body{{ attrs(attributes|default).addClass('be_login_two_factor') }}>>
+<body{{ attrs(attributes|default).addClass('be_login_two_factor') }}>
 
 {% block container %}
     <div id="container">


### PR DESCRIPTION
### Description

First bugfix for 5.7.0 🥳 😅 

<img width="318" height="516" alt="grafik" src="https://github.com/user-attachments/assets/f7684792-ee40-4593-a56a-f1e9eadac504" />
