### PR TITLE
Add `|default` to the `form_explanation` text variable

### DIFF
--- a/core-bundle/contao/templates/twig/form_explanation.html.twig
+++ b/core-bundle/contao/templates/twig/form_explanation.html.twig
@@ -4,5 +4,5 @@
 %}
 
 <div{{ wrapperAttributes }}>
-    {{ this.text|sanitize_html('contao')|csp_inline_styles|encode_email|insert_tag_raw }}
+    {{ this.text|default|sanitize_html('contao')|csp_inline_styles|encode_email|insert_tag_raw }}
 </div>


### PR DESCRIPTION
As the text field for explanation is not mandatory it could be empty.
This currently leads to the following error which is fixed by this PR:

```
Twig\Error\RuntimeError:
Neither the property "text" nor one of the methods "text()", "gettext()", "istext()", "hastext()" or "__call()" exist and have public access in class "Contao\FormExplanation" in "@Contao/form_explanation.html.twig" at line 7.

  at vendor/contao/core-bundle/contao/templates/twig/form_explanation.html.twig:7
  at Twig\Extension\CoreExtension::getAttribute()
     (var/cache/dev/twig/5a/5ae09e36d5a6b44245be41cdcfa72477.php:59)
  at __TwigTemplate_4b7981bb137c3d797fae4e538df6deb3->doDisplay()
     (vendor/twig/twig/src/Template.php:402)
  at Twig\Template->yield()
     (vendor/twig/twig/src/Template.php:358)
  at Twig\Template->display()
     (vendor/twig/twig/src/Template.php:373)
  at Twig\Template->render()
     (vendor/twig/twig/src/TemplateWrapper.php:51)
  at Twig\TemplateWrapper->render()
     (vendor/twig/twig/src/Environment.php:333)
  at Twig\Environment->render()
     (vendor/contao/core-bundle/contao/library/Contao/TemplateInheritance.php:394)
  at Contao\Widget->baseRenderTwigSurrogateIfExists()
     (vendor/contao/core-bundle/contao/library/Contao/Widget.php:1567)
  at Contao\Widget->renderTwigSurrogateIfExists()
     (vendor/contao/core-bundle/contao/library/Contao/TemplateInheritance.php:83)
  at Contao\Widget->inherit()
     (vendor/contao/core-bundle/contao/library/Contao/Widget.php:596)
  at Contao\Widget->parse()
     (var/cache/dev/contao/dca/tl_form_field.php:59)
  at tl_form_field->listFormFields()
     (vendor/contao/core-bundle/contao/classes/DataContainer.php:1344)
  at Contao\DataContainer->generateRecordLabel()
     (vendor/contao/core-bundle/contao/drivers/DC_Table.php:4236)
  at Contao\DC_Table->parentView()
     (vendor/contao/core-bundle/contao/drivers/DC_Table.php:523)
  at Contao\DC_Table->showAll()
     (vendor/contao/core-bundle/contao/classes/Backend.php:463)
  at Contao\Backend->getBackendModule()
     (vendor/contao/core-bundle/contao/controllers/BackendMain.php:143)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/Backend/BackendController.php:45)
  at Contao\CoreBundle\Controller\Backend\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (web/index.php:42)
  at require('.../index.php')
     (web/app.php:13)                
```