### PR TITLE
Fix the field order in the default palette of `make:contao:content-element`

### DIFF
--- a/maker-bundle/skeleton/content-element/tl_content.tpl.php
+++ b/maker-bundle/skeleton/content-element/tl_content.tpl.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 <?php endif; ?>
 
 $GLOBALS['TL_DCA']['tl_content']['palettes']['<?= $element_name ?>'] = '
-    {type_legend},title,headline,type;
+    {type_legend},type,headline,title;
     {template_legend:hide},customTpl;
     {protected_legend:hide},protected;
     {expert_legend:hide},cssID;


### PR DESCRIPTION
Follow-up to #9357 - this changes also changes the order of fields in the generated palette of the `make:contao:content-element` command.