### PR TITLE
Fix timestamp fields in breadcrumb do not get formatted as expected

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -166,6 +166,7 @@ services:
         class: Contao\CoreBundle\EventListener\DataContainer\FallbackRecordLabelListener
         arguments:
             - '@translator'
+            - '@contao.data_container.value_formatter'
 
     contao.listener.data_container.file_image_preview:
         class: Contao\CoreBundle\EventListener\DataContainer\FileImagePreviewListener

--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -15,7 +15,6 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 use Contao\CoreBundle\DataContainer\ValueFormatter;
 use Contao\CoreBundle\Event\DataContainerRecordLabelEvent;
 use Contao\DcaLoader;
-use Contao\StringUtil;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;

--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -50,7 +50,7 @@ class FallbackRecordLabelListener
         $defaultSearchField = $GLOBALS['TL_DCA'][$table]['list']['sorting']['defaultSearchField'] ?? null;
 
         if ($defaultSearchField && ($label = $event->getData()[$defaultSearchField] ?? null)) {
-            $event->setLabel(trim(StringUtil::decodeEntities(strip_tags((string) $this->valueFormatter->format($table, $defaultSearchField, $label, null)))));
+            $event->setLabel(trim(StringUtil::decodeEntities(strip_tags($this->valueFormatter->format($table, $defaultSearchField, $label, null)))));
         } else {
             $messageDomain = "contao_$table";
 

--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -29,8 +29,7 @@ class FallbackRecordLabelListener
     public function __construct(
         private readonly TranslatorInterface&TranslatorBagInterface $translator,
         private readonly ValueFormatter $valueFormatter,
-    )
-    {
+    ) {
     }
 
     public function __invoke(DataContainerRecordLabelEvent $event): void

--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 use Contao\CoreBundle\DataContainer\ValueFormatter;
 use Contao\CoreBundle\Event\DataContainerRecordLabelEvent;
 use Contao\DcaLoader;
+use Contao\StringUtil;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;

--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\CoreBundle\DataContainer\ValueFormatter;
 use Contao\CoreBundle\Event\DataContainerRecordLabelEvent;
 use Contao\DcaLoader;
 use Contao\StringUtil;
@@ -25,7 +26,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[AsEventListener(priority: -1)]
 class FallbackRecordLabelListener
 {
-    public function __construct(private readonly TranslatorInterface&TranslatorBagInterface $translator)
+    public function __construct(
+        private readonly TranslatorInterface&TranslatorBagInterface $translator,
+        private readonly ValueFormatter $valueFormatter,
+    )
     {
     }
 
@@ -46,7 +50,7 @@ class FallbackRecordLabelListener
         $defaultSearchField = $GLOBALS['TL_DCA'][$table]['list']['sorting']['defaultSearchField'] ?? null;
 
         if ($defaultSearchField && ($label = $event->getData()[$defaultSearchField] ?? null)) {
-            $event->setLabel(trim(StringUtil::decodeEntities(strip_tags((string) $label))));
+            $event->setLabel(trim(StringUtil::decodeEntities(strip_tags((string) $this->valueFormatter->format($table, $defaultSearchField, $label, null)))));
         } else {
             $messageDomain = "contao_$table";
 

--- a/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
@@ -88,7 +88,8 @@ class FallbackRecordLabelListenerTest extends TestCase
             ->expects($this->once())
             ->method('format')
             ->with('tl_foo', 'fieldA', 'A <span>(B &amp; B)</span>', null)
-            ->willReturn('A (B & B)');
+            ->willReturn('A (B & B)')
+        ;
 
         $listener = new FallbackRecordLabelListener($translator, $formatter);
         $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123, 'fieldA' => 'A <span>(B &amp; B)</span>']));

--- a/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
@@ -118,6 +118,6 @@ class FallbackRecordLabelListenerTest extends TestCase
         $listener = new FallbackRecordLabelListener($translator, $formatter);
         $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123, 'fieldA' => '1772131097']));
 
-        $this->assertSame('', $event->getLabel());
+        $this->assertSame('2026-02-26', $event->getLabel());
     }
 }

--- a/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
@@ -114,7 +114,6 @@ class FallbackRecordLabelListenerTest extends TestCase
             ->with('tl_foo', 'fieldA', '1772131097', null)
             ->willReturn('2026-02-26')
         ;
-        //dd($formatter->format('tl_foo', 'fieldA', '1772131097', null));
 
         $listener = new FallbackRecordLabelListener($translator, $formatter);
         $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123, 'fieldA' => '1772131097']));

--- a/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener\DataContainer;
 
 use Contao\Config;
+use Contao\CoreBundle\DataContainer\ValueFormatter;
 use Contao\CoreBundle\Event\DataContainerRecordLabelEvent;
 use Contao\CoreBundle\EventListener\DataContainer\FallbackRecordLabelListener;
 use Contao\CoreBundle\Tests\Fixtures\TranslatorStub;
@@ -34,7 +35,7 @@ class FallbackRecordLabelListenerTest extends TestCase
 
     public function testIgnoresOtherIdentifiers(): void
     {
-        $listener = new FallbackRecordLabelListener($this->createStub(TranslatorStub::class));
+        $listener = new FallbackRecordLabelListener($this->createStub(TranslatorStub::class), $this->createStub(ValueFormatter::class));
         $listener($event = new DataContainerRecordLabelEvent('contao.something.tl_foo.123', ['id' => 123]));
 
         $this->assertNull($event->getLabel());
@@ -66,7 +67,7 @@ class FallbackRecordLabelListenerTest extends TestCase
             ->willReturn('Edit 123')
         ;
 
-        $listener = new FallbackRecordLabelListener($translator);
+        $listener = new FallbackRecordLabelListener($translator, $this->createStub(ValueFormatter::class));
         $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123]));
 
         $this->assertSame('Edit 123', $event->getLabel());
@@ -81,7 +82,7 @@ class FallbackRecordLabelListenerTest extends TestCase
 
         $translator = $this->createStub(TranslatorStub::class);
 
-        $listener = new FallbackRecordLabelListener($translator);
+        $listener = new FallbackRecordLabelListener($translator, $this->createStub(ValueFormatter::class));
         $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123, 'fieldA' => 'A <span>(B &amp; B)</span>']));
 
         $this->assertSame('A (B & B)', $event->getLabel());


### PR DESCRIPTION
Fixes #9481

Based on 5.7 as requested in [this Comment](https://github.com/contao/contao/issues/9481#issuecomment-3966024348) 