### PR TITLE
Write the `DC_Folder` sources using the virtual filesystem

### DIFF
--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -2139,9 +2139,11 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 					$strSource = gzencode($strSource);
 				}
 
-				// Write the file
-				$objFile->write($strSource);
-				$objFile->close();
+				// Write the file using the VFS (see #9450)
+				System::getContainer()
+					->get('contao.filesystem.virtual.files')
+					->write(Path::makeRelative($objFile->path, 'files'), $strSource)
+				;
 
 				// Update the database
 				if ($this->blnIsDbAssisted && $objMeta !== null)

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -238,6 +238,7 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         $config
             ->mountLocalAdapter($uploadPath, $uploadPath, 'files')
             ->addVirtualFilesystem($filesStorageName = 'files', $uploadPath)
+            ->setPublic(true)
         ;
 
         $config


### PR DESCRIPTION
Fixes #9450 - this way the DBAFS will automatically be up to date when a source is changed.