### PR TITLE
Trigger the `InteractiveLoginEvent` for the back end login

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1036,7 +1036,6 @@ services:
             - '@security.token_storage'
             - '@contao.routing.page_registry'
             - '@http_kernel'
-            - '@request_stack'
             - !abstract set by ContaoLoginFactory::createAuthenticator()
             - !abstract set by ContaoLoginFactory::createAuthenticator()
 

--- a/core-bundle/src/DependencyInjection/Security/ContaoLoginFactory.php
+++ b/core-bundle/src/DependencyInjection/Security/ContaoLoginFactory.php
@@ -77,8 +77,8 @@ class ContaoLoginFactory extends AbstractFactory
             ->replaceArgument(0, new Reference($userProviderId))
             ->replaceArgument(1, new Reference($this->createAuthenticationSuccessHandler($container, $firewallName, $config)))
             ->replaceArgument(2, new Reference($this->createAuthenticationFailureHandler($container, $firewallName, $config)))
-            ->replaceArgument(11, new Reference($twoFactorAuthenticatorId))
-            ->replaceArgument(12, $options)
+            ->replaceArgument(10, new Reference($twoFactorAuthenticatorId))
+            ->replaceArgument(11, $options)
         ;
 
         return $authenticatorId;

--- a/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php
+++ b/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php
@@ -16,13 +16,11 @@ use Contao\CoreBundle\Exception\ResponseException;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Routing\ScopeMatcher;
-use Contao\PageModel;
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Scheb\TwoFactorBundle\Security\Http\Authenticator\Passport\Credentials\TwoFactorCodeCredentials;
 use Scheb\TwoFactorBundle\Security\Http\Authenticator\TwoFactorAuthenticator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -72,7 +70,6 @@ class ContaoLoginAuthenticator extends AbstractAuthenticator implements Authenti
         private readonly TokenStorageInterface $tokenStorage,
         private readonly PageRegistry $pageRegistry,
         private readonly HttpKernelInterface $httpKernel,
-        private readonly RequestStack $requestStack,
         private readonly TwoFactorAuthenticator $twoFactorAuthenticator,
         array $options,
     ) {
@@ -182,13 +179,7 @@ class ContaoLoginAuthenticator extends AbstractAuthenticator implements Authenti
 
     public function isInteractive(): bool
     {
-        if (!$request = $this->requestStack->getCurrentRequest()) {
-            return false;
-        }
-
-        $page = $request->attributes->get('pageModel');
-
-        return $page instanceof PageModel;
+        return true;
     }
 
     private function getCredentials(Request $request): array

--- a/core-bundle/tests/DependencyInjection/Security/ContaoLoginFactoryTest.php
+++ b/core-bundle/tests/DependencyInjection/Security/ContaoLoginFactoryTest.php
@@ -51,7 +51,7 @@ class ContaoLoginFactoryTest extends TestCase
         $this->assertEquals(new Reference('contao.security.frontend_user_provider'), $arguments['index_0']);
         $this->assertEquals(new Reference('contao.security.authentication_success_handler'), $arguments['index_1']);
         $this->assertEquals(new Reference('contao.security.authentication_failure_handler'), $arguments['index_2']);
-        $this->assertEquals(new Reference('security.authenticator.two_factor.contao_frontend'), $arguments['index_11']);
+        $this->assertEquals(new Reference('security.authenticator.two_factor.contao_frontend'), $arguments['index_10']);
 
         $this->assertTrue($container->hasDefinition($twoFactorFirewallConfigId));
 

--- a/core-bundle/tests/Security/Authenticator/ContaoLoginAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authenticator/ContaoLoginAuthenticatorTest.php
@@ -28,7 +28,6 @@ use Scheb\TwoFactorBundle\Security\Http\Authenticator\Passport\Credentials\TwoFa
 use Scheb\TwoFactorBundle\Security\Http\Authenticator\TwoFactorAuthenticator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -80,30 +79,6 @@ class ContaoLoginAuthenticatorTest extends TestCase
         $request->request->set('FORM_SUBMIT', 'tl_login_1');
 
         $this->assertTrue($authenticator->supports($request));
-    }
-
-    public function testIfAuthenticationIsInteractive(): void
-    {
-        $authenticator = $this->getContaoLoginAuthenticator();
-
-        $this->assertFalse($authenticator->isInteractive());
-
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
-
-        $authenticator = $this->getContaoLoginAuthenticator(requestStack: $requestStack);
-
-        $this->assertFalse($authenticator->isInteractive());
-
-        $request = new Request();
-        $request->attributes->set('pageModel', $this->createMock(PageModel::class));
-
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
-
-        $authenticator = $this->getContaoLoginAuthenticator(requestStack: $requestStack);
-
-        $this->assertTrue($authenticator->isInteractive());
     }
 
     public function testCallsTheSuccessAndFailureHandlers(): void
@@ -459,7 +434,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
     /**
      * @param UserProviderInterface<UserInterface>|null $userProvider
      */
-    private function getContaoLoginAuthenticator(UserProviderInterface|null $userProvider = null, AuthenticationSuccessHandlerInterface|null $successHandler = null, AuthenticationFailureHandlerInterface|null $failureHandler = null, ScopeMatcher|null $scopeMatcher = null, RouterInterface|null $router = null, UriSigner|null $uriSigner = null, PageModel|null $errorPage = null, TokenStorageInterface|null $tokenStorage = null, PageRegistry|null $pageRegistry = null, HttpKernelInterface|null $httpKernel = null, RequestStack|null $requestStack = null, TwoFactorAuthenticator|null $twoFactorAuthenticator = null, array $options = []): ContaoLoginAuthenticator
+    private function getContaoLoginAuthenticator(UserProviderInterface|null $userProvider = null, AuthenticationSuccessHandlerInterface|null $successHandler = null, AuthenticationFailureHandlerInterface|null $failureHandler = null, ScopeMatcher|null $scopeMatcher = null, RouterInterface|null $router = null, UriSigner|null $uriSigner = null, PageModel|null $errorPage = null, TokenStorageInterface|null $tokenStorage = null, PageRegistry|null $pageRegistry = null, HttpKernelInterface|null $httpKernel = null, TwoFactorAuthenticator|null $twoFactorAuthenticator = null, array $options = []): ContaoLoginAuthenticator
     {
         $pageFinder = $this->createMock(PageFinder::class);
         $pageFinder
@@ -480,7 +455,6 @@ class ContaoLoginAuthenticatorTest extends TestCase
             $tokenStorage ?? $this->mockTokenStorage(FrontendUser::class),
             $pageRegistry ?? $this->mockPageRegistry(),
             $httpKernel ?? $this->mockHttpKernel(),
-            $requestStack ?? $this->mockRequestStack(),
             $twoFactorAuthenticator ?? $this->mockTwoFactorAuthenticator(),
             $options,
         );
@@ -522,11 +496,6 @@ class ContaoLoginAuthenticatorTest extends TestCase
     private function mockHttpKernel(): HttpKernelInterface
     {
         return $this->createMock(HttpKernelInterface::class);
-    }
-
-    private function mockRequestStack(): RequestStack
-    {
-        return $this->createMock(RequestStack::class);
     }
 
     private function mockTwoFactorAuthenticator(): TwoFactorAuthenticator


### PR DESCRIPTION
The `InteractiveLoginEvent` in Symfony is not triggered on backend logins because the authenticator checks for `pageModel` in the request parameters—a parameter that only exists for frontend logins.

https://github.com/contao/contao/blob/3d35bb4530c96586893e370500d79c91903a1402/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php#L191

This PR removes that check and always returns `true`, effectively treating both frontend and backend logins as interactive.

As a result, the `InteractiveLoginListener` can now also be used for backend logins.