### PR TITLE
Pass the pagination instance to legacy templates

### DIFF
--- a/calendar-bundle/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/contao/modules/ModuleEventlist.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\PageOutOfRangeException;
+use Contao\CoreBundle\Pagination\LegacyTemplatePaginationProxy;
 use Contao\CoreBundle\Pagination\PaginationConfig;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -290,7 +291,7 @@ class ModuleEventlist extends Events
 
 			list($offset, $limit) = $pagination->getIndexRange();
 
-			$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
+			$this->Template->pagination = new LegacyTemplatePaginationProxy(System::getContainer()->get('twig'), $pagination);
 		}
 
 		$strMonth = '';

--- a/comments-bundle/contao/classes/Comments.php
+++ b/comments-bundle/contao/classes/Comments.php
@@ -14,6 +14,7 @@ use Contao\CommentsBundle\Util\BbCode;
 use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\PageOutOfRangeException;
+use Contao\CoreBundle\Pagination\LegacyTemplatePaginationProxy;
 use Contao\CoreBundle\Pagination\PaginationConfig;
 use Contao\CoreBundle\Util\UrlUtil;
 use Nyholm\Psr7\Uri;
@@ -77,7 +78,7 @@ class Comments extends Frontend
 			$offset = $pagination->getOffset();
 
 			// Initialize the pagination menu
-			$objTemplate->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
+			$objTemplate->pagination = new LegacyTemplatePaginationProxy(System::getContainer()->get('twig'), $pagination);
 		}
 
 		$objTemplate->allowComments = true;

--- a/core-bundle/contao/modules/ModuleSearch.php
+++ b/core-bundle/contao/modules/ModuleSearch.php
@@ -14,6 +14,7 @@ use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\PageOutOfRangeException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\Image\Studio\Figure;
+use Contao\CoreBundle\Pagination\LegacyTemplatePaginationProxy;
 use Contao\CoreBundle\Pagination\PaginationConfig;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -209,7 +210,7 @@ class ModuleSearch extends Module
 				// Pagination menu
 				if ($pagination->getPageCount() > 1)
 				{
-					$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
+					$this->Template->pagination = new LegacyTemplatePaginationProxy(System::getContainer()->get('twig'), $pagination);
 				}
 
 				$this->Template->page = $pagination->getCurrent();

--- a/core-bundle/src/Pagination/LegacyTemplatePaginationProxy.php
+++ b/core-bundle/src/Pagination/LegacyTemplatePaginationProxy.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Pagination;
+
+use Twig\Environment;
+
+/**
+ * @internal
+ */
+final class LegacyTemplatePaginationProxy implements \Stringable
+{
+    public function __construct(
+        private readonly Environment $twig,
+        private readonly Pagination $pagination,
+        private readonly string $template = '@Contao/frontend_module/pagination.html.twig',
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->twig->render($this->template, ['pagination' => $this->pagination]);
+    }
+
+    public function getObject(): Pagination
+    {
+        return $this->pagination;
+    }
+}

--- a/listing-bundle/contao/modules/ModuleListing.php
+++ b/listing-bundle/contao/modules/ModuleListing.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\PageOutOfRangeException;
+use Contao\CoreBundle\Pagination\LegacyTemplatePaginationProxy;
 use Contao\CoreBundle\Pagination\PaginationConfig;
 
 /**
@@ -219,7 +220,7 @@ class ModuleListing extends Module
 			try
 			{
 				$pagination = System::getContainer()->get('contao.pagination.factory')->create(new PaginationConfig($id, $objTotal->count, $per_page));
-				$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
+				$this->Template->pagination = new LegacyTemplatePaginationProxy(System::getContainer()->get('twig'), $pagination);
 			}
 			catch (PageOutOfRangeException $e)
 			{

--- a/news-bundle/contao/modules/ModuleNewsArchive.php
+++ b/news-bundle/contao/modules/ModuleNewsArchive.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\PageOutOfRangeException;
+use Contao\CoreBundle\Pagination\LegacyTemplatePaginationProxy;
 use Contao\CoreBundle\Pagination\PaginationConfig;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -185,7 +186,7 @@ class ModuleNewsArchive extends ModuleNews
 				$offset = $pagination->getOffset();
 
 				// Add the pagination menu
-				$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
+				$this->Template->pagination = new LegacyTemplatePaginationProxy(System::getContainer()->get('twig'), $pagination);
 			}
 		}
 

--- a/news-bundle/contao/modules/ModuleNewsList.php
+++ b/news-bundle/contao/modules/ModuleNewsList.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\PageOutOfRangeException;
+use Contao\CoreBundle\Pagination\LegacyTemplatePaginationProxy;
 use Contao\CoreBundle\Pagination\PaginationConfig;
 use Contao\Model\Collection;
 use Symfony\Component\HttpFoundation\Request;
@@ -149,7 +150,7 @@ class ModuleNewsList extends ModuleNews
 			}
 
 			// Add the pagination menu
-			$this->Template->pagination = System::getContainer()->get('twig')->render('@Contao/frontend_module/pagination.html.twig', array('pagination' => $pagination));
+			$this->Template->pagination = new LegacyTemplatePaginationProxy(System::getContainer()->get('twig'), $pagination);
 		}
 
 		$objArticles = $this->fetchItems($this->news_archives, $blnFeatured, $limit ?: 0, $offset);


### PR DESCRIPTION
@Toflar brought up a good point about the pagination in all our legacy modules. Since it is simply a rendered string, you cannot take advantage of customising the component for one particular template in the Twig template pendants.

This PR introduces a `\Stringable` proxy class that makes this possible. With this you can then adjust any part of the pagination component only for one particular template, e.g. the newslist:

```twig
{# templates/mod_newslist.html.twig #}
{% extends '@Contao/mod_newslist.html.twig' %}
{% use "@Contao/component/_pagination.html.twig" %}

{# Render "X / Y" instead of "Page X of Y" #}
{% block pagination_total %}
    {% if pagination|default %}
        <p>{{ pagination.current }} / {{ pagination.pageCount }}</p>
    {% endif %}
{% endblock %}

{% block content %}

    {% if not articles %}
        <p class="empty">{{ empty }}</p>
    {% else %}
        {{ articles|join|raw }}

        {% if pagination.object|default %}
            {% with {pagination: pagination.object} %}{{ block('pagination_component') }}{% endwith %}
        {% endif %}
    {% endif %}

{% endblock %}
```