### PR TITLE
Add VFS public Uri handling capability to the player

### DIFF
--- a/core-bundle/tests/Controller/ContentElement/PlayerControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/PlayerControllerTest.php
@@ -13,13 +13,55 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Controller\ContentElement;
 
 use Contao\CoreBundle\Controller\ContentElement\PlayerController;
+use Contao\CoreBundle\Filesystem\FilesystemItem;
+use Contao\CoreBundle\Filesystem\PublicUri\Options;
+use Contao\CoreBundle\Filesystem\VirtualFilesystem;
+use Nyholm\Psr7\Uri;
+use Symfony\Component\Uid\Uuid;
 
 class PlayerControllerTest extends ContentElementTestCase
 {
     public function testOutputsFigure(): void
     {
+        $storage = $this->createStub(VirtualFilesystem::class);
+        $storage
+            ->method('getPrefix')
+            ->willReturn('files')
+        ;
+
+        $storage
+            ->method('get')
+            ->willReturnCallback(
+                static function (Uuid $uuid): FilesystemItem|null {
+                    $storageMap = [
+                        self::FILE_VIDEO_MP4 => new FilesystemItem(true, 'video.mp4', null, null, 'video/mp4'),
+                        self::FILE_VIDEO_OGV => new FilesystemItem(true, 'video.ogv', null, null, 'video/ogg'),
+                    ];
+
+                    return $storageMap[$uuid->toRfc4122()] ?? null;
+                },
+            )
+        ;
+
+        $storage
+            ->method('generatePublicUri')
+            ->willReturnCallback(
+                function (string $path, Options|null $options = null): Uri|null {
+                    $this->assertNotNull($options);
+                    $this->assertNotNull($options->get(Options::OPTION_TEMPORARY_ACCESS_INFORMATION));
+
+                    $publicUriMap = [
+                        'video.mp4' => new Uri('https://example.com/files/video.mp4'),
+                        'video.ogv' => new Uri('https://example.com/files/video.ogv'),
+                    ];
+
+                    return $publicUriMap[$path] ?? null;
+                },
+            )
+        ;
+
         $response = $this->renderWithModelData(
-            new PlayerController($this->getDefaultStorage()),
+            new PlayerController($storage),
             [
                 'type' => 'player',
                 'playerSRC' => serialize([


### PR DESCRIPTION
Allows you to embed protected videos or audio files directly via the player content element (just like the download(s) element).