### PR TITLE
Render modern layout with RegularPageController

### DIFF
--- a/core-bundle/contao/controllers/FrontendIndex.php
+++ b/core-bundle/contao/controllers/FrontendIndex.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\Page\RegularPageController;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
@@ -30,6 +31,13 @@ class FrontendIndex extends Frontend
 	 */
 	public function renderPage(PageModel $pageModel)
 	{
+		$layout = LayoutModel::findById($pageModel->layout);
+
+		if (null !== $layout && 'modern' === $layout->type)
+		{
+			return System::getContainer()->get(RegularPageController::class)->__invoke($pageModel);
+		}
+
 		global $objPage;
 
 		$objPage = $pageModel;

--- a/core-bundle/contao/controllers/FrontendIndex.php
+++ b/core-bundle/contao/controllers/FrontendIndex.php
@@ -35,7 +35,7 @@ class FrontendIndex extends Frontend
 
 		if (null !== $layout && 'modern' === $layout->type)
 		{
-			return System::getContainer()->get(RegularPageController::class)->__invoke($pageModel);
+			return System::getContainer()->get(RegularPageController::class)($pageModel);
 		}
 
 		global $objPage;

--- a/core-bundle/src/Controller/Page/ErrorPageController.php
+++ b/core-bundle/src/Controller/Page/ErrorPageController.php
@@ -40,6 +40,7 @@ class ErrorPageController extends AbstractController implements ContentCompositi
         return $this->framework
             ->createInstance(FrontendIndex::class)
             ->renderPage($pageModel)
+            ->setStatusCode((int) substr($pageModel->type, -3))
         ;
     }
 


### PR DESCRIPTION
This is a temporary fix for #9443 

If a custom page controller want's to render page, it would currently need to duplicate everything of `RegularPageController`, including the legacy layout check. I think that should be improved, in the meantime this fix allows the old way to work.