### PR TITLE
Add the missing `insert_tag_raw` in the form templates

### DIFF
--- a/core-bundle/contao/templates/twig/form_explanation.html.twig
+++ b/core-bundle/contao/templates/twig/form_explanation.html.twig
@@ -4,5 +4,5 @@
 %}
 
 <div{{ wrapperAttributes }}>
-    {{ this.text|sanitize_html('contao')|encode_email|csp_inline_styles }}
+    {{ this.text|sanitize_html('contao')|encode_email|csp_inline_styles|insert_tag_raw }}
 </div>

--- a/core-bundle/contao/templates/twig/form_explanation.html.twig
+++ b/core-bundle/contao/templates/twig/form_explanation.html.twig
@@ -4,5 +4,5 @@
 %}
 
 <div{{ wrapperAttributes }}>
-    {{ this.text|sanitize_html('contao')|encode_email|csp_inline_styles|insert_tag_raw }}
+    {{ this.text|sanitize_html('contao')|csp_inline_styles|encode_email|insert_tag_raw }}
 </div>

--- a/core-bundle/contao/templates/twig/form_message.html.twig
+++ b/core-bundle/contao/templates/twig/form_message.html.twig
@@ -1,3 +1,3 @@
 <div class="form-confirmation">
-    {{ message|sanitize_html('contao')|encode_email|csp_inline_styles|insert_tag_raw }}
+    {{ message|sanitize_html('contao')|csp_inline_styles|encode_email|insert_tag_raw }}
 </div>


### PR DESCRIPTION
`{{link_url::*}}` is often used in `form_explanation` to link to the privacy policy.