### PR TITLE
Add the missing migration service definitions

### DIFF
--- a/calendar-bundle/config/services.yaml
+++ b/calendar-bundle/config/services.yaml
@@ -57,6 +57,11 @@ services:
             - '@security.helper'
             - '@contao.routing.content_url_generator'
 
+    contao_calendar.migration.keep_canonical:
+        class: Contao\CalendarBundle\Migration\KeepCanonicalMigration
+        arguments:
+            - '@database_connection'
+
     contao_calendar.picker.event_provider:
         class: Contao\CalendarBundle\Picker\EventPickerProvider
         arguments:

--- a/news-bundle/config/services.yaml
+++ b/news-bundle/config/services.yaml
@@ -97,6 +97,11 @@ services:
             - '@filesystem'
             - '%contao.web_dir%'
 
+    contao_news.migration.keep_canonical:
+        class: Contao\NewsBundle\Migration\KeepCanonicalMigration
+        arguments:
+            - '@database_connection'
+
     contao_news.picker.news_provider:
         class: Contao\NewsBundle\Picker\NewsPickerProvider
         arguments:


### PR DESCRIPTION
Noticed while reviewing https://github.com/contao/contao/pull/9546.

Apparently, this got forgotten in https://github.com/contao/contao/pull/6215.

Note for @leofeyer: Merging upstream in 5.7 is needed but it does not have to go in `main` as https://github.com/contao/contao/pull/9546 removed all migrations including these ones.