### PR TITLE
Add the missing `basicEntities` conversion for form fields

### DIFF
--- a/core-bundle/contao/dca/tl_form_field.php
+++ b/core-bundle/contao/dca/tl_form_field.php
@@ -166,7 +166,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 		(
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('maxlength'=>255, 'tl_class'=>'w50'),
+			'eval'                    => array('maxlength'=>255, 'tl_class'=>'w50', 'basicEntities'=>true),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'name' => array
@@ -180,7 +180,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 		(
 			'search'                  => true,
 			'inputType'               => 'textarea',
-			'eval'                    => array('rte'=>'tinyMCE', 'basicEntities'=>true, 'helpwizard'=>true),
+			'eval'                    => array('rte'=>'tinyMCE', 'basicEntities'=>true, 'helpwizard'=>true, 'basicEntities'=>true),
 			'explanation'             => 'insertTags',
 			'sql'                     => "text NULL"
 		),
@@ -188,13 +188,13 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 		(
 			'search'                  => true,
 			'inputType'               => 'textarea',
-			'eval'                    => array('mandatory'=>true, 'allowHtml'=>true, 'class'=>'monospace', 'rte'=>'ace|html'),
+			'eval'                    => array('mandatory'=>true, 'allowHtml'=>true, 'class'=>'monospace', 'rte'=>'ace|html', 'basicEntities'=>true),
 			'sql'                     => "text NULL"
 		),
 		'options' => array
 		(
 			'inputType'               => 'optionWizard',
-			'eval'                    => array('mandatory'=>true, 'allowHtml'=>true),
+			'eval'                    => array('mandatory'=>true, 'allowHtml'=>true, 'basicEntities'=>true),
 			'xlabel' => array
 			(
 				array('tl_form_field', 'optionImportWizard')
@@ -219,7 +219,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 		(
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			'eval'                    => array('decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50', 'basicEntities'=>true),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'customRgxp' => array
@@ -232,7 +232,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 		(
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('maxlength'=>255, 'tl_class'=>'w50'),
+			'eval'                    => array('maxlength'=>255, 'tl_class'=>'w50', 'basicEntities'=>true),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'minlength' => array
@@ -340,7 +340,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 		(
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			'eval'                    => array('decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50', 'basicEntities'=>true),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'accesskey' => array


### PR DESCRIPTION
When updating from Contao 4.13 to Contao >=5.0.0, the basic entities (`[-]`, `[nbsp]`, etc.) in form fields of the form generator were converted by our migration:

https://github.com/contao/contao/blob/a9a30eefbc427b24d7ac68dde302d37256791911/core-bundle/src/Migration/Version500/BasicEntitiesMigration.php#L77-L83

However, all except `text` are missing `'basicEntities' => true` in their `eval`. Which means that you end up with labels like `Foo&shy;bar` in the back end - and entering `[-]` will not convert it to `&shy;` in the front end.

This PR adds the missing `basicEntities` settings for form fields.