### PR TITLE
Fix a Twig issue in the `form_html.html.twig` template

### DIFF
--- a/core-bundle/contao/templates/twig/form_html.html.twig
+++ b/core-bundle/contao/templates/twig/form_html.html.twig
@@ -1,1 +1,1 @@
-{{ html|default|sanitize_html('contao') }}
+{{ html|default|sanitize_html('contao')|insert_tag_raw }}

--- a/core-bundle/contao/templates/twig/form_html.html.twig
+++ b/core-bundle/contao/templates/twig/form_html.html.twig
@@ -1,1 +1,1 @@
-{{ this.html|sanitize_html('contao') }}
+{{ html|default|sanitize_html('contao') }}

--- a/core-bundle/contao/templates/twig/form_html.html.twig
+++ b/core-bundle/contao/templates/twig/form_html.html.twig
@@ -1,1 +1,1 @@
-{{ html|default|sanitize_html('contao')|insert_tag_raw }}
+{{ this.html|default|sanitize_html('contao')|insert_tag_raw }}


### PR DESCRIPTION
### Description

Regression from the template rewrite.

Seen an error happening within client logs, html can additionally be null (when creating the field and not updating it yet)

https://github.com/contao/contao/blob/f01dcd4dd824da4314e8f01b9b2e01160d4213ac/core-bundle/contao/dca/tl_form_field.php#L158-L164
