### PR TITLE
Cast timestamps to int in the `ValueFormatter`

### DIFF
--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -93,21 +93,21 @@ class ValueFormatter implements ResetInterface
     public function formatGroup(string $table, string $field, mixed $value, int $mode, mixed $dc): string
     {
         if (\in_array($mode, [DataContainer::SORT_DAY_ASC, DataContainer::SORT_DAY_DESC, DataContainer::SORT_DAY_BOTH], true)) {
-            return $value ? Date::parse(Config::get('dateFormat'), $value) : '-';
+            return $value ? Date::parse(Config::get('dateFormat'), (int) $value) : '-';
         }
 
         if (\in_array($mode, [DataContainer::SORT_MONTH_ASC, DataContainer::SORT_MONTH_DESC, DataContainer::SORT_MONTH_BOTH], true)) {
-            $intMonth = $value ? date('m', $value) - 1 : '-';
+            $intMonth = $value ? date('m', (int) $value) - 1 : '-';
 
             if (isset($GLOBALS['TL_LANG']['MONTHS'][$intMonth])) {
-                return $value ? $GLOBALS['TL_LANG']['MONTHS'][$intMonth].' '.date('Y', $value) : '-';
+                return $value ? $GLOBALS['TL_LANG']['MONTHS'][$intMonth].' '.date('Y', (int) $value) : '-';
             }
 
-            return $value ? date('Y-m', $value) : '-';
+            return $value ? date('Y-m', (int) $value) : '-';
         }
 
         if (\in_array($mode, [DataContainer::SORT_YEAR_ASC, DataContainer::SORT_YEAR_DESC, DataContainer::SORT_YEAR_BOTH], true)) {
-            return $value ? date('Y', $value) : '-';
+            return $value ? date('Y', (int) $value) : '-';
         }
 
         if ('checkbox' === ($GLOBALS['TL_DCA'][$table]['fields'][$field]['inputType'] ?? null) && !($GLOBALS['TL_DCA'][$table]['fields'][$field]['eval']['multiple'] ?? null)) {


### PR DESCRIPTION
Timestamps might be stored in `VARCHAR` fields in the DB, like with `tl_comment.date`.
This for example leads to the following exception when opening the comments backend module.

```
TypeError:
date(): Argument #2 ($timestamp) must be of type ?int, string given

  at vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:100
  at date('m', '1676228095')
     (vendor/contao/contao/core-bundle/src/DataContainer/ValueFormatter.php:100)
  at Contao\CoreBundle\DataContainer\ValueFormatter->formatGroup('tl_comments', 'date', '1676228095', 8, object(DC_Table))
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:5368)
  at Contao\DC_Table->formatGroupHeader('date', '1676228095', 8, array('id' => 4, 'tstamp' => 1676228095, 'source' => 'tl_news', 'parent' => 7, 'date' => '1676228095', 'name' => 'Tester', 'email' => 'fake@email.co', 'website' => '', 'member' => 0, 'comment' => '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Urna lectus velit odio nibh lacus, odio nunc elementum, tortor. Cursus congue habitant ipsum, commodo mattis mauris sit urna dui. Vel auctor in aliquam in cursus fermentum elit sit elit. Velit placerat scelerisque feugiat ut imperdiet enim sollicitudin lectus. Mauris amet, ac vitae et pellentesque eget feugiat hac. Amet posuere tempus pharetra, hendrerit morbi dictum adipiscing.<br>Ullamcorper rhoncus, massa urna scelerisque arcu mattis eget. Risus scelerisque posuere egestas eros sit amet, posuere. Quis platea venenatis, et arcu consequat justo, nunc eu. Facilisi molestie ultrices aliquet facilisis sapien, diam. Tempor ipsum, quis non faucibus venenatis non laoreet elit purus. Amet massa morbi praesent aliquam integer ut.   Tortor et, eget eget sem elit tempor. Volutpat eget lacus, sagittis in. Blandit volutpat neque senectus arcu a semper. Porta auctor quisque pellentesque euismod elementum. Diam non proin duis nunc. Ullamcorper nisl at odio semper facilisis pellentesque lacinia. Eget aliquam urna sit quis.  Tincidunt dictum enim ac tellus id imperdiet sapien. At ultrices in mi turpis sed. Habitasse tincidunt sit est eget vulputate egestas. Tincidunt porttitor egestas diam et a semper. Ut magna ipsum, tempor lorem porttitor. Diam duis velit sit commodo hendrerit dignissim duis morbi. Maecenas pharetra gravida tortor, consequat integer faucibus urna in semper. Hendrerit turpis consectetur tellus massa porta nisi, sit nunc in. Blandit maecenas phasellus amet nibh. Maecenas aliquam enim risus, consectetur mi. Quam eget leo egestas mauris eu non eget tincidunt. Fusce fusce malesuada vel diam, id pellentesque magnis viverra tincidunt. Venenatis mattis libero integer amet. Nisl sed sagittis vulputate vestibulum consectetur.</p>', 'addReply' => 0, 'author' => 0, 'reply' => null, 'published' => 1, 'ip' => '', 'notified' => 1, 'notifiedReply' => 0))
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:4523)
  at Contao\DC_Table->listView()
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:523)
  at Contao\DC_Table->showAll()
     (vendor/contao/contao/core-bundle/contao/classes/Backend.php:459)
  at Contao\Backend->getBackendModule('comments', null)
     (vendor/contao/contao/core-bundle/contao/controllers/BackendMain.php:143)
  at Contao\BackendMain->run()
     (vendor/contao/contao/core-bundle/src/Controller/Backend/BackendController.php:45)
  at Contao\CoreBundle\Controller\Backend\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:42)
  at require('.../contao57/public/index.php')
     (/Users/lukasbableck/.composer/vendor/laravel/valet/server.php:110)                
```