### PR TITLE
Make the preheader optional in the `mail_responsive` template

### DIFF
--- a/core-bundle/contao/templates/mail/mail_responsive.html5
+++ b/core-bundle/contao/templates/mail/mail_responsive.html5
@@ -303,7 +303,9 @@
         <td>&nbsp;</td>
         <td class="container">
           <div class="content">
-            <span class="preheader"><?= $this->preheader ?></span>
+            <?php if ($this->preheader): ?>
+              <span class="preheader"><?= $this->preheader ?></span>
+            <?php endif; ?>
             <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
               <tr>
                 <td class="wrapper">

--- a/core-bundle/contao/templates/twig/mail_responsive.html.twig
+++ b/core-bundle/contao/templates/twig/mail_responsive.html.twig
@@ -284,7 +284,9 @@
             <td>&nbsp;</td>
             <td class="container">
                 <div class="content">
-                    <span class="preheader">{{ preheader }}</span>
+                    {% if preheader|default %}
+                        <span class="preheader">{{ preheader }}</span>
+                    {% endif %}
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
                         <tr>
                             <td class="wrapper">


### PR DESCRIPTION
Fixes https://github.com/terminal42/contao-notification_center/issues/427

Regardless of the issue in the NC, it makes sense to make `preheader` fully optional in the templates, as it is also optional in the `contao/newsletter-bundle`, which actually uses this template.

https://github.com/contao/contao/blob/64bdacbae5eaaf1681ef90a86a961608198ac49c/newsletter-bundle/contao/dca/tl_newsletter.php#L124-L130