### PR TITLE
Flatten array values in the `ValueFormatter`

### DIFF
--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -488,7 +488,7 @@ class ValueFormatter implements ResetInterface
     private function flatten(mixed $value): string
     {
         if (\is_array($value)) {
-            if (isset($value['value'], $value['unit']) && \count($value) == 2) {
+            if (isset($value['value'], $value['unit']) && 2 === \count($value)) {
                 return trim($value['value'].', '.$value['unit']);
             }
 

--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -331,7 +331,7 @@ class ValueFormatter implements ResetInterface
             return Idna::decodeEmail((string) $value);
         }
 
-        return (string) $value;
+        return $this->flatten($value);
     }
 
     private function getDateOptions(string $table, string $field, array $values): array
@@ -483,5 +483,31 @@ class ValueFormatter implements ResetInterface
         }
 
         return null;
+    }
+
+    private function flatten(mixed $value): string
+    {
+        if (\is_array($value)) {
+            if (isset($value['value'], $value['unit']) && \count($value) == 2) {
+                return trim($value['value'].', '.$value['unit']);
+            }
+
+            foreach ($value as $kk => $vv) {
+                if (\is_array($vv)) {
+                    $vals = array_values($vv);
+                    $value[$kk] = array_shift($vals).' ('.implode(', ', array_filter($vals)).')';
+                }
+            }
+
+            if (ArrayUtil::isAssoc($value)) {
+                foreach ($value as $kk => $vv) {
+                    $value[$kk] = $kk.': '.$vv;
+                }
+            }
+
+            return implode(', ', $value);
+        }
+
+        return (string) $value;
     }
 }

--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -216,6 +216,8 @@ class ValueFormatter implements ResetInterface
 
     public function getLabel(string $table, string $field, mixed $value, mixed $dc): string
     {
+        $value = StringUtil::deserialize($value);
+
         // Translate UUIDs to paths
         if ('fileTree' === ($GLOBALS['TL_DCA'][$table]['fields'][$field]['inputType'] ?? null)) {
             $objFile = $this->framework->getAdapter(FilesModel::class)->findByUuid($value);
@@ -431,7 +433,7 @@ class ValueFormatter implements ResetInterface
             return StringUtil::deserialize($value, true);
         }
 
-        return StringUtil::deserialize($value);
+        return $value;
     }
 
     private function fetchForeignValue(string $table, string $field, mixed $id): mixed

--- a/core-bundle/tests/DataContainer/ValueFormatterTest.php
+++ b/core-bundle/tests/DataContainer/ValueFormatterTest.php
@@ -115,6 +115,36 @@ class ValueFormatterTest extends TestCase
             'foo,bar',
         ];
 
+        yield 'Serialized headline' => [
+            serialize(['unit' => 'h1', 'value' => 'foo']),
+            [],
+            'foo, h1',
+        ];
+
+        yield 'Serialized array (#1)' => [
+            serialize(['foo', 'bar']),
+            [],
+            'foo, bar',
+        ];
+
+        yield 'Serialized array (#2)' => [
+            serialize([['foo', 'bar', 'baz']]),
+            [],
+            'foo (bar, baz)',
+        ];
+
+        yield 'Serialized array (#3)' => [
+            serialize(['foo' => 'bar']),
+            [],
+            'foo: bar',
+        ];
+
+        yield 'Serialized array (#4)' => [
+            serialize(['foo' => 'bar', 'bar' => ['baz', 1, 2, 3]]),
+            [],
+            'foo: bar, bar: baz (1, 2, 3)',
+        ];
+
         yield 'Date' => [
             '1764689390',
             ['eval' => ['rgxp' => 'date']],


### PR DESCRIPTION
Since https://github.com/contao/contao/pull/9460/changes#diff-176d0493d327440e96d4f93c316598651e57b6d1fdd8e39f2e59ac5ea93ea3fcR434 values are always unserialized (being consistent with the <5.7 approach), I ran into an **array to string conversion** error in my back end. I then remembered and found https://github.com/contao/contao/pull/9460/changes#diff-d435f42f940856c7253fdef43ab51701ac38816414b06b80fc042acaabb3101fL619-L646 which was missing in the `ValueFormatter`