### PR TITLE
Add the remaining deprecations in the `calendar-bundle`

### DIFF
--- a/calendar-bundle/contao/classes/Calendar.php
+++ b/calendar-bundle/contao/classes/Calendar.php
@@ -24,6 +24,8 @@ class Calendar extends Frontend
 	/**
 	 * Current events
 	 * @var array
+	 *
+	 * @deprecated Deprecated sind Contao 5.7, to be removed in Contao 6
 	 */
 	protected $arrEvents = array();
 
@@ -129,6 +131,9 @@ class Calendar extends Frontend
 	 * Generate an XML file and save it to the root directory
 	 *
 	 * @param array $arrFeed
+	 *
+	 * @deprecated Deprecated sind Contao 5.7, to be removed in Contao 6;
+	 *             use the "calendar_feed" page instead
 	 */
 	protected function generateFiles($arrFeed)
 	{

--- a/calendar-bundle/contao/classes/Events.php
+++ b/calendar-bundle/contao/classes/Events.php
@@ -30,12 +30,16 @@ abstract class Events extends Module
 	/**
 	 * Today 00:00:00
 	 * @var string
+	 *
+	 * @deprecated Deprecated sind Contao 5.7, to be removed in Contao 6
 	 */
 	protected $intTodayBegin;
 
 	/**
 	 * Today 23:59:59
 	 * @var string
+	 *
+	 * @deprecated Deprecated sind Contao 5.7, to be removed in Contao 6
 	 */
 	protected $intTodayEnd;
 


### PR DESCRIPTION
Follow-up to #8390. This adds deprecations to some remaining protected properties in the `contao/calendar-bundle`.

See also #9540