### PR TITLE
Update the TinyMCE skin to oxide

### DIFF
--- a/core-bundle/contao/templates/backend/be_tinyMCE.html5
+++ b/core-bundle/contao/templates/backend/be_tinyMCE.html5
@@ -16,7 +16,7 @@ if ($this->enableTinyMce):
     license_key: 'gpl',
     branding: false,
     promotion: false,
-    skin: (document.documentElement.dataset.colorScheme === 'dark' ? 'tinymce-5-dark' : 'tinymce-5'),
+    skin: (document.documentElement.dataset.colorScheme === 'dark' ? 'oxide-dark' : 'oxide'),
     setup: function (editor) {
       editor.getElement().removeAttribute('required');
       document.querySelectorAll('[accesskey]').forEach(function (el) {

--- a/core-bundle/contao/templates/twig/be_tinyMCE.html.twig
+++ b/core-bundle/contao/templates/twig/be_tinyMCE.html.twig
@@ -10,7 +10,7 @@
                 license_key: 'gpl',
                 branding: false,
                 promotion: false,
-                skin: (document.documentElement.dataset.colorScheme === 'dark' ? 'tinymce-5-dark' : 'tinymce-5'),
+                skin: (document.documentElement.dataset.colorScheme === 'dark' ? 'oxide-dark' : 'oxide'),
                 setup: function (editor) {
                     editor.getElement().removeAttribute('required');
                     document.querySelectorAll('[accesskey]').forEach(function (el) {


### PR DESCRIPTION
Customer of mine mentioned that we still use the "old tinyMCE version 5" in Contao 5.7 LTS.
I was sure that we didn't so I checked. Turns out it just looks still old 😉 

Let's fix that so it matches the refreshed UI 😊 

Before:

<img width="1681" height="528" alt="Bildschirmfoto 2026-02-19 um 09 57 47" src="https://github.com/user-attachments/assets/346abafe-2dae-4110-a152-20fc92c27793" />

After:

<img width="1667" height="527" alt="Bildschirmfoto 2026-02-19 um 09 58 03" src="https://github.com/user-attachments/assets/a4164fe7-c799-4a63-8fef-f85223156b7c" />

