### PR TITLE
Fix nullable `html` variable being passed to the filter

### DIFF
--- a/core-bundle/contao/templates/twig/ce_html.html.twig
+++ b/core-bundle/contao/templates/twig/ce_html.html.twig
@@ -1,1 +1,1 @@
-{{ html|sanitize_html('contao')|insert_tag_raw }}
+{{ html|default|sanitize_html('contao')|insert_tag_raw }}

--- a/core-bundle/contao/templates/twig/mod_html.html.twig
+++ b/core-bundle/contao/templates/twig/mod_html.html.twig
@@ -1,1 +1,1 @@
-{{ html|sanitize_html('contao')|insert_tag_raw }}
+{{ html|default|sanitize_html('contao')|insert_tag_raw }}


### PR DESCRIPTION
Fixes two remaining places where we pass the nullable `tl_content.html` and `tl_module.html` fields to a filter.