### PR TITLE
Replace insert tags in article teasers

### DIFF
--- a/core-bundle/contao/templates/twig/mod_article.html.twig
+++ b/core-bundle/contao/templates/twig/mod_article.html.twig
@@ -11,7 +11,7 @@
             <div class="ce_text block">
                 <h2>{{ headline|insert_tag_raw }}</h2>
                 <div class="teaser">
-                    {{ teaser|default|sanitize_html('contao')|csp_inline_styles }}
+                    {{ teaser|default|sanitize_html('contao')|csp_inline_styles|insert_tag_raw }}
                     <p class="more"><a href="{{ href }}" title="{{ readMore }}">{{ more }} <span class="invisible">{{ headline }}</span></a></p>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #9651

This was the last remaining `teaser` where we did not add `|insert_tag_raw`, as far as I can see.