### PR TITLE
Replace insert tags in placeholders and help texts

### DIFF
--- a/core-bundle/contao/templates/twig/form_captcha.html.twig
+++ b/core-bundle/contao/templates/twig/form_captcha.html.twig
@@ -13,6 +13,8 @@
         <p class="error">{{ getErrorAsString.invoke() }}</p>
     {% endif %}
 
+    {% set input_attributes = attrs(getAttributes.invoke()) %}
+
     <input{{ attrs()
         .set('type', 'text')
         .set('name', this.name)
@@ -21,7 +23,8 @@
         .addClass(this.class|default)
         .set('aria-describedby', "captcha_text_#{this.id}")
         .set('value', '')
-        .mergeWith(getAttributes.invoke())
+        .mergeWith(input_attributes)
+        .set('placeholder', input_attributes.placeholder|insert_tag)
     }}>
     <span id="captcha_text_{{ this.id }}" class="captcha_text{% if this.class|default %} {{ this.class|default }}{% endif %}">{{ getQuestion.invoke() }}</span>
     <input type="hidden" name="{{ this.name }}_hash{{ hasErrors.invoke() ? 1 + this.sum ** 2 : '' }}" value="{{ hasErrors.invoke() ? getHash.invoke() : '' }}">

--- a/core-bundle/contao/templates/twig/form_checkbox.html.twig
+++ b/core-bundle/contao/templates/twig/form_checkbox.html.twig
@@ -43,7 +43,7 @@
         {% endfor %}
 
         {% if this.help|default %}
-            <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help }}</p>
+            <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help|insert_tag_raw }}</p>
         {% endif %}
 
     </fieldset>

--- a/core-bundle/contao/templates/twig/form_password.html.twig
+++ b/core-bundle/contao/templates/twig/form_password.html.twig
@@ -30,6 +30,6 @@
     }}>
 
     {% if this.help|default %}
-        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help }}</p>
+        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help|insert_tag_raw }}</p>
     {% endif %}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/form_radio.html.twig
+++ b/core-bundle/contao/templates/twig/form_radio.html.twig
@@ -41,7 +41,7 @@
         {% endfor %}
 
         {% if this.help|default %}
-            <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help }}</p>
+            <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help|insert_tag_raw }}</p>
         {% endif %}
 
     </fieldset>

--- a/core-bundle/contao/templates/twig/form_range.html.twig
+++ b/core-bundle/contao/templates/twig/form_range.html.twig
@@ -31,6 +31,6 @@
     }}>
 
     {% if this.help|default %}
-        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help }}</p>
+        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help|insert_tag_raw }}</p>
     {% endif %}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/form_select.html.twig
+++ b/core-bundle/contao/templates/twig/form_select.html.twig
@@ -44,6 +44,6 @@
     </select>
 
     {% if this.help|default %}
-        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help }}</p>
+        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help|insert_tag_raw }}</p>
     {% endif %}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/form_text.html.twig
+++ b/core-bundle/contao/templates/twig/form_text.html.twig
@@ -17,6 +17,8 @@
         <p class="error">{{ getErrorAsString.invoke() }}</p>
     {% endif %}
 
+    {% set input_attributes = attrs(getAttributes.invoke()) %}
+
     <input{{ attrs()
         .set('type', this.type)
         .set('name', this.name)
@@ -26,9 +28,10 @@
         .addClass(this.class|default)
         .set('value', convertDate.invoke(this.value|default|insert_tag))
         .set('aria-describedby', "help_ctrl_#{this.id}", this.help|default)
-        .mergeWith(getAttributes.invoke())
+        .mergeWith(input_attributes)
+        .set('placeholder', input_attributes.placeholder|insert_tag)
     }}>
     {% if this.help|default %}
-        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help }}</p>
+        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help|insert_tag_raw }}</p>
     {% endif %}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/form_textarea.html.twig
+++ b/core-bundle/contao/templates/twig/form_textarea.html.twig
@@ -17,6 +17,8 @@
         <p class="error">{{ getErrorAsString.invoke() }}</p>
     {% endif %}
 
+    {% set textarea_attributes= attrs(getAttributes.invoke()) %}
+
     <textarea{{ attrs()
         .set('name', this.name)
         .set('id', "ctrl_#{this.id}")
@@ -25,10 +27,11 @@
         .set('rows', this.rows)
         .set('cols', this.cols)
         .set('aria-describedby', "help_ctrl_#{this.id}", this.help|default)
-        .mergeWith(getAttributes.invoke())
+        .mergeWith(textarea_attributes)
+        .set('placeholder', textarea_attributes.placeholder|insert_tag)
     }}>{{ this.value|insert_tag }}</textarea>
 
     {% if this.help|default %}
-        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help }}</p>
+        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help|insert_tag_raw }}</p>
     {% endif %}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/form_textarea.html.twig
+++ b/core-bundle/contao/templates/twig/form_textarea.html.twig
@@ -17,7 +17,7 @@
         <p class="error">{{ getErrorAsString.invoke() }}</p>
     {% endif %}
 
-    {% set textarea_attributes= attrs(getAttributes.invoke()) %}
+    {% set textarea_attributes = attrs(getAttributes.invoke()) %}
 
     <textarea{{ attrs()
         .set('name', this.name)

--- a/core-bundle/contao/templates/twig/form_upload.html.twig
+++ b/core-bundle/contao/templates/twig/form_upload.html.twig
@@ -29,6 +29,6 @@
     }}>
 
     {% if this.help|default %}
-        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help }}</p>
+        <p class="help" id="help_ctrl_{{ this.id }}">{{ this.help|insert_tag_raw }}</p>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Common usage might be the `{{iflng::*}}` insert tag for example.