### PR TITLE
Use the page finder to check page access

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -527,7 +527,7 @@ services:
     contao.listener.page_access:
         class: Contao\CoreBundle\EventListener\PageAccessListener
         arguments:
-            - '@contao.framework'
+            - '@contao.routing.page_finder'
             - '@security.helper'
 
     contao.listener.page_trail_cache_tags:

--- a/core-bundle/tests/EventListener/PageAccessListenerTest.php
+++ b/core-bundle/tests/EventListener/PageAccessListenerTest.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\Tests\EventListener;
 use Contao\CoreBundle\EventListener\PageAccessListener;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
-use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\PageModel;
@@ -43,121 +43,8 @@ class PageAccessListenerTest extends TestCase
             ->willReturn($request)
         ;
 
-        $listener = new PageAccessListener($this->mockFramework(), $security);
+        $listener = new PageAccessListener($this->mockPageFinder(null), $security);
         $listener($event);
-
-        $this->assertFalse($request->attributes->has('pageModel'));
-    }
-
-    public function testSetsPageModelFromGlobalWithIdInRequest(): void
-    {
-        $security = $this->createMock(Security::class);
-        $security
-            ->expects($this->never())
-            ->method('isGranted')
-        ;
-
-        $request = new Request();
-        $request->attributes->set('pageModel', 42);
-
-        $event = $this->createMock(RequestEvent::class);
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $GLOBALS['objPage'] = $this->createClassWithPropertiesStub(PageModel::class, ['id' => 42]);
-
-        $listener = new PageAccessListener($this->mockFramework(), $security);
-        $listener($event);
-
-        $this->assertSame($GLOBALS['objPage'], $request->attributes->get('pageModel'));
-
-        unset($GLOBALS['objPage']);
-    }
-
-    public function testSetsPageModelFromModelWithIdInRequest(): void
-    {
-        $security = $this->createMock(Security::class);
-        $security
-            ->expects($this->never())
-            ->method('isGranted')
-        ;
-
-        $request = new Request();
-        $request->attributes->set('pageModel', 42);
-
-        $event = $this->createMock(RequestEvent::class);
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $pageModel = $this->createClassWithPropertiesStub(PageModel::class, ['id' => 42]);
-
-        $listener = new PageAccessListener($this->mockFramework(42, $pageModel), $security);
-        $listener($event);
-
-        $this->assertSame($pageModel, $request->attributes->get('pageModel'));
-    }
-
-    public function testSetsPageModelFromGlobalWithModelInRequest(): void
-    {
-        $security = $this->createMock(Security::class);
-        $security
-            ->expects($this->never())
-            ->method('isGranted')
-        ;
-
-        $pageModel = $this->createClassWithPropertiesStub(PageModel::class, ['id' => 42]);
-
-        $request = new Request();
-        $request->attributes->set('pageModel', $pageModel);
-
-        $event = $this->createMock(RequestEvent::class);
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $GLOBALS['objPage'] = $this->createClassWithPropertiesStub(PageModel::class, ['id' => 42]);
-
-        $listener = new PageAccessListener($this->mockFramework(), $security);
-        $listener($event);
-
-        $this->assertNotSame($pageModel, $request->attributes->get('pageModel'));
-        $this->assertSame($GLOBALS['objPage'], $request->attributes->get('pageModel'));
-
-        unset($GLOBALS['objPage']);
-    }
-
-    public function testSetsPageModelFromModelInRequest(): void
-    {
-        $security = $this->createMock(Security::class);
-        $security
-            ->expects($this->never())
-            ->method('isGranted')
-        ;
-
-        $pageModel = $this->createClassWithPropertiesStub(PageModel::class, ['id' => 42]);
-
-        $request = new Request();
-        $request->attributes->set('pageModel', $pageModel);
-
-        $event = $this->createMock(RequestEvent::class);
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $listener = new PageAccessListener($this->mockFramework(), $security);
-        $listener($event);
-
-        $this->assertSame($pageModel, $request->attributes->get('pageModel'));
     }
 
     public function testDeniesAccessToProtectedPageIfMemberIsNotLoggedIn(): void
@@ -176,23 +63,18 @@ class PageAccessListenerTest extends TestCase
             'groups' => [1, 2, 3],
         ]);
 
-        $request = new Request();
-        $request->attributes->set('pageModel', $pageModel);
-
         $event = $this->createMock(RequestEvent::class);
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->willReturn($request)
+            ->willReturn(new Request())
         ;
 
         $this->expectException(InsufficientAuthenticationException::class);
         $this->expectExceptionMessage('Not authenticated');
 
-        $listener = new PageAccessListener($this->mockFramework(), $security);
+        $listener = new PageAccessListener($this->mockPageFinder($pageModel), $security);
         $listener($event);
-
-        $this->assertSame($pageModel, $request->attributes->get('pageModel'));
     }
 
     public function testDeniesAccessToProtectedPageIfMemberIsNotInGroup(): void
@@ -213,23 +95,18 @@ class PageAccessListenerTest extends TestCase
             'groups' => [1, 2, 3],
         ]);
 
-        $request = new Request();
-        $request->attributes->set('pageModel', $pageModel);
-
         $event = $this->createMock(RequestEvent::class);
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->willReturn($request)
+            ->willReturn(new Request())
         ;
 
         $this->expectException(AccessDeniedException::class);
         $this->expectExceptionMessage('Member does not have access to page ID 42');
 
-        $listener = new PageAccessListener($this->mockFramework(), $security);
+        $listener = new PageAccessListener($this->mockPageFinder($pageModel), $security);
         $listener($event);
-
-        $this->assertSame($pageModel, $request->attributes->get('pageModel'));
     }
 
     public function testDeniesAccessToProtectedPageIfMemberIsNotGuest(): void
@@ -250,23 +127,18 @@ class PageAccessListenerTest extends TestCase
             'groups' => [-1, 1],
         ]);
 
-        $request = new Request();
-        $request->attributes->set('pageModel', $pageModel);
-
         $event = $this->createMock(RequestEvent::class);
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->willReturn($request)
+            ->willReturn(new Request())
         ;
 
         $this->expectException(AccessDeniedException::class);
         $this->expectExceptionMessage('Member does not have access to page ID 42');
 
-        $listener = new PageAccessListener($this->mockFramework(), $security);
+        $listener = new PageAccessListener($this->mockPageFinder($pageModel), $security);
         $listener($event);
-
-        $this->assertSame($pageModel, $request->attributes->get('pageModel'));
     }
 
     public function testGrantsAccessToProtectedPageIfMemberIsInGroup(): void
@@ -287,20 +159,15 @@ class PageAccessListenerTest extends TestCase
             'groups' => [1, 2, 3],
         ]);
 
-        $request = new Request();
-        $request->attributes->set('pageModel', $pageModel);
-
         $event = $this->createMock(RequestEvent::class);
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->willReturn($request)
+            ->willReturn(new Request())
         ;
 
-        $listener = new PageAccessListener($this->mockFramework(), $security);
+        $listener = new PageAccessListener($this->mockPageFinder($pageModel), $security);
         $listener($event);
-
-        $this->assertSame($pageModel, $request->attributes->get('pageModel'));
     }
 
     public function testGrantsAccessToProtectedPageIfIsGuest(): void
@@ -321,58 +188,26 @@ class PageAccessListenerTest extends TestCase
             'groups' => [-1, 1],
         ]);
 
-        $request = new Request();
-        $request->attributes->set('pageModel', $pageModel);
-
         $event = $this->createMock(RequestEvent::class);
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->willReturn($request)
+            ->willReturn(new Request())
         ;
 
-        $listener = new PageAccessListener($this->mockFramework(), $security);
+        $listener = new PageAccessListener($this->mockPageFinder($pageModel), $security);
         $listener($event);
-
-        $this->assertSame($pageModel, $request->attributes->get('pageModel'));
     }
 
-    private function mockFramework(int|null $id = null, PageModel|null $pageModel = null): ContaoFramework&MockObject
+    private function mockPageFinder(PageModel|null $pageModel): PageFinder&MockObject
     {
-        $framework = $this->createMock(ContaoFramework::class);
-
-        if (null === $id) {
-            $framework
-                ->expects($this->never())
-                ->method('initialize')
-            ;
-
-            $framework
-                ->expects($this->never())
-                ->method('getAdapter')
-            ;
-
-            return $framework;
-        }
-
-        $pageAdapter = $this->createAdapterMock(['findById']);
-        $pageAdapter
+        $pageFinder = $this->createMock(PageFinder::class);
+        $pageFinder
             ->expects($this->once())
-            ->method('findById')
+            ->method('getCurrentPage')
             ->willReturn($pageModel)
         ;
 
-        $framework
-            ->expects($this->once())
-            ->method('initialize')
-        ;
-
-        $framework
-            ->expects($this->once())
-            ->method('getAdapter')
-            ->willReturn($pageAdapter)
-        ;
-
-        return $framework;
+        return $pageFinder;
     }
 }


### PR DESCRIPTION
We switched everything to the `PageFinder` in #6997 but seem to have forgotten this place (still implementing the logic from https://github.com/contao/contao/pull/2591)