### PR TITLE
Remove `aria-current` from active items that are not links

### DIFF
--- a/core-bundle/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/contao/templates/modules/mod_breadcrumb.html5
@@ -23,7 +23,7 @@ $this->wrapperAttributes = $this
     <ul>
       <?php foreach ($this->items as $item): ?>
         <?php if ($item['isActive']): ?>
-          <li class="active" aria-current="page"><?= $item['link'] ?></li>
+          <li class="active"><?= $item['link'] ?></li>
         <?php else: ?>
           <li><a href="<?= $item['href'] ?>"><?= $item['link'] ?></a></li>
         <?php endif; ?>

--- a/core-bundle/contao/templates/navigation/nav_default.html5
+++ b/core-bundle/contao/templates/navigation/nav_default.html5
@@ -2,7 +2,7 @@
 <ul class="<?= $this->level ?>">
   <?php foreach ($this->items as $item): ?>
     <?php if ($item['isActive']): ?>
-      <li class="<?= $item['class'] ?>"><strong class="<?= $item['class'] ?>" aria-current="page"<?php if (!empty($item['subitems'])): ?> aria-haspopup="true"<?php endif; ?>><?= $item['link'] ?></strong><?= $item['subitems'] ?? '' ?></li>
+      <li class="<?= $item['class'] ?>"><strong class="<?= $item['class'] ?>"<?php if (!empty($item['subitems'])): ?> aria-haspopup="true"<?php endif; ?>><?= $item['link'] ?></strong><?= $item['subitems'] ?? '' ?></li>
     <?php else: ?>
       <li<?php if ($item['class']): ?> class="<?= $item['class'] ?>"<?php endif; ?>><a href="<?= $item['href'] ?>"<?php if ($item['class']): ?> class="<?= $item['class'] ?>"<?php endif; ?><?php if ('' !== $item['accesskey']): ?> accesskey="<?= $item['accesskey'] ?>"<?php endif; ?><?= $item['target'] ?><?= $item['rel'] ?? '' ?><?php if (!empty($item['subitems'])): ?> aria-haspopup="true"<?php endif; ?>><?= $item['link'] ?></a><?= $item['subitems'] ?? '' ?></li>
     <?php endif; ?>

--- a/core-bundle/contao/templates/twig/mod_breadcrumb.html.twig
+++ b/core-bundle/contao/templates/twig/mod_breadcrumb.html.twig
@@ -20,7 +20,7 @@
         <ul>
             {% for item in items %}
                 {% if item.isActive %}
-                    <li class="active" aria-current="page">{{ item.link|insert_tag }}</li>
+                    <li class="active">{{ item.link|insert_tag }}</li>
                 {% else %}
                     <li><a href="{{ item.href }}">{{ item.link }}</a></li>
                 {% endif %}

--- a/core-bundle/contao/templates/twig/nav_default.html.twig
+++ b/core-bundle/contao/templates/twig/nav_default.html.twig
@@ -3,7 +3,6 @@
         {% if item.isActive %}
             <li class="{{ item.class }}"><strong{{ attrs()
                     .addClass(item.class)
-                    .set('aria-current', 'page')
                     .set('aria-haspopup', true, item.subitems|default)
                 }}>{{ item.link }}</strong>
                 {{- item.subitems|default|raw -}}


### PR DESCRIPTION
### Description

Removes the usage of `aria-current` from active items within navigations:

- see #9589 for reference