### PR TITLE
Activate Turbo for the Template Studio if it is disabled on the outer element

### DIFF
--- a/core-bundle/contao/templates/twig/backend/template_studio/index.html.twig
+++ b/core-bundle/contao/templates/twig/backend/template_studio/index.html.twig
@@ -38,7 +38,7 @@
             {{ include('@Contao/backend/component/_favorites.html.twig') }}
         </h1>
 
-        <section id="template-studio" class="content chrome" data-contao--template-studio-target="content">
+        <section id="template-studio" class="content chrome" data-contao--template-studio-target="content" data-turbo="true">
             <div id="template-studio--nav">
                 {# Theme selector #}
                 {% if themes|length %}


### PR DESCRIPTION
If you disable turbo on the `html` element, the template studio won't work anymore.

<img width="1006" height="543" alt="Bildschirmfoto 2026-02-23 um 22 34 37" src="https://github.com/user-attachments/assets/cd292dca-095a-4830-b859-5d3a2fb60a08" />
