### PR TITLE
Use a delegate template when rendering Twig components

### DIFF
--- a/calendar-bundle/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/contao/modules/ModuleEventlist.php
@@ -290,7 +290,7 @@ class ModuleEventlist extends Events
 
 			list($offset, $limit) = $pagination->getIndexRange();
 
-			$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/component/_pagination.html.twig', array('pagination' => $pagination));
+			$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
 		}
 
 		$strMonth = '';

--- a/comments-bundle/contao/classes/Comments.php
+++ b/comments-bundle/contao/classes/Comments.php
@@ -77,7 +77,7 @@ class Comments extends Frontend
 			$offset = $pagination->getOffset();
 
 			// Initialize the pagination menu
-			$objTemplate->pagination = System::getContainer()->get('twig')->render('@Contao/component/_pagination.html.twig', array('pagination' => $pagination));
+			$objTemplate->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
 		}
 
 		$objTemplate->allowComments = true;

--- a/core-bundle/contao/modules/ModuleSearch.php
+++ b/core-bundle/contao/modules/ModuleSearch.php
@@ -209,7 +209,7 @@ class ModuleSearch extends Module
 				// Pagination menu
 				if ($pagination->getPageCount() > 1)
 				{
-					$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/component/_pagination.html.twig', array('pagination' => $pagination));
+					$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
 				}
 
 				$this->Template->page = $pagination->getCurrent();

--- a/core-bundle/contao/templates/frontend_module/pagination.html.twig
+++ b/core-bundle/contao/templates/frontend_module/pagination.html.twig
@@ -1,0 +1,3 @@
+{% use '@Contao/component/_pagination.html.twig' %}
+
+{{ block('pagination_component') }}

--- a/core-bundle/contao/templates/insert_tag/figure.html.twig
+++ b/core-bundle/contao/templates/insert_tag/figure.html.twig
@@ -1,0 +1,3 @@
+{% use '@Contao/component/_figure.html.twig' %}
+
+{{ block('figure_component') }}

--- a/core-bundle/src/Image/Studio/FigureRenderer.php
+++ b/core-bundle/src/Image/Studio/FigureRenderer.php
@@ -45,7 +45,7 @@ class FigureRenderer
      * @param array<string, mixed>                                $configuration Configuration for the FigureBuilder
      * @param string                                              $template      A Contao or Twig template
      */
-    public function render(FilesModel|FilesystemItem|ImageInterface|int|string $from, PictureConfiguration|array|int|string|null $size, array $configuration = [], string $template = '@Contao/component/_figure.html.twig'): string|null
+    public function render(FilesModel|FilesystemItem|ImageInterface|int|string $from, PictureConfiguration|array|int|string|null $size, array $configuration = [], string $template = '@Contao/insert_tag/figure.html.twig'): string|null
     {
         if (!$figure = $this->buildFigure($from, $size, $configuration)) {
             return null;

--- a/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
+++ b/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
@@ -477,7 +477,7 @@ class LegacyInsertTag implements InsertTagResolverNestedResolvedInterface
                 }
 
                 $size = $configuration['size'] ?? null;
-                $template = $configuration['template'] ?? '@Contao/component/_figure.html.twig';
+                $template = $configuration['template'] ?? '@Contao/insert_tag/figure.html.twig';
 
                 unset($configuration['size'], $configuration['template']);
 

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -298,7 +298,7 @@ class InsertTagsTest extends TestCase
 
     public static function provideFigureInsertTags(): iterable
     {
-        $defaultTemplate = '@Contao/component/_figure.html.twig';
+        $defaultTemplate = '@Contao/insert_tag/figure.html.twig';
 
         yield 'without any configuration' => [
             '{{figure::123}}',

--- a/core-bundle/tests/Image/Studio/FigureRendererTest.php
+++ b/core-bundle/tests/Image/Studio/FigureRendererTest.php
@@ -187,7 +187,7 @@ class FigureRendererTest extends TestCase
         $this->assertNull($figureRenderer->render('invalid-resource', null));
     }
 
-    private function getFigureRenderer(array $figureBuilderCalls = [], string $expectedTemplate = '@Contao/component/_figure.html.twig'): FigureRenderer
+    private function getFigureRenderer(array $figureBuilderCalls = [], string $expectedTemplate = '@Contao/insert_tag/figure.html.twig'): FigureRenderer
     {
         $figure = new Figure($this->createStub(ImageResult::class));
 

--- a/listing-bundle/contao/modules/ModuleListing.php
+++ b/listing-bundle/contao/modules/ModuleListing.php
@@ -219,7 +219,7 @@ class ModuleListing extends Module
 			try
 			{
 				$pagination = System::getContainer()->get('contao.pagination.factory')->create(new PaginationConfig($id, $objTotal->count, $per_page));
-				$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/component/_pagination.html.twig', array('pagination' => $pagination));
+				$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
 			}
 			catch (PageOutOfRangeException $e)
 			{

--- a/news-bundle/contao/modules/ModuleNewsArchive.php
+++ b/news-bundle/contao/modules/ModuleNewsArchive.php
@@ -185,7 +185,7 @@ class ModuleNewsArchive extends ModuleNews
 				$offset = $pagination->getOffset();
 
 				// Add the pagination menu
-				$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/component/_pagination.html.twig', array('pagination' => $pagination));
+				$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
 			}
 		}
 

--- a/news-bundle/contao/modules/ModuleNewsList.php
+++ b/news-bundle/contao/modules/ModuleNewsList.php
@@ -149,7 +149,7 @@ class ModuleNewsList extends ModuleNews
 			}
 
 			// Add the pagination menu
-			$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/component/_pagination.html.twig', array('pagination' => $pagination));
+			$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
 		}
 
 		$objArticles = $this->fetchItems($this->news_archives, $blnFeatured, $limit ?: 0, $offset);


### PR DESCRIPTION
Same as #9627 for Contao 6

This also includes a new `insert_tag/figure` template - similar to the one for the pagination.