### PR TITLE
Enforce the naming convention for `HtmlAttributes` variables in Twig templates

### DIFF
--- a/.twig-cs-fixer.php
+++ b/.twig-cs-fixer.php
@@ -3,6 +3,7 @@
 use Contao\CoreBundle\Twig\Defer\DeferTokenParser;
 use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
 use Contao\CoreBundle\Twig\Slots\SlotTokenParser;
+use Contao\Tools\TwigCsFixer\Rules\HtmlAttributesVariableNameRule;
 use TwigCsFixer\Config\Config;
 use TwigCsFixer\File\Finder;
 use TwigCsFixer\Rules\File\DirectoryNameRule;
@@ -54,6 +55,8 @@ $ruleset->addRule(new ForbiddenFunctionRule([
     'contao_section', // only for legacy layouts
     'contao_sections', // only for legacy layouts
 ]));
+
+$ruleset->addRule(new HtmlAttributesVariableNameRule());
 
 $config = new Config();
 $config->allowNonFixableRules();

--- a/.twig-cs-fixer.php
+++ b/.twig-cs-fixer.php
@@ -47,6 +47,7 @@ foreach ($templatePaths as $templatePath) {
 }
 
 $ruleset->addRule(new FileExtensionRule());
+$ruleset->addRule(new HtmlAttributesVariableNameRule());
 $ruleset->addRule(new ValidConstantFunctionRule());
 
 $ruleset->addRule(new ForbiddenFunctionRule([
@@ -55,8 +56,6 @@ $ruleset->addRule(new ForbiddenFunctionRule([
     'contao_section', // only for legacy layouts
     'contao_sections', // only for legacy layouts
 ]));
-
-$ruleset->addRule(new HtmlAttributesVariableNameRule());
 
 $config = new Config();
 $config->allowNonFixableRules();

--- a/core-bundle/contao/templates/twig/backend/template_studio/index.html.twig
+++ b/core-bundle/contao/templates/twig/backend/template_studio/index.html.twig
@@ -5,7 +5,7 @@
 {% block ace_assets %}{% endblock %}
 
 {% block main %}
-    {% set template_studio_attrs = attrs()
+    {% set template_studio_attributes = attrs()
         .set('id', 'main')
         .set('aria-labelledby', 'main_headline')
         .set('data-controller', 'contao--template-studio')
@@ -13,9 +13,9 @@
         .set('data-contao--template-studio-follow-url-value', path('_contao_template_studio_follow.stream'))
         .set('data-contao--template-studio-block-info-url-value', path('_contao_template_studio_block_info.stream'))
         .set('data-twig-environment', environment_information|json_encode)
-        .mergeWith(template_studio_attrs|default)
+        .mergeWith(template_studio_attributes|default)
     %}
-    <main{{ template_studio_attrs }}>
+    <main{{ template_studio_attributes }}>
         {# Headline #}
         <h1 id="main_headline">
             {{ headline }}

--- a/core-bundle/contao/templates/twig/backend/template_studio/info/_block_info.html.twig
+++ b/core-bundle/contao/templates/twig/backend/template_studio/info/_block_info.html.twig
@@ -37,11 +37,11 @@
         <form class="block_hierarchy" method="get" data-turbo-stream>
             {# Block description #}
             {% for element in hierarchy %}
-                {% set element_attrs = attrs()
+                {% set element_attributes = attrs()
                     .addClass('block')
                     .addClass('target', element.target)
                     .addClass('shadowed', element.shadowed) %}
-                <div{{ element_attrs }}>
+                <div{{ element_attributes }}>
                     {{ include('@Contao/backend/template_studio/_template_badges.html.twig', {
                         badges: [
                             element.template.namespace == 'Contao_Global' ? 'user' : null,

--- a/core-bundle/contao/templates/twig/content_element/_video.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/_video.html.twig
@@ -17,12 +17,12 @@
                 {{ block('splash_screen_component') }}
             {% else %}
                 {% block iframe %}
-                    {% set iframe_attrs = attrs({width, height, src: source.url, allowfullscreen: true, referrerpolicy: 'strict-origin-when-cross-origin'})
+                    {% set iframe_attributes = attrs({width, height, src: source.url, allowfullscreen: true, referrerpolicy: 'strict-origin-when-cross-origin'})
                         .setIfExists('title', title|default)
-                        .mergeWith(iframe_attrs|default)
+                        .mergeWith(iframe_attributes|default)
                     %}
-                    {% do csp_source('frame-src', iframe_attrs.src) %}
-                    <iframe{{ iframe_attrs }}></iframe>
+                    {% do csp_source('frame-src', iframe_attributes.src) %}
+                    <iframe{{ iframe_attributes }}></iframe>
                 {% endblock %}
             {% endif %}
 

--- a/core-bundle/contao/templates/twig/content_element/youtube.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/youtube.html.twig
@@ -1,9 +1,9 @@
 {% trans_default_domain 'contao_default' %}
 {% extends '@Contao/content_element/_video.html.twig' %}
 
-{% set iframe_attrs = attrs()
+{% set iframe_attributes = attrs()
     .set('allow', 'autoplay; encrypted-media; picture-in-picture; fullscreen')
-    .mergeWith(iframe_attrs|default)
+    .mergeWith(iframe_attributes|default)
 %}
 
 {% block splash_screen_text %}

--- a/vendor-bin/twig-cs-fixer/composer.json
+++ b/vendor-bin/twig-cs-fixer/composer.json
@@ -7,7 +7,7 @@
     },
     "autoload": {
         "psr-4": {
-          "Contao\\Tools\\TwigCsFixer\\": "src/"
+            "Contao\\Tools\\TwigCsFixer\\": "src/"
         }
     },
     "config": {

--- a/vendor-bin/twig-cs-fixer/composer.json
+++ b/vendor-bin/twig-cs-fixer/composer.json
@@ -5,6 +5,11 @@
     "require-dev": {
         "symfony/twig-bridge": "^7.4"
     },
+    "autoload": {
+        "psr-4": {
+          "Contao\\Tools\\TwigCsFixer\\": "src/"
+        }
+    },
     "config": {
         "platform": {
             "php": "8.3"

--- a/vendor-bin/twig-cs-fixer/src/Rules/HtmlAttributesVariableNameRule.php
+++ b/vendor-bin/twig-cs-fixer/src/Rules/HtmlAttributesVariableNameRule.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Contao\Tools\TwigCsFixer\Rules;
+
+use TwigCsFixer\Rules\AbstractRule;
+use TwigCsFixer\Token\Token;
+use TwigCsFixer\Token\Tokens;
+use TwigCsFixer\Util\StringUtil;
+
+/**
+ * Ensures that variables, that are assigned an HtmlAttributes instance via the
+ * "attrs()" function have a suffix "_attributes" in their name.
+ *
+ * Examples of valid naming:
+ *   {% set foo_attributes = attrs() […] %}
+ *   {% set foo_bar_attributes = attrs() […] %}
+ *   {% set attributes = attrs() […] %}
+ *
+ * Examples of invalid naming:
+ *   {% set bar = attrs() […] %}
+ *   {% set bar_attrs = attrs() […] %}
+ *   {% set barattributes = attrs() […] %}
+ */
+final class HtmlAttributesVariableNameRule extends AbstractRule
+{
+    const EXPECTED_SUFFIX = 'attributes';
+
+    protected function process(int $tokenIndex, Tokens $tokens): void
+    {
+        $token = $tokens->get($tokenIndex);
+
+        if (!$token->isMatching(Token::BLOCK_NAME_TYPE, 'set')) {
+            return;
+        }
+
+        $nameTokenIndex = $tokens->findNext(Token::NAME_TYPE, $tokenIndex);
+
+        $valueToken = $tokens->get(
+            $tokens->findNext(
+                [...Token::INDENT_TOKENS, Token::OPERATOR_TYPE],
+                $nameTokenIndex + 1,
+                exclude: true,
+            )
+        );
+
+        if ($valueToken->isMatching(Token::FUNCTION_NAME_TYPE, 'attrs')) {
+            $this->validateAttrsVariable($tokens->get($nameTokenIndex));
+        }
+    }
+
+    private function validateAttrsVariable(Token $token): void
+    {
+        $name = $token->getValue();
+
+        if (preg_match(sprintf('/(?:^|\w_)%s$/', preg_quote(self::EXPECTED_SUFFIX, '/')), $name) === 1) {
+            return;
+        }
+
+        $this->addError(
+            \sprintf(
+                'The variable name storing the result of an "attrs()" function must have the "%s" suffix, got "%s".',
+                self::EXPECTED_SUFFIX,
+                $name
+            ),
+            $token,
+        );
+    }
+}

--- a/vendor-bin/twig-cs-fixer/src/Rules/HtmlAttributesVariableNameRule.php
+++ b/vendor-bin/twig-cs-fixer/src/Rules/HtmlAttributesVariableNameRule.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Contao\Tools\TwigCsFixer\Rules;
@@ -6,10 +7,9 @@ namespace Contao\Tools\TwigCsFixer\Rules;
 use TwigCsFixer\Rules\AbstractRule;
 use TwigCsFixer\Token\Token;
 use TwigCsFixer\Token\Tokens;
-use TwigCsFixer\Util\StringUtil;
 
 /**
- * Ensures that variables, that are assigned an HtmlAttributes instance via the
+ * Ensures that variables that are assigned an HtmlAttributes instance via the
  * "attrs()" function have a suffix "_attributes" in their name.
  *
  * Examples of valid naming:
@@ -24,7 +24,7 @@ use TwigCsFixer\Util\StringUtil;
  */
 final class HtmlAttributesVariableNameRule extends AbstractRule
 {
-    const EXPECTED_SUFFIX = 'attributes';
+    private const EXPECTED_SUFFIX = 'attributes';
 
     protected function process(int $tokenIndex, Tokens $tokens): void
     {
@@ -53,7 +53,7 @@ final class HtmlAttributesVariableNameRule extends AbstractRule
     {
         $name = $token->getValue();
 
-        if (preg_match(sprintf('/(?:^|\w_)%s$/', preg_quote(self::EXPECTED_SUFFIX, '/')), $name) === 1) {
+        if (1 === preg_match(sprintf('/(?:^|\w_)%s$/', preg_quote(self::EXPECTED_SUFFIX, '/')), $name)) {
             return;
         }
 


### PR DESCRIPTION
Fixes #9453 and adds a respective rule to the Twig CS Fixer.