### PR TITLE
Do not dispatch search index messages in debug mode

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -483,6 +483,7 @@ services:
             - '@messenger.bus.default'
             - '%fragment.path%'
             - '%contao.backend.route_prefix%'
+            - '%kernel.debug%'
 
     contao.listener.security.logout:
         class: Contao\CoreBundle\EventListener\Security\LogoutListener

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -45,6 +45,10 @@ class SearchIndexListener
      */
     public function __invoke(TerminateEvent $event): void
     {
+        if ($this->debugMode) {
+            return;
+        }
+
         $response = $event->getResponse();
 
         if ($response->isRedirection()) {
@@ -52,10 +56,6 @@ class SearchIndexListener
         }
 
         $request = $event->getRequest();
-
-        if ($this->debugMode) {
-            return;
-        }
 
         // Only handle GET requests (see #1194, #7240)
         if (!$request->isMethod(Request::METHOD_GET)) {

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -35,6 +35,7 @@ class SearchIndexListener
         private readonly MessageBusInterface $messageBus,
         private readonly string $fragmentPath = '_fragment',
         private readonly string $contaoBackendRoutePrefix = '/contao',
+        private readonly bool $debugMode = false,
         private readonly int $enabledFeatures = self::FEATURE_INDEX | self::FEATURE_DELETE,
     ) {
     }
@@ -51,6 +52,10 @@ class SearchIndexListener
         }
 
         $request = $event->getRequest();
+
+        if ($this->debugMode) {
+            return;
+        }
 
         // Only handle GET requests (see #1194, #7240)
         if (!$request->isMethod(Request::METHOD_GET)) {


### PR DESCRIPTION
This PR changes the `SearchIndexListener` to never dispatch any `SearchIndexMessage`, neither index nor delete, when in debug mode.
Without this change all pages that are visited in debug mode are deleted from the index, which is not only unnecessary, but also annoying when trying to test things like adding a primaryImageOfPage to a pages JSON-LD for the search. 🙃 