### PR TITLE
Move the template editor check to a `save_callback`

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -65,6 +65,12 @@ services:
             - '@security.helper'
             - '@request_stack'
 
+    contao.listener.data_container.check_template_editor_save:
+        class: Contao\CoreBundle\EventListener\DataContainer\CheckTemplateEditorSaveListener
+        arguments:
+            - '@security.helper'
+            - '@translator'
+
     contao.listener.data_container.content_composition:
         class: Contao\CoreBundle\EventListener\DataContainer\ContentCompositionListener
         public: true

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -656,11 +656,9 @@ class tl_user extends Backend
 	/**
 	 * Return all modules except profile modules
 	 *
-	 * @param DataContainer $dc
-	 *
 	 * @return array
 	 */
-	public function getModules(DataContainer $dc)
+	public function getModules()
 	{
 		$arrModules = array();
 
@@ -680,15 +678,6 @@ class tl_user extends Backend
 			}
 
 			$arrModules[$k] = array_keys($v);
-		}
-
-		$modules = StringUtil::deserialize($dc->activeRecord->modules);
-
-		// Unset the template editor unless the user is an administrator or has been granted access to the template editor
-		if (!BackendUser::getInstance()->isAdmin && (!is_array($modules) || !in_array('tpl_editor', $modules)) && ($key = array_search('tpl_editor', $arrModules['design'])) !== false)
-		{
-			unset($arrModules['design'][$key]);
-			$arrModules['design'] = array_values($arrModules['design']);
 		}
 
 		return $arrModules;

--- a/core-bundle/contao/dca/tl_user_group.php
+++ b/core-bundle/contao/dca/tl_user_group.php
@@ -307,11 +307,9 @@ class tl_user_group extends Backend
 	/**
 	 * Return all modules except profile modules
 	 *
-	 * @param DataContainer $dc
-	 *
 	 * @return array
 	 */
-	public function getModules(DataContainer $dc)
+	public function getModules()
 	{
 		$arrModules = array();
 
@@ -331,15 +329,6 @@ class tl_user_group extends Backend
 			}
 
 			$arrModules[$k] = array_keys($v);
-		}
-
-		$modules = StringUtil::deserialize($dc->activeRecord->modules);
-
-		// Unset the template editor unless the user is an administrator or has been granted access to the template editor
-		if (!BackendUser::getInstance()->isAdmin && (!is_array($modules) || !in_array('tpl_editor', $modules)) && ($key = array_search('tpl_editor', $arrModules['design'])) !== false)
-		{
-			unset($arrModules['design'][$key]);
-			$arrModules['design'] = array_values($arrModules['design']);
 		}
 
 		return $arrModules;

--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -288,7 +288,7 @@
         <source>Element ID %d cannot be inserted here because it conflicts with an existing element.</source>
       </trans-unit>
       <trans-unit id="ERR.grantTemplateEditor">
-        <source>Access to the template editor is not allowed to be granted.</source>
+        <source>You can only grant access to the template editor if you are an admin.</source>
       </trans-unit>
       <trans-unit id="SEC.question1">
         <source>Please add %d and %d.</source>

--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -287,6 +287,9 @@
       <trans-unit id="ERR.copyUnique">
         <source>Element ID %d cannot be inserted here because it conflicts with an existing element.</source>
       </trans-unit>
+      <trans-unit id="ERR.grantTemplateEditor">
+        <source>Access to the template editor is not allowed to be granted.</source>
+      </trans-unit>
       <trans-unit id="SEC.question1">
         <source>Please add %d and %d.</source>
       </trans-unit>

--- a/core-bundle/src/EventListener/DataContainer/CheckTemplateEditorSaveListener.php
+++ b/core-bundle/src/EventListener/DataContainer/CheckTemplateEditorSaveListener.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Checks whether "tpl_editor" is added to the allowed back end modules and denies
- * saving, if the user is not admin and the user or user group did not previously
+ * saving if the user is not admin and the user or user group did not previously
  * have access to the template editor.
  */
 #[AsCallback('tl_user', 'fields.modules.save')]
@@ -49,7 +49,7 @@ class CheckTemplateEditorSaveListener
 
         $currentModules = StringUtil::deserialize($dc->getCurrentRecord()['modules'] ?? null);
 
-        // Allow change if access to template editor was already granted
+        // Allow changing if access to template editor was already granted
         if (\is_array($currentModules) && \in_array('tpl_editor', $currentModules, true)) {
             return $value;
         }

--- a/core-bundle/src/EventListener/DataContainer/CheckTemplateEditorSaveListener.php
+++ b/core-bundle/src/EventListener/DataContainer/CheckTemplateEditorSaveListener.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\DataContainer;
+use Contao\StringUtil;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Checks whether "tpl_editor" is added to the allowed back end modules and denies
+ * saving, if the user is not admin and the user or user group did not previously
+ * have access to the template editor.
+ */
+#[AsCallback('tl_user', 'fields.modules.save')]
+#[AsCallback('tl_user_group', 'fields.modules.save')]
+class CheckTemplateEditorSaveListener
+{
+    public function __construct(
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    public function __invoke(mixed $value, DataContainer $dc): mixed
+    {
+        if ($this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+            return $value;
+        }
+
+        $newModules = StringUtil::deserialize($value);
+
+        // Do nothing if access to the template editor is not tried to be granted
+        if (!\is_array($newModules) || !\in_array('tpl_editor', $newModules, true)) {
+            return $value;
+        }
+
+        $currentModules = StringUtil::deserialize($dc->getCurrentRecord()['modules'] ?? null);
+
+        // Allow change if access to template editor was already granted
+        if (\is_array($currentModules) && \in_array('tpl_editor', $currentModules, true)) {
+            return $value;
+        }
+
+        throw new AccessDeniedException($this->translator->trans('ERR.grantTemplateEditor', [], 'contao_default'));
+    }
+}

--- a/core-bundle/src/Security/Voter/DataContainer/TemplateEditorModuleVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/TemplateEditorModuleVoter.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Voter\DataContainer;
+
+use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\CoreBundle\Security\DataContainer\CreateAction;
+use Contao\CoreBundle\Security\DataContainer\UpdateAction;
+use Contao\StringUtil;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
+
+/**
+ * @internal
+ */
+class TemplateEditorModuleVoter implements CacheableVoterInterface
+{
+    public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)
+    {
+    }
+
+    public function supportsAttribute(string $attribute): bool
+    {
+        return \in_array($attribute, [ContaoCorePermissions::DC_PREFIX.'tl_user', ContaoCorePermissions::DC_PREFIX.'tl_user_group'], true);
+    }
+
+    public function supportsType(string $subjectType): bool
+    {
+        return \in_array($subjectType, [CreateAction::class, UpdateAction::class], true);
+    }
+
+    public function vote(TokenInterface $token, $subject, array $attributes): int
+    {
+        if (!$subject instanceof CreateAction && !$subject instanceof UpdateAction) {
+            return self::ACCESS_ABSTAIN;
+        }
+
+        if (
+            !\in_array('tpl_editor', StringUtil::deserialize($subject->getNew()['modules'] ?? null, true), true)
+            || (
+                $subject instanceof UpdateAction
+                && \in_array('tpl_editor', StringUtil::deserialize($subject->getCurrent()['modules'] ?? null, true), true)
+            )
+            || $this->accessDecisionManager->decide($token, ['ROLE_ADMIN'])
+        ) {
+            return self::ACCESS_ABSTAIN;
+        }
+
+        return self::ACCESS_DENIED;
+    }
+}

--- a/core-bundle/tests/Security/Voter/DataContainer/TemplateEditorModuleVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/TemplateEditorModuleVoterTest.php
@@ -79,7 +79,7 @@ class TemplateEditorModuleVoterTest extends TestCase
     {
         $token = $this->createStub(TokenInterface::class);
 
-        $accessDecisionManager = $this->createStub(AccessDecisionManagerInterface::class);
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
         $accessDecisionManager
             ->expects($this->once())
             ->method('decide')
@@ -109,7 +109,7 @@ class TemplateEditorModuleVoterTest extends TestCase
     {
         $token = $this->createStub(TokenInterface::class);
 
-        $accessDecisionManager = $this->createStub(AccessDecisionManagerInterface::class);
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
         $accessDecisionManager
             ->expects($this->once())
             ->method('decide')

--- a/core-bundle/tests/Security/Voter/DataContainer/TemplateEditorModuleVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/TemplateEditorModuleVoterTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Security\Voter\DataContainer;
+
+use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\CoreBundle\Security\DataContainer\CreateAction;
+use Contao\CoreBundle\Security\DataContainer\UpdateAction;
+use Contao\CoreBundle\Security\Voter\DataContainer\TemplateEditorModuleVoter;
+use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class TemplateEditorModuleVoterTest extends TestCase
+{
+    public function testAbstainsCreateIfTemplateEditorIsNotInModules(): void
+    {
+        $subject = new CreateAction('tl_user', [
+            'id' => 42,
+        ]);
+
+        $voter = new TemplateEditorModuleVoter($this->createStub(AccessDecisionManagerInterface::class));
+        $decision = $voter->vote($this->createStub(TokenInterface::class), $subject, [ContaoCorePermissions::DC_PREFIX.'tl_user']);
+
+        $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $decision);
+    }
+
+    public function testAbstainsUpdateIfTemplateEditorIsNotInNewModules(): void
+    {
+        $subject = new UpdateAction(
+            'tl_user',
+            [
+                'id' => 42,
+                'foo' => 'bar',
+            ],
+            [
+                'id' => 42,
+                'foo' => 'baz',
+            ],
+        );
+
+        $voter = new TemplateEditorModuleVoter($this->createStub(AccessDecisionManagerInterface::class));
+        $decision = $voter->vote($this->createStub(TokenInterface::class), $subject, [ContaoCorePermissions::DC_PREFIX.'tl_user']);
+
+        $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $decision);
+    }
+
+    public function testAbstainsUpdateIfTemplateEditorIsInCurrentModules(): void
+    {
+        $subject = new UpdateAction(
+            'tl_user',
+            [
+                'id' => 42,
+                'modules' => serialize(['foo', 'tpl_editor']),
+            ],
+            [
+                'id' => 42,
+                'modules' => serialize(['bar', 'tpl_editor']),
+            ],
+        );
+
+        $voter = new TemplateEditorModuleVoter($this->createStub(AccessDecisionManagerInterface::class));
+        $decision = $voter->vote($this->createStub(TokenInterface::class), $subject, [ContaoCorePermissions::DC_PREFIX.'tl_user']);
+
+        $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $decision);
+    }
+
+    public function testAbstainsIfUserIsAdmin(): void
+    {
+        $token = $this->createStub(TokenInterface::class);
+
+        $accessDecisionManager = $this->createStub(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($token, ['ROLE_ADMIN'])
+            ->willReturn(true)
+        ;
+
+        $subject = new UpdateAction(
+            'tl_user',
+            [
+                'id' => 42,
+                'modules' => serialize(['foo']),
+            ],
+            [
+                'id' => 42,
+                'modules' => serialize(['foo', 'tpl_editor']),
+            ],
+        );
+
+        $voter = new TemplateEditorModuleVoter($accessDecisionManager);
+        $decision = $voter->vote($token, $subject, [ContaoCorePermissions::DC_PREFIX.'tl_user']);
+
+        $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $decision);
+    }
+
+    public function testDeniesIfTemplateEditorIs(): void
+    {
+        $token = $this->createStub(TokenInterface::class);
+
+        $accessDecisionManager = $this->createStub(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($token, ['ROLE_ADMIN'])
+            ->willReturn(false)
+        ;
+
+        $subject = new UpdateAction(
+            'tl_user',
+            [
+                'id' => 42,
+                'modules' => serialize(['foo']),
+            ],
+            [
+                'id' => 42,
+                'modules' => serialize(['foo', 'tpl_editor']),
+            ],
+        );
+
+        $voter = new TemplateEditorModuleVoter($accessDecisionManager);
+        $decision = $voter->vote($token, $subject, [ContaoCorePermissions::DC_PREFIX.'tl_user']);
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $decision);
+    }
+
+    public static function actionClassProvider(): iterable
+    {
+        yield [CreateAction::class];
+
+        yield [UpdateAction::class];
+    }
+}


### PR DESCRIPTION
Implements the `tpl_editor` change check to a `save_callback` as discussed [here](https://github.com/contao/contao/pull/9144#issuecomment-4005613131).