### PR TITLE
Remove `preserveTags` for password fields

### DIFF
--- a/core-bundle/contao/dca/tl_member.php
+++ b/core-bundle/contao/dca/tl_member.php
@@ -251,7 +251,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['password'],
 			'inputType'               => 'password',
-			'eval'                    => array('mandatory'=>true, 'preserveTags'=>true, 'minlength'=>Config::get('minPasswordLength'), 'feEditable'=>true, 'feGroup'=>'login', 'tl_class'=>'w50'),
+			'eval'                    => array('mandatory'=>true, 'minlength'=>Config::get('minPasswordLength'), 'feEditable'=>true, 'feGroup'=>'login', 'tl_class'=>'w50'),
 			'save_callback' => array
 			(
 				array('tl_member', 'setNewPassword')

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -188,7 +188,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['password'],
 			'inputType'               => 'password',
-			'eval'                    => array('mandatory'=>true, 'preserveTags'=>true, 'minlength'=>Config::get('minPasswordLength'), 'tl_class'=>'w50'),
+			'eval'                    => array('mandatory'=>true, 'minlength'=>Config::get('minPasswordLength'), 'tl_class'=>'w50'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'pwChange' => array


### PR DESCRIPTION
The `password` widget actually hardcodes `useRawRequestData` for itself:

https://github.com/contao/contao/blob/1c91b2b134064b7d1140584eed875acccf74d04f/core-bundle/contao/widgets/Password.php#L56

Which means that the `preserveTags` setting is never really evaluated:

https://github.com/contao/contao/blob/1c91b2b134064b7d1140584eed875acccf74d04f/core-bundle/contao/library/Contao/Widget.php#L758-L770

Except for `DC_Table::show()` where it would be evaluated:

https://github.com/contao/contao/blob/1c91b2b134064b7d1140584eed875acccf74d04f/core-bundle/contao/drivers/DC_Table.php#L625-L628

But the `password` widget is hardcoded to never be shown in `show()`:

https://github.com/contao/contao/blob/1c91b2b134064b7d1140584eed875acccf74d04f/core-bundle/contao/drivers/DC_Table.php#L522-L525