### PR TITLE
Replace insert tags for password field placeholders

### DIFF
--- a/core-bundle/contao/templates/twig/form_password.html.twig
+++ b/core-bundle/contao/templates/twig/form_password.html.twig
@@ -17,6 +17,8 @@
         <p class="error">{{ getErrorAsString.invoke() }}</p>
     {% endif %}
 
+    {% set input_attributes = attrs(getAttributes.invoke()) %}
+
     <input{{ attrs()
         .set('type', 'password')
         .set('name', this.name)
@@ -27,6 +29,7 @@
         .set('autocomplete', 'new-password')
         .set('aria-describedby', "help_ctrl_#{this.id}", this.help|default)
         .mergeWith(getAttributes.invoke())
+        .setIfExists('placeholder', input_attributes.placeholder|default|insert_tag)
     }}>
 
     {% if this.help|default %}


### PR DESCRIPTION
The password fields placeholder probably was overlooked in https://github.com/contao/contao/pull/9495