### PR TITLE
Use the `manifest.json` file in the `Image::getHtml()` method

### DIFF
--- a/core-bundle/contao/library/Contao/Image.php
+++ b/core-bundle/contao/library/Contao/Image.php
@@ -91,6 +91,8 @@ class Image
 	{
 		list($template, $defaultSize) = self::getHtmlTemplateAndDefaultSize($src);
 
+		$icons = System::getContainer()->getParameter('contao.backend.icons');
+
 		$attributesObject = new HtmlAttributes($attributes);
 
 		$search = array('{width}', '{height}', '{alt}', '{attributes}');
@@ -105,7 +107,9 @@ class Image
 				if (isset($darkAttributes[$icon]))
 				{
 					$pathinfo = pathinfo($darkAttributes[$icon]);
-					$darkAttributes[$icon] = $pathinfo['filename'] . '--dark.' . $pathinfo['extension'];
+					$fileName = $pathinfo['filename'] . '--dark.' . $pathinfo['extension'];
+
+					$darkAttributes[$icon] = isset($icons[$fileName]) ? pathinfo($icons[$fileName]['path'], PATHINFO_BASENAME) : $fileName;
 				}
 			}
 
@@ -115,8 +119,20 @@ class Image
 
 		if (str_contains($template, '{lightAttributes}'))
 		{
+			$lightAttributes = new HtmlAttributes($attributesObject);
+
+			foreach (array('data-icon', 'data-icon-disabled') as $icon)
+			{
+				if (isset($attributesObject[$icon]))
+				{
+					$fileName = pathinfo($lightAttributes[$icon], PATHINFO_BASENAME);
+
+					$lightAttributes[$icon] = isset($icons[$fileName]) ? pathinfo($icons[$fileName]['path'], PATHINFO_BASENAME) : $fileName;
+				}
+			}
+
 			$search[] = '{lightAttributes}';
-			$replace[] = (new HtmlAttributes($attributesObject))->mergeWith(array('class' => 'color-scheme--light', 'loading' => 'lazy'))->toString();
+			$replace[] = $lightAttributes->mergeWith(array('class' => 'color-scheme--light', 'loading' => 'lazy'))->toString();
 		}
 
 		return str_replace($search, $replace, $template);

--- a/core-bundle/contao/library/Contao/Image.php
+++ b/core-bundle/contao/library/Contao/Image.php
@@ -123,7 +123,7 @@ class Image
 
 			foreach (array('data-icon', 'data-icon-disabled') as $icon)
 			{
-				if (isset($attributesObject[$icon]))
+				if (isset($lightAttributes[$icon]))
 				{
 					$fileName = pathinfo($lightAttributes[$icon], PATHINFO_BASENAME);
 


### PR DESCRIPTION
### Description

The current backend icons for the toggle operations + the switch from dark/light are broken due to switching to a manifest.json for all icons.