### PR TITLE
Fix the current page appearing twice in the breadcrumb

### DIFF
--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -65,7 +65,7 @@ class ModuleBreadcrumb extends Module
 
 		// Get all pages up to the root page
 		$parents = array_reverse($objPage->trail);
-		array_pop($parents); // Remove current page (last trail item)
+		array_shift($parents); // Remove current page
 		$objPages = PageModel::findMultipleByIds($parents);
 
 		if ($objPages !== null)


### PR DESCRIPTION
Fixes the breadcrumb bug introduced in #9465 that caused the current page to be displayed twice.