### PR TITLE
Remove the unused `_store_referrer` attribute

### DIFF
--- a/core-bundle/config/routes.yaml
+++ b/core-bundle/config/routes.yaml
@@ -11,7 +11,6 @@ contao_backend_redirect:
     path: '%contao.backend.route_prefix%/'
     defaults:
         _scope: backend
-        _store_referrer: false
         _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction
         route: contao_backend
         permanent: true

--- a/core-bundle/src/Controller/Backend/BackendController.php
+++ b/core-bundle/src/Controller/Backend/BackendController.php
@@ -45,8 +45,8 @@ class BackendController extends AbstractController
         return $controller->run();
     }
 
-    #[Route('/login', name: 'contao_backend_login', defaults: ['_store_referrer' => false])]
-    #[Route('/login-link', name: 'contao_backend_login_link', defaults: ['_store_referrer' => false])]
+    #[Route('/login', name: 'contao_backend_login')]
+    #[Route('/login-link', name: 'contao_backend_login_link')]
     public function loginAction(Request $request): Response
     {
         $this->initializeContaoFramework();
@@ -73,13 +73,13 @@ class BackendController extends AbstractController
     /**
      * Symfony will un-authenticate the user automatically by calling this route.
      */
-    #[Route('/logout', name: 'contao_backend_logout', defaults: ['_store_referrer' => false])]
+    #[Route('/logout', name: 'contao_backend_logout')]
     public function logoutAction(): RedirectResponse
     {
         return $this->redirectToRoute('contao_backend_login');
     }
 
-    #[Route('/password', name: 'contao_backend_password', defaults: ['_store_referrer' => false])]
+    #[Route('/password', name: 'contao_backend_password')]
     public function passwordAction(): Response
     {
         $this->initializeContaoFramework();
@@ -89,7 +89,7 @@ class BackendController extends AbstractController
         return $controller->run();
     }
 
-    #[Route('/confirm', name: 'contao_backend_confirm', defaults: ['_store_referrer' => false])]
+    #[Route('/confirm', name: 'contao_backend_confirm')]
     public function confirmAction(): Response
     {
         $this->initializeContaoFramework();
@@ -99,7 +99,7 @@ class BackendController extends AbstractController
         return $controller->run();
     }
 
-    #[Route('/help', name: 'contao_backend_help', defaults: ['_store_referrer' => false])]
+    #[Route('/help', name: 'contao_backend_help')]
     public function helpAction(): Response
     {
         $this->initializeContaoFramework();
@@ -109,7 +109,7 @@ class BackendController extends AbstractController
         return $controller->run();
     }
 
-    #[Route('/popup', name: 'contao_backend_popup', defaults: ['_store_referrer' => false])]
+    #[Route('/popup', name: 'contao_backend_popup')]
     public function popupAction(): Response
     {
         $this->initializeContaoFramework();
@@ -119,7 +119,7 @@ class BackendController extends AbstractController
         return $controller->run();
     }
 
-    #[Route('/alerts', name: 'contao_backend_alerts', defaults: ['_store_referrer' => false])]
+    #[Route('/alerts', name: 'contao_backend_alerts')]
     public function alertsAction(): Response
     {
         $this->initializeContaoFramework();
@@ -134,7 +134,7 @@ class BackendController extends AbstractController
      * It will determine the current provider URL based on the value, which is usually
      * read dynamically via JavaScript.
      */
-    #[Route('/picker', name: 'contao_backend_picker', defaults: ['_store_referrer' => false])]
+    #[Route('/picker', name: 'contao_backend_picker')]
     public function pickerAction(Request $request): RedirectResponse
     {
         $extras = [];
@@ -157,7 +157,7 @@ class BackendController extends AbstractController
         return new RedirectResponse($picker->getCurrentUrl());
     }
 
-    #[Route('/{parameters}', name: 'contao_backend_fallback', requirements: ['parameters' => '.*'], defaults: ['_store_referrer' => false], priority: -1000)]
+    #[Route('/{parameters}', name: 'contao_backend_fallback', requirements: ['parameters' => '.*'], priority: -1000)]
     public function backendFallback(): Response
     {
         // Backwards compatibility: render the legacy bundle template if it exists

--- a/core-bundle/src/Controller/Backend/JobsController.php
+++ b/core-bundle/src/Controller/Backend/JobsController.php
@@ -30,7 +30,7 @@ class JobsController extends AbstractBackendController
     #[Route(
         '%contao.backend.route_prefix%/jobs/pending',
         name: '_contao_jobs_pending.stream',
-        defaults: ['_scope' => 'backend', '_store_referrer' => false],
+        defaults: ['_scope' => 'backend'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]

--- a/core-bundle/src/Controller/Backend/PreviewController.php
+++ b/core-bundle/src/Controller/Backend/PreviewController.php
@@ -31,7 +31,7 @@ use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
  * requested front end page while ensuring that the /preview.php entry point is
  * used. When requested, the front end user gets authenticated.
  */
-#[Route('%contao.backend.route_prefix%/preview', name: 'contao_backend_preview', defaults: ['_scope' => 'backend', '_allow_preview' => true, '_store_referrer' => false])]
+#[Route('%contao.backend.route_prefix%/preview', name: 'contao_backend_preview', defaults: ['_scope' => 'backend', '_allow_preview' => true])]
 class PreviewController
 {
     public function __construct(

--- a/core-bundle/src/Controller/Backend/PreviewSwitchController.php
+++ b/core-bundle/src/Controller/Backend/PreviewSwitchController.php
@@ -38,7 +38,7 @@ use Twig\Error\Error as TwigError;
  * - Provide the member usernames for the datalist
  * - Process the switch action (i.e. log in a specific front end user)
  */
-#[Route('%contao.backend.route_prefix%/preview_switch', name: 'contao_backend_switch', defaults: ['_scope' => 'backend', '_allow_preview' => true, '_store_referrer' => false])]
+#[Route('%contao.backend.route_prefix%/preview_switch', name: 'contao_backend_switch', defaults: ['_scope' => 'backend', '_allow_preview' => true])]
 class PreviewSwitchController
 {
     public function __construct(

--- a/core-bundle/src/Controller/Backend/SearchController.php
+++ b/core-bundle/src/Controller/Backend/SearchController.php
@@ -26,7 +26,7 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Route(
     '%contao.backend.route_prefix%/search',
     name: '_contao_backend_search.stream',
-    defaults: ['_scope' => 'backend', '_store_referrer' => false, '_token_check' => false],
+    defaults: ['_scope' => 'backend', '_token_check' => false],
     methods: ['GET', 'POST'],
     condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
 )]

--- a/core-bundle/src/Controller/Backend/TemplateStudioController.php
+++ b/core-bundle/src/Controller/Backend/TemplateStudioController.php
@@ -105,7 +105,7 @@ class TemplateStudioController extends AbstractBackendController
     #[Route(
         '/%contao.backend.route_prefix%/template-studio-tree',
         name: '_contao_template_studio_tree.stream',
-        defaults: ['_scope' => 'backend', '_store_referrer' => false],
+        defaults: ['_scope' => 'backend'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -122,7 +122,7 @@ class TemplateStudioController extends AbstractBackendController
     #[Route(
         '/%contao.backend.route_prefix%/template-studio/select_theme',
         name: '_contao_template_studio_select_theme.stream',
-        defaults: ['_scope' => 'backend', '_token_check' => false, '_store_referrer' => false],
+        defaults: ['_scope' => 'backend', '_token_check' => false],
         methods: ['POST'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -149,7 +149,7 @@ class TemplateStudioController extends AbstractBackendController
         '/%contao.backend.route_prefix%/template-studio/resource/{identifier}',
         name: '_contao_template_studio_editor_tab.stream',
         requirements: ['identifier' => '.+'],
-        defaults: ['_scope' => 'backend', '_store_referrer' => false],
+        defaults: ['_scope' => 'backend'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -264,7 +264,7 @@ class TemplateStudioController extends AbstractBackendController
     #[Route(
         '/%contao.backend.route_prefix%/template-studio-follow',
         name: '_contao_template_studio_follow.stream',
-        defaults: ['_scope' => 'backend', '_store_referrer' => false],
+        defaults: ['_scope' => 'backend'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -283,7 +283,7 @@ class TemplateStudioController extends AbstractBackendController
     #[Route(
         '/%contao.backend.route_prefix%/template-studio-block-info',
         name: '_contao_template_studio_block_info.stream',
-        defaults: ['_scope' => 'backend', '_store_referrer' => false],
+        defaults: ['_scope' => 'backend'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -375,7 +375,7 @@ class TemplateStudioController extends AbstractBackendController
     #[Route(
         '/%contao.backend.route_prefix%/template-studio-annotations-data',
         name: '_contao_template_studio_annotations_data.stream',
-        defaults: ['_scope' => 'backend', '_store_referrer' => false],
+        defaults: ['_scope' => 'backend'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -404,7 +404,7 @@ class TemplateStudioController extends AbstractBackendController
         '/%contao.backend.route_prefix%/template-studio/resource/{identifier}',
         name: '_contao_template_studio_operation.stream',
         requirements: ['identifier' => '.+'],
-        defaults: ['_scope' => 'backend', '_token_check' => false, '_store_referrer' => false],
+        defaults: ['_scope' => 'backend', '_token_check' => false],
         methods: ['POST'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]


### PR DESCRIPTION
We removed the `StoreRefererListener` in #8817 - but we still have leftover `_store_referrer` request attributes in various controllers.