### PR TITLE
Fix an invalid query if `root` incorrectly contains non-numerical IDs

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3391,7 +3391,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		{
 			// Ensure correct sorting of root IDs, e.g. if user is given access to a limited set of root page.
 			$topMostRootIds = $db
-				->prepare("SELECT id FROM $table WHERE id IN (" . implode(',', $this->root) . ') ORDER BY sorting, id')
+				->prepare("SELECT id FROM $table WHERE id IN (" . implode(',', array_map('\intval', $this->root)) . ') ORDER BY sorting, id')
 				->execute()
 				->fetchEach('id');
 		}
@@ -4920,7 +4920,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 			if (!empty($this->root) && \is_array($this->root))
 			{
-				$arrProcedure[] = 'id IN(' . implode(',', $this->root) . ')';
+				$arrProcedure[] = 'id IN(' . implode(',', array_map('\intval', $this->root)) . ')';
 			}
 
 			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
@@ -5522,7 +5522,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		// $this->root might not have a correct order here, let's make sure it's ordered by sorting
 		if ($this->root && $db->fieldExists('sorting', $table))
 		{
-			$this->root = $db->execute("SELECT id FROM $table WHERE id IN (" . implode(',', $this->root) . ") ORDER BY sorting, id")->fetchEach('id');
+			$this->root = $db->execute("SELECT id FROM $table WHERE id IN (" . implode(',', array_map('\intval', $this->root)) . ") ORDER BY sorting, id")->fetchEach('id');
 		}
 	}
 

--- a/core-bundle/src/EventListener/DataContainer/UserRootListener.php
+++ b/core-bundle/src/EventListener/DataContainer/UserRootListener.php
@@ -79,7 +79,7 @@ class UserRootListener implements ResetInterface
 
         $rootField = $GLOBALS['TL_DCA'][$table]['config']['userRoot'];
         $root = $user->{$rootField};
-        $root = array_filter($root ?? [], is_numeric(...));
+        $root = array_filter((array) $root, is_numeric(...));
 
         if ([] === $root) {
             $root = [0];

--- a/core-bundle/src/EventListener/DataContainer/UserRootListener.php
+++ b/core-bundle/src/EventListener/DataContainer/UserRootListener.php
@@ -79,8 +79,9 @@ class UserRootListener implements ResetInterface
 
         $rootField = $GLOBALS['TL_DCA'][$table]['config']['userRoot'];
         $root = $user->{$rootField};
+        $root = array_filter($root ?? [], is_numeric(...));
 
-        if (empty($root) || !\is_array($root)) {
+        if ([] === $root) {
             $root = [0];
         }
 

--- a/core-bundle/tests/EventListener/DataContainer/UserRootListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/UserRootListenerTest.php
@@ -265,6 +265,24 @@ class UserRootListenerTest extends TestCase
         $this->assertSame([1, 2, 3], $GLOBALS['TL_DCA']['tl_foo']['list']['sorting']['root']);
     }
 
+    public function testDoesNotFilterRecordsByNonNumericRoots(): void
+    {
+        $user = $this->createClassWithPropertiesStub(BackendUser::class, [
+            'foobars' => [1, 2, 3, 'foo'],
+        ]);
+
+        $this->registerCallbacks($this->mockSecurity(true, $user));
+
+        $GLOBALS['TL_DCA']['tl_foo']['config']['userRoot'] = 'foobars';
+
+        $callback = $GLOBALS['TL_DCA']['tl_foo']['config']['onload_callback'][0] ?? null;
+        $this->assertIsCallable($callback);
+        $callback();
+
+        $this->assertArrayHasKey('root', $GLOBALS['TL_DCA']['tl_foo']['list']['sorting'] ?? []);
+        $this->assertSame([1, 2, 3], $GLOBALS['TL_DCA']['tl_foo']['list']['sorting']['root']);
+    }
+
     public function testDoesNotAdjustsPermissionsIfIdIsAlreadyEnabled(): void
     {
         $user = $this->createClassWithPropertiesStub(BackendUser::class, [


### PR DESCRIPTION
When trying to access image sizes as a non-admin backend user `root` will contain `crop`, `proportional` and `box`.
This will cause an invalid query with the following exception.

```
Doctrine\DBAL\Exception\InvalidFieldNameException:
An exception occurred while executing a query: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'crop' in 'WHERE'

  at vendor/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php:63
  at Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter->convert(object(Exception), object(Query))
     (vendor/doctrine/dbal/src/Connection.php:1460)
  at Doctrine\DBAL\Connection->handleDriverException(object(Exception), object(Query))
     (vendor/doctrine/dbal/src/Connection.php:1396)
  at Doctrine\DBAL\Connection->convertExceptionDuringQuery(object(Exception), 'SELECT COUNT(*) AS count FROM tl_image_size WHERE pid=? AND id IN(crop,proportional,box)', array(1), array(object(ParameterType)))
     (vendor/doctrine/dbal/src/Connection.php:809)
  at Doctrine\DBAL\Connection->executeQuery('SELECT COUNT(*) AS count FROM tl_image_size WHERE pid=? AND id IN(crop,proportional,box)', array(1), array(object(ParameterType)))
     (vendor/contao/contao/core-bundle/contao/library/Contao/Database/Statement.php:268)
  at Contao\Database\Statement->query('', array(1))
     (vendor/contao/contao/core-bundle/contao/library/Contao/Database/Statement.php:219)
  at Contao\Database\Statement->execute(1)
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:4938)
  at Contao\DC_Table->limitMenu()
     (vendor/contao/contao/core-bundle/contao/classes/DataContainer.php:1152)
  at Contao\DataContainer->panel()
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:522)
  at Contao\DC_Table->showAll()
     (vendor/contao/contao/core-bundle/contao/classes/Backend.php:459)
  at Contao\Backend->getBackendModule('themes', null)
     (vendor/contao/contao/core-bundle/contao/controllers/BackendMain.php:143)
  at Contao\BackendMain->run()
     (vendor/contao/contao/core-bundle/src/Controller/Backend/BackendController.php:45)
  at Contao\CoreBundle\Controller\Backend\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:42)
  at require('..../public/index.php')
     (/Users/lukasbableck/.composer/vendor/laravel/valet/server.php:110)
```