### PR TITLE
Replace insert tags within custom head tags

### DIFF
--- a/core-bundle/contao/templates/twig/fe_page.html.twig
+++ b/core-bundle/contao/templates/twig/fe_page.html.twig
@@ -36,7 +36,7 @@
         {{ framework|raw }}
         {{ stylesheets|raw }}
         {{ mooScripts|raw }}
-        {{ head|raw }}
+        {{ head|insert_tag_raw|raw }}
     {% endblock %}
 
 </head>


### PR DESCRIPTION
### Description

Usage like this within the head tags in the legacy layout is currently not possible (it did work with fe_page.html5)
```
<meta property="og:title" content="{{page::pageTitle}}" />
```
