### PR TITLE
Encode invalid and disallowed URL protocols in BBCode

### DIFF
--- a/comments-bundle/src/Util/BbCode.php
+++ b/comments-bundle/src/Util/BbCode.php
@@ -197,7 +197,7 @@ final class BbCode
 
                     try {
                         if (Validator::isUrl($uri)) {
-                            return \sprintf('<a href="%s" rel="noopener noreferrer nofollow">%s</a>', StringUtil::specialchars(Idna::encodeUrl($uri), true), StringUtil::specialchars($title, true));
+                            return \sprintf('<a href="%s" rel="noopener noreferrer nofollow">%s</a>', StringUtil::specialcharsUrl(Idna::encodeUrl($uri), true), StringUtil::specialchars($title, true));
                         }
                     } catch (\InvalidArgumentException) {
                     }

--- a/comments-bundle/tests/Util/BbCodeTest.php
+++ b/comments-bundle/tests/Util/BbCodeTest.php
@@ -11,10 +11,25 @@ declare(strict_types=1);
  */
 
 use Contao\CommentsBundle\Util\BbCode;
-use PHPUnit\Framework\TestCase;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\System;
 
 class BbCodeTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        System::setContainer($this->getContainerWithContaoConfiguration(self::getTempDir()));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetStaticProperties([System::class]);
+
+        parent::tearDown();
+    }
+
     /**
      * @dataProvider provideBbCode
      */
@@ -130,6 +145,21 @@ class BbCodeTest extends TestCase
         yield 'encodes URLs' => [
             '[url]https://example.com/foo&bar[/url]',
             '<a href="https://example.com/foo&amp;bar" rel="noopener noreferrer nofollow">https://example.com/foo&amp;bar</a>',
+        ];
+
+        yield 'encodes invalid url protocol' => [
+            '[url=special:protocol]foo[/url]',
+            '<a href="special%3Aprotocol" rel="noopener noreferrer nofollow">foo</a>',
+        ];
+
+        yield 'encodes javascript url protocol' => [
+            '[url]javascript:alert(1)[/url]',
+            '<a href="javascript%3Aalert(1)" rel="noopener noreferrer nofollow">javascript:alert(1)</a>',
+        ];
+
+        yield 'encodes encoded javascript url protocol' => [
+            '[url]javascript&colon;alert(1)[/url]',
+            'javascript&colon;alert(1)',
         ];
 
         yield 'encodes insert tags' => [

--- a/comments-bundle/tests/Util/BbCodeTest.php
+++ b/comments-bundle/tests/Util/BbCodeTest.php
@@ -16,13 +16,6 @@ use Contao\System;
 
 class BbCodeTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        System::setContainer($this->getContainerWithContaoConfiguration(self::getTempDir()));
-    }
-
     protected function tearDown(): void
     {
         $this->resetStaticProperties([System::class]);
@@ -35,6 +28,8 @@ class BbCodeTest extends TestCase
      */
     public function testConvertToHtml(string $bbCode, string $expectedHtml): void
     {
+        System::setContainer($this->getContainerWithContaoConfiguration());
+
         $GLOBALS['TL_LANG']['MSC'] = [
             'com_quote' => '%s wrote:',
             'com_code' => 'Code:',


### PR DESCRIPTION
We already disallow `javascript` in _Comments.php_ itself, but this should guarantee that only allowed URL protocols can be used in BBCode.