### PR TITLE
Set the correct enctype for the Template Studio editor form

### DIFF
--- a/core-bundle/contao/templates/twig/backend/template_studio/editor/_editor_tab.html.twig
+++ b/core-bundle/contao/templates/twig/backend/template_studio/editor/_editor_tab.html.twig
@@ -7,7 +7,7 @@
     {% block content %}
         {# Operations #}
         {% if operations|length %}
-            <form class="operations" method="post">
+            <form class="operations" method="post" enctype="multipart/form-data">
                 {% for operation in operations %}
                     {{ include('@Contao/backend/template_studio/editor/_operation_button.html.twig') }}
                 {% endfor %}


### PR DESCRIPTION
Fixes #9530

Currently the code of edited templates is submitted via query params and form data, probably somehow caused by how Turbo handles forms(?)
This can cause the URL to get too long for the webserver to handle and the server will just close the connection. On my local dev environment with Laravel Valet (nginx + PHP-FPM 8.5) this seems to happen at ~7600 characters.

Before:
<img width="2050" height="222" alt="image" src="https://github.com/user-attachments/assets/60bea18d-639a-4074-9515-30cc2e803763" />
<img width="373" height="132" alt="image" src="https://github.com/user-attachments/assets/4ee823e2-1eb1-4989-92cf-ed24b80b9e8b" />

After:
<img width="723" height="41" alt="image" src="https://github.com/user-attachments/assets/341ee685-d729-4d77-9f52-32adac250957" />
<img width="1026" height="286" alt="image" src="https://github.com/user-attachments/assets/e7a2c996-5059-470c-9ce5-e8f0aa0f2cbc" />

