### PR TITLE
Do not limit crawler on the command line

### DIFF
--- a/core-bundle/src/Messenger/Message/CrawlMessage.php
+++ b/core-bundle/src/Messenger/Message/CrawlMessage.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Messenger\Message;
 
-use Contao\CoreBundle\Messenger\Message\ScopeAwareMessageTrait;
 use Symfony\Component\Messenger\Attribute\AsMessage;
 
 /**

--- a/core-bundle/src/Messenger/Message/CrawlMessage.php
+++ b/core-bundle/src/Messenger/Message/CrawlMessage.php
@@ -12,15 +12,17 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Messenger\Message;
 
+use Contao\CoreBundle\Messenger\Message\ScopeAwareMessageTrait;
 use Symfony\Component\Messenger\Attribute\AsMessage;
 
 /**
  * @internal
  */
 #[AsMessage('contao_prio_low')]
-class CrawlMessage implements JobIdAwareMessageInterface
+class CrawlMessage implements JobIdAwareMessageInterface, ScopeAwareMessageInterface
 {
     use JobIdAwareMessageTrait;
+    use ScopeAwareMessageTrait;
 
     public function __construct(
         public array $subscribers,

--- a/core-bundle/src/Messenger/MessageHandler/CrawlMessageHandler.php
+++ b/core-bundle/src/Messenger/MessageHandler/CrawlMessageHandler.php
@@ -77,7 +77,7 @@ class CrawlMessageHandler
         $logger = $this->createLogger($job, $message->subscribers);
 
         $escargot = $escargot
-            ->withMaxDurationInSeconds(20) // This we can improve in the future. It's only needed in the "web" scope
+            ->withMaxDurationInSeconds('cli' === \PHP_SAPI ? 0 : 20) // Limit to 20 seconds in the "web" scope
             ->withConcurrency($this->concurrency)
             ->withMaxDepth($message->maxDepth)
             ->withLogger($logger)

--- a/core-bundle/src/Messenger/MessageHandler/CrawlMessageHandler.php
+++ b/core-bundle/src/Messenger/MessageHandler/CrawlMessageHandler.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Crawl\Monolog\CrawlCsvLogHandler;
 use Contao\CoreBundle\Job\Job;
 use Contao\CoreBundle\Job\Jobs;
 use Contao\CoreBundle\Messenger\Message\CrawlMessage;
+use Contao\CoreBundle\Messenger\Message\ScopeAwareMessageInterface;
 use Monolog\Handler\GroupHandler;
 use Monolog\Level;
 use Monolog\Logger;
@@ -77,7 +78,7 @@ class CrawlMessageHandler
         $logger = $this->createLogger($job, $message->subscribers);
 
         $escargot = $escargot
-            ->withMaxDurationInSeconds('cli' === \PHP_SAPI ? 0 : 20) // Limit to 20 seconds in the "web" scope
+            ->withMaxDurationInSeconds(ScopeAwareMessageInterface::SCOPE_CLI === $message->getScope() ? 0 : 20) // Limit to 20 seconds in the "web" scope
             ->withConcurrency($this->concurrency)
             ->withMaxDepth($message->maxDepth)
             ->withLogger($logger)


### PR DESCRIPTION
In Contao 5.3 the crawler was executed within the web scope when triggered via the back end, thus we limited its max duration to 20 seconds.

However, since Contao `5.7.0` (https://github.com/contao/contao/pull/8826) the crawler now _might_ be executed on the command line through one of the Messenger workers.

This PR removes the max duration when the `CrawlMessageHandler` is executed on the command line.

Background: someone [on the forum](https://community.contao.org/de/showthread.php?89114-Suchindex-Configured-max-duration-reached) was wondering why their whole website cannot be indexed when triggered via the back end. The website is quite large with over 1500 URLs in the sitemap - and the TTFB is quite high (over 500ms). Thus only a very small fraction of the website can ever be indexed within 20 seconds. Said user is still on Contao 5.3 - but in Contao 5.7 things could be different with properly executed messenger workers.