### PR TITLE
Implement the error pages as proper page controllers

### DIFF
--- a/core-bundle/config/controller.yaml
+++ b/core-bundle/config/controller.yaml
@@ -237,7 +237,10 @@ services:
 
     Contao\CoreBundle\Controller\Page\ErrorPageController:
         arguments:
-            - '@contao.framework'
+            - '@uri_signer'
+            - '@?logger'
+        tags:
+            - { name: monolog.logger, channel: contao.error }
 
     Contao\CoreBundle\Controller\Page\ForwardPageController:
         arguments:

--- a/core-bundle/contao/pages/PageError401.php
+++ b/core-bundle/contao/pages/PageError401.php
@@ -10,12 +10,18 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\Page\ErrorPageController;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
 use Symfony\Component\HttpFoundation\Response;
 
+trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', PageError401::class, ErrorPageController::class);
+
 /**
  * Provide methods to handle an error 401 page.
+ *
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ *             use Contao\CoreBundle\Controller\Page\ErrorPageController instead.
  */
 class PageError401 extends Frontend
 {

--- a/core-bundle/contao/pages/PageError403.php
+++ b/core-bundle/contao/pages/PageError403.php
@@ -10,12 +10,18 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\Page\ErrorPageController;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
 
+trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', PageError403::class, ErrorPageController::class);
+
 /**
  * Provide methods to handle an error 403 page.
+ *
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ *             use Contao\CoreBundle\Controller\Page\ErrorPageController instead.
  */
 class PageError403 extends Frontend
 {

--- a/core-bundle/contao/pages/PageError404.php
+++ b/core-bundle/contao/pages/PageError404.php
@@ -10,12 +10,18 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\Page\ErrorPageController;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
 
+trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', PageError404::class, ErrorPageController::class);
+
 /**
  * Provide methods to handle an error 404 page.
+ *
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ *             use Contao\CoreBundle\Controller\Page\ErrorPageController instead.
  */
 class PageError404 extends Frontend
 {

--- a/core-bundle/src/Controller/Page/ErrorPageController.php
+++ b/core-bundle/src/Controller/Page/ErrorPageController.php
@@ -12,13 +12,16 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Controller\Page;
 
-use Contao\CoreBundle\Controller\AbstractController;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsPage;
-use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Routing\Page\ContentCompositionInterface;
-use Contao\FrontendIndex;
 use Contao\PageModel;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @internal
@@ -27,24 +30,50 @@ use Symfony\Component\HttpFoundation\Response;
 #[AsPage('error_403', path: false)]
 #[AsPage('error_404', path: false)]
 #[AsPage('error_503', path: false)]
-class ErrorPageController extends AbstractController implements ContentCompositionInterface
+class ErrorPageController extends AbstractPageController implements ContentCompositionInterface
 {
-    public function __construct(private readonly ContaoFramework $framework)
-    {
+    public function __construct(
+        private readonly UriSigner $uriSigner,
+        private readonly LoggerInterface|null $logger = null,
+    ) {
     }
 
-    public function __invoke(PageModel $pageModel): Response
+    public function __invoke(PageModel $pageModel, Request $request): Response
     {
-        $this->framework->initialize();
+        // Handle redirect for 401, 403, 404
+        if ('error_503' !== $pageModel->type && $pageModel->autoforward && $pageModel->jumpTo) {
+            $pageAdapter = $this->getContaoAdapter(PageModel::class);
 
-        return $this->framework
-            ->createInstance(FrontendIndex::class)
-            ->renderPage($pageModel)
-        ;
+            if (!$target = $pageAdapter->findById($pageModel->jumpTo)) {
+                $this->logger?->error(\sprintf('Forward page ID "%s" does not exist', $pageModel->jumpTo));
+
+                throw new ForwardPageNotFoundException('Forward page not found');
+            }
+
+            $url = $this->generateContentUrl($target, [], UrlGeneratorInterface::ABSOLUTE_URL);
+
+            // Add the referrer so the login module can redirect back
+            if ('error_401' === $pageModel->type) {
+                $url .= '?'.http_build_query(['redirect' => $request->getUri()]);
+                $url = $this->uriSigner->sign($url);
+            }
+
+            return new RedirectResponse($url, Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->renderPage($pageModel)->setStatusCode((int) substr($pageModel->type, -3));
     }
 
     public function supportsContentComposition(PageModel $pageModel): bool
     {
         return 'error_503' === $pageModel->type || !$pageModel->autoforward;
+    }
+
+    protected function setCacheHeaders(Response $response, PageModel $pageModel): Response
+    {
+        // Never cache error pages
+        $response->headers->set('Cache-Control', 'no-cache, no-store');
+
+        return $response->setPrivate();
     }
 }

--- a/core-bundle/src/Controller/Page/ErrorPageController.php
+++ b/core-bundle/src/Controller/Page/ErrorPageController.php
@@ -41,7 +41,7 @@ class ErrorPageController extends AbstractPageController implements ContentCompo
     public function __invoke(PageModel $pageModel, Request $request): Response
     {
         // Handle redirect for 401, 403, 404
-        if ('error_503' !== $pageModel->type && $pageModel->autoforward && $pageModel->jumpTo) {
+        if (\in_array($pageModel->type, ['error_401', 'error_403', 'error_404'], true) && $pageModel->autoforward && $pageModel->jumpTo) {
             $pageAdapter = $this->getContaoAdapter(PageModel::class);
 
             if (!$target = $pageAdapter->findById($pageModel->jumpTo)) {
@@ -66,7 +66,7 @@ class ErrorPageController extends AbstractPageController implements ContentCompo
 
     public function supportsContentComposition(PageModel $pageModel): bool
     {
-        return 'error_503' === $pageModel->type || !$pageModel->autoforward;
+        return 'error_503' === $pageModel->type || (\in_array($pageModel->type, ['error_401', 'error_403', 'error_404'], true) && !$pageModel->autoforward);
     }
 
     protected function setCacheHeaders(Response $response, PageModel $pageModel): Response

--- a/core-bundle/tests/Controller/Page/ErrorPageControllerTest.php
+++ b/core-bundle/tests/Controller/Page/ErrorPageControllerTest.php
@@ -12,38 +12,40 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Controller\Page;
 
+use Contao\CoreBundle\ContentComposition\ContentComposition;
+use Contao\CoreBundle\ContentComposition\ContentCompositionBuilder;
 use Contao\CoreBundle\Controller\Page\ErrorPageController;
+use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
+use Contao\CoreBundle\Routing\Page\PageRegistry;
+use Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
 use Contao\CoreBundle\Tests\TestCase;
-use Contao\FrontendIndex;
+use Contao\CoreBundle\Twig\LayoutTemplate;
+use Contao\LayoutModel;
 use Contao\PageModel;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class ErrorPageControllerTest extends TestCase
 {
-    public function testRendersThePageThroughFrontendIndex(): void
+    public function testRendersThePage(): void
     {
-        $response = $this->createStub(Response::class);
-        $pageModel = $this->createClassWithPropertiesStub(PageModel::class);
+        $pageModel = $this->createClassWithPropertiesStub(PageModel::class, [
+            'type' => 'error_404',
+            'autoforward' => false,
+        ]);
 
-        $frontendIndex = $this->createMock(FrontendIndex::class);
-        $frontendIndex
-            ->expects($this->once())
-            ->method('renderPage')
-            ->with($pageModel)
-            ->willReturn($response)
-        ;
+        $controller = $this->getErrorPageController();
 
-        $framework = $this->createContaoFrameworkMock();
-        $framework
-            ->expects($this->once())
-            ->method('createInstance')
-            ->with(FrontendIndex::class)
-            ->willReturn($frontendIndex)
-        ;
+        $response = $controller($pageModel, new Request());
 
-        $controller = new ErrorPageController($framework);
-
-        $this->assertSame($response, $controller($pageModel));
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('<content>', $response->getContent());
     }
 
     public function testSupportsContentComposition(): void
@@ -53,7 +55,7 @@ class ErrorPageControllerTest extends TestCase
             'autoforward' => false,
         ]);
 
-        $controller = new ErrorPageController($this->createContaoFrameworkStub());
+        $controller = new ErrorPageController($this->createStub(UriSigner::class));
 
         $this->assertTrue($controller->supportsContentComposition($pageModel));
     }
@@ -65,7 +67,7 @@ class ErrorPageControllerTest extends TestCase
             'autoforward' => true,
         ]);
 
-        $controller = new ErrorPageController($this->createContaoFrameworkStub());
+        $controller = new ErrorPageController($this->createStub(UriSigner::class));
 
         $this->assertFalse($controller->supportsContentComposition($pageModel));
     }
@@ -77,8 +79,142 @@ class ErrorPageControllerTest extends TestCase
             'autoforward' => true,
         ]);
 
-        $controller = new ErrorPageController($this->createContaoFrameworkStub());
+        $controller = new ErrorPageController($this->createStub(UriSigner::class));
 
         $this->assertTrue($controller->supportsContentComposition($pageModel));
+    }
+
+    public function testThrowsForwardPageNotFoundException(): void
+    {
+        $pageModel = $this->createClassWithPropertiesStub(PageModel::class, [
+            'type' => 'error_404',
+            'autoforward' => true,
+            'jumpTo' => 74656,
+        ]);
+
+        $pageAdapter = $this->createAdapterMock(['findById']);
+        $pageAdapter
+            ->expects($this->once())
+            ->method('findById')
+            ->with(74656)
+            ->willReturn(null)
+        ;
+
+        $framework = $this->createContaoFrameworkStub([
+            PageModel::class => $pageAdapter,
+        ]);
+
+        $controller = $this->getErrorPageController($framework);
+
+        $this->expectException(ForwardPageNotFoundException::class);
+        $this->expectExceptionMessage('Forward page not found');
+
+        $controller($pageModel, new Request());
+    }
+
+    public function testRedirectsToForwardPage(): void
+    {
+        $pageModel = $this->createClassWithPropertiesStub(PageModel::class, [
+            'type' => 'error_401',
+            'autoforward' => true,
+            'jumpTo' => 74656,
+        ]);
+
+        $targetPage = $this->createStub(PageModel::class);
+
+        $pageAdapter = $this->createAdapterMock(['findById']);
+        $pageAdapter
+            ->expects($this->once())
+            ->method('findById')
+            ->with(74656)
+            ->willReturn($targetPage)
+        ;
+
+        $framework = $this->createContaoFrameworkStub([
+            PageModel::class => $pageAdapter,
+        ]);
+
+        $contentUrlGenerator = $this->createMock(ContentUrlGenerator::class);
+        $contentUrlGenerator
+            ->expects($this->once())
+            ->method('generate')
+            ->with($targetPage, [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.com/foobar')
+        ;
+
+        $request = Request::create('https://example.com/moobar');
+
+        $uriSigner = $this->createMock(UriSigner::class);
+        $uriSigner
+            ->expects($this->once())
+            ->method('sign')
+            ->with('https://example.com/foobar?'.http_build_query(['redirect' => 'https://example.com/moobar']))
+            ->willReturn('<signed uri>')
+        ;
+
+        $controller = $this->getErrorPageController($framework, $contentUrlGenerator, $uriSigner);
+        $response = $controller($pageModel, $request);
+
+        $this->assertSame(Response::HTTP_SEE_OTHER, $response->getStatusCode());
+        $this->assertSame('<signed uri>', $response->headers->get('Location'));
+    }
+
+    private function getErrorPageController(ContaoFramework|null $framework = null, ContentUrlGenerator|null $contentUrlGenerator = null, UriSigner|null $uriSigner = null): ErrorPageController
+    {
+        if (!$framework) {
+            $layoutAdapter = $this->createAdapterStub(['findById']);
+            $layoutAdapter
+                ->method('findById')
+                ->willReturn($this->createClassWithPropertiesStub(LayoutModel::class, ['type' => 'modern']))
+            ;
+
+            $framework = $this->createContaoFrameworkStub([
+                LayoutModel::class => $layoutAdapter,
+            ]);
+        }
+
+        $responseContextFactory = $this->createStub(CoreResponseContextFactory::class);
+        $responseContextFactory
+            ->method('createContaoWebpageResponseContext')
+            ->willReturn(new ResponseContext())
+        ;
+
+        $contentCompositionBuilder = $this->createStub(ContentCompositionBuilder::class);
+        $contentCompositionBuilder
+            ->method('buildLayoutTemplate')
+            ->willReturn(new LayoutTemplate('<template>', static fn () => new Response('<content>')))
+        ;
+
+        $contentCompositionBuilder
+            ->method('setResponseContext')
+            ->willReturnSelf()
+        ;
+
+        $contentComposition = $this->createStub(ContentComposition::class);
+        $contentComposition
+            ->method('createContentCompositionBuilder')
+            ->willReturn($contentCompositionBuilder)
+        ;
+
+        if (!$contentUrlGenerator) {
+            $contentUrlGenerator = $this->createStub(ContentUrlGenerator::class);
+        }
+
+        if (!$uriSigner) {
+            $uriSigner = $this->createStub(UriSigner::class);
+        }
+
+        $container = $this->getContainerWithContaoConfiguration();
+        $container->set('contao.framework', $framework);
+        $container->set('event_dispatcher', $this->createStub(EventDispatcherInterface::class));
+        $container->set('contao.routing.response_context_factory', $responseContextFactory);
+        $container->set('contao.content_composition', $contentComposition);
+        $container->set('contao.routing.page_registry', $this->createStub(PageRegistry::class));
+        $container->set('contao.routing.content_url_generator', $contentUrlGenerator);
+
+        $controller = new ErrorPageController($uriSigner);
+        $controller->setContainer($container);
+
+        return $controller;
     }
 }

--- a/core-bundle/tests/Controller/Page/ErrorPageControllerTest.php
+++ b/core-bundle/tests/Controller/Page/ErrorPageControllerTest.php
@@ -41,7 +41,6 @@ class ErrorPageControllerTest extends TestCase
         ]);
 
         $controller = $this->getErrorPageController();
-
         $response = $controller($pageModel, new Request());
 
         $this->assertSame(404, $response->getStatusCode());


### PR DESCRIPTION
This deprecates the remaining `PageErrorXYZ` classes and implements them as proper page controllers. This is a pre-requisite for https://github.com/contao/contao/pull/9562