### PR TITLE
Remove `@charset` and BOM from the compiled SCSS files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
         "scheb/2fa-bundle": "^6.0 || ^7.0",
         "scheb/2fa-trusted-device": "^6.0 || ^7.0",
         "scrivo/highlight.php": "^9.18",
-        "scssphp/scssphp": "^1.5",
+        "scssphp/scssphp": "^1.7",
         "simplepie/simplepie": "^1.3",
         "spatie/schema-org": "^3.4",
         "spomky-labs/otphp": "^11.3",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -98,7 +98,7 @@
         "scheb/2fa-bundle": "^6.0 || ^7.0",
         "scheb/2fa-trusted-device": "^6.0 || ^7.0",
         "scrivo/highlight.php": "^9.18",
-        "scssphp/scssphp": "^1.5",
+        "scssphp/scssphp": "^1.7",
         "simplepie/simplepie": "^1.3",
         "spatie/schema-org": "^3.4",
         "spomky-labs/otphp": "^11.3",

--- a/core-bundle/contao/library/Contao/Combiner.php
+++ b/core-bundle/contao/library/Contao/Combiner.php
@@ -403,6 +403,7 @@ class Combiner extends System
 			$objCompiler = new Compiler();
 			$objCompiler->setImportPaths($this->strRootDir . '/' . \dirname($arrFile['name']));
 			$objCompiler->setOutputStyle($blnDebug ? OutputStyle::EXPANDED : OutputStyle::COMPRESSED);
+			$objCompiler->setCharset(false);
 
 			if ($blnDebug)
 			{

--- a/core-bundle/tests/Contao/CombinerTest.php
+++ b/core-bundle/tests/Contao/CombinerTest.php
@@ -248,7 +248,7 @@ class CombinerTest extends TestCase
 
     public function testDoesNotAddCharset(): void
     {
-        $this->filesystem->dumpFile($this->getTempDir().'/file.scss', ".foobar { content: 'ö' }");
+        $this->filesystem->dumpFile($this->getTempDir().'/file.scss', '.foobar { content: "ö" }');
 
         $combiner = new Combiner();
         $combiner->add('file.scss');

--- a/core-bundle/tests/Contao/CombinerTest.php
+++ b/core-bundle/tests/Contao/CombinerTest.php
@@ -246,6 +246,19 @@ class CombinerTest extends TestCase
         );
     }
 
+    public function testDoesNotAddCharset(): void
+    {
+        $this->filesystem->dumpFile($this->getTempDir().'/file.scss', ".foobar { content: 'ö' }");
+
+        $combiner = new Combiner();
+        $combiner->add('file.scss');
+
+        $this->assertStringEqualsFile(
+            $this->getTempDir().'/'.$combiner->getCombinedFile(),
+            ".foobar{content:\"ö\"}\n",
+        );
+    }
+
     public function testCombinesJsFiles(): void
     {
         $this->filesystem->dumpFile($this->getTempDir().'/file1.js', 'file1();');


### PR DESCRIPTION
Fixes #9601

This removes `@charset` from compiled SCSS files (and the Byte Order Mark in newer scssphp versions) as they might end up in the middle of the file when combined with regular CSS files when **Combine scripts** is enabled.