### PR TITLE
Reverse the supervisor provider array

### DIFF
--- a/core-bundle/src/DataCollector/ContaoDataCollector.php
+++ b/core-bundle/src/DataCollector/ContaoDataCollector.php
@@ -237,7 +237,7 @@ class ContaoDataCollector extends DataCollector implements FrameworkAwareInterfa
             'available' => $this->backendSearch?->isAvailable() ?? false,
             'requires_sqlite' => $this->backendSearchAdapter instanceof LoupeAdapter,
             'sqlite_supported' => array_intersect(['pdo_sqlite', 'sqlite3'], [...get_loaded_extensions(true), ...get_loaded_extensions()]),
-            'supervisor_supported' => Supervisor::canSuperviseWithProviders(Supervisor::getDefaultProviders()),
+            'supervisor_supported' => Supervisor::canSuperviseWithProviders(array_reverse(Supervisor::getDefaultProviders())),
             'pnctl_disabled' => array_filter(explode(',', (string) \ini_get('disable_functions')), static fn (string $f) => str_starts_with($f, 'pnctl_')),
             'cron_running' => $this->cron->hasMinutelyCliCron(),
             'cli_workers_running' => $this->webWorker?->hasCliWorkersRunning() ?? false,

--- a/core-bundle/src/DataCollector/ContaoDataCollector.php
+++ b/core-bundle/src/DataCollector/ContaoDataCollector.php
@@ -237,6 +237,8 @@ class ContaoDataCollector extends DataCollector implements FrameworkAwareInterfa
             'available' => $this->backendSearch?->isAvailable() ?? false,
             'requires_sqlite' => $this->backendSearchAdapter instanceof LoupeAdapter,
             'sqlite_supported' => array_intersect(['pdo_sqlite', 'sqlite3'], [...get_loaded_extensions(true), ...get_loaded_extensions()]),
+            // For performance, we reverse the array of default providers, so that the
+            // FlockProvider comes first, which serves as an early out when present.
             'supervisor_supported' => Supervisor::canSuperviseWithProviders(array_reverse(Supervisor::getDefaultProviders())),
             'pnctl_disabled' => array_filter(explode(',', (string) \ini_get('disable_functions')), static fn (string $f) => str_starts_with($f, 'pnctl_')),
             'cron_running' => $this->cron->hasMinutelyCliCron(),


### PR DESCRIPTION
This would shave off another ~230ms in `dev` - under Windows.

Why does this help? Since https://github.com/Toflar/cronjob-supervisor/pull/14 a `FlockProvider` is available and this one always simply returns `true` for `isSupported()` - but it comes last in the default array (since it is supposed to be a fallback). Therefore `WindowsTaskListProvider::isSupported()` is always executed first, which takes ~230ms. By reversing the array, we have an early out, as long as the `Supervisor` continues to support the `FlockProvider`.