### PR TITLE
Reset the globals and the response context on error pages

### DIFF
--- a/core-bundle/contao/controllers/FrontendIndex.php
+++ b/core-bundle/contao/controllers/FrontendIndex.php
@@ -67,6 +67,7 @@ class FrontendIndex extends Frontend
 
 			return $objHandler->getResponse($objPage, true);
 		}
+		// Render the error page (see #5570)
 		catch (\Throwable $e)
 		{
 			// Restore the globals (see #7659)

--- a/core-bundle/contao/controllers/FrontendIndex.php
+++ b/core-bundle/contao/controllers/FrontendIndex.php
@@ -66,7 +66,7 @@ class FrontendIndex extends Frontend
 
 			return $objHandler->getResponse($objPage, true);
 		}
-		finally
+		catch (\Throwable $e)
 		{
 			// Restore the globals (see #7659)
 			list(
@@ -81,6 +81,8 @@ class FrontendIndex extends Frontend
 			) = $arrBackup;
 
 			System::getContainer()->get('contao.routing.response_context_accessor')->setResponseContext($responseContext);
+
+			throw $e;
 		}
 	}
 }

--- a/core-bundle/contao/controllers/FrontendIndex.php
+++ b/core-bundle/contao/controllers/FrontendIndex.php
@@ -55,6 +55,7 @@ class FrontendIndex extends Frontend
 			$GLOBALS['TL_JQUERY'] ?? array(),
 			$GLOBALS['TL_USER_CSS'] ?? array(),
 			$GLOBALS['TL_FRAMEWORK_CSS'] ?? array(),
+			$GLOBALS['TL_JAVASCRIPT'] ?? array(),
 			System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext()
 		);
 
@@ -65,9 +66,7 @@ class FrontendIndex extends Frontend
 
 			return $objHandler->getResponse($objPage, true);
 		}
-
-		// Render the error page (see #5570)
-		catch (UnusedArgumentsException $e)
+		finally
 		{
 			// Restore the globals (see #7659)
 			list(
@@ -77,12 +76,11 @@ class FrontendIndex extends Frontend
 				$GLOBALS['TL_JQUERY'],
 				$GLOBALS['TL_USER_CSS'],
 				$GLOBALS['TL_FRAMEWORK_CSS'],
+				$GLOBALS['TL_JAVASCRIPT'],
 				$responseContext
 			) = $arrBackup;
 
 			System::getContainer()->get('contao.routing.response_context_accessor')->setResponseContext($responseContext);
-
-			throw $e;
 		}
 	}
 }

--- a/core-bundle/contao/controllers/FrontendIndex.php
+++ b/core-bundle/contao/controllers/FrontendIndex.php
@@ -56,6 +56,7 @@ class FrontendIndex extends Frontend
 			$GLOBALS['TL_USER_CSS'] ?? array(),
 			$GLOBALS['TL_FRAMEWORK_CSS'] ?? array(),
 			$GLOBALS['TL_JAVASCRIPT'] ?? array(),
+			$GLOBALS['TL_CSS'] ?? array(),
 			System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext()
 		);
 
@@ -77,6 +78,7 @@ class FrontendIndex extends Frontend
 				$GLOBALS['TL_USER_CSS'],
 				$GLOBALS['TL_FRAMEWORK_CSS'],
 				$GLOBALS['TL_JAVASCRIPT'],
+				$GLOBALS['TL_CSS'],
 				$responseContext
 			) = $arrBackup;
 


### PR DESCRIPTION
If you have several fragments on a page that add assets to `$GLOBALS` and then a fragment that is executed _afterwards_ throws a `PageNotFoundException`, these assets will still be included when the 404 page is rendered. This PR fixes that by always restoring the previous state in case of an exception.

Previously this was _only_ done for the `UnusedArgumentsException` when there are unused route parameters present. (Also it was missing the reset for `TL_JAVASCRIPT`.)

@aschempp completely resetting the `$GLOBALS` and the response context is not the correct solution - otherwise you would again not be able to create and pre-fill the response context in your own `PageController` (where you execute `(new FrontendIndex())->renderPage($page)`).