### PR TITLE
Generate the breadcrumb from the page trail

### DIFF
--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -64,7 +64,9 @@ class ModuleBreadcrumb extends Module
 		$request = $container->get('request_stack')->getCurrentRequest();
 
 		// Get all pages up to the root page
-		$objPages = PageModel::findMultipleByIds(array_reverse($objPage->trail));
+		$parents = array_reverse($objPage->trail);
+		array_pop($parents); // Remove current page (last trail item)
+		$objPages = PageModel::findMultipleByIds($parents);
 
 		if ($objPages !== null)
 		{

--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -64,7 +64,7 @@ class ModuleBreadcrumb extends Module
 		$request = $container->get('request_stack')->getCurrentRequest();
 
 		// Get all pages up to the root page
-		$objPages = PageModel::findParentsById($objPage->pid);
+		$objPages = PageModel::findMultipleByIds(array_reverse($objPage->trail));
 
 		if ($objPages !== null)
 		{


### PR DESCRIPTION
The page trail is already known in the page model. It should be more efficient to fetch all records in one query instead of a query for each parent record.