### PR TITLE
Fix the inconsistent active pagination element

### DIFF
--- a/core-bundle/contao/templates/twig/backend/component/_pagination.html.twig
+++ b/core-bundle/contao/templates/twig/backend/component/_pagination.html.twig
@@ -42,15 +42,22 @@
                         {% for page in pagination.pages %}
                             {% block pagination_link %}
                                 <li>
-                                    {% set link_attributes = attrs()
-                                        .set(link_attribute, pagination.urlForPage(page))
-                                        .set('aria-label', 'MSC.goToPage'|trans([page]))
-                                        .set('aria-current', 'page', pagination.current|default == page)
-                                        .addClass('link')
-                                        .addClass('active', pagination.current|default == page)
-                                        .mergeWith(link_attributes|default)
-                                    %}
-                                    <{{ link_element }}{{ link_attributes }}>{% block pagination_link_label %}{{ page }}{% endblock %}</{{ link_element }}>
+                                    {% if pagination.current == page %}
+                                        {% set active_attributes = attrs()
+                                            .addClass('active')
+                                            .set('aria-current', 'page')
+                                            .mergeWith(active_attributes|default)
+                                        %}
+                                        <strong{{ active_attributes }}>{% block pagination_active_label %}{{ page }}{% endblock %}</strong>
+                                    {% else %}
+                                        {% set link_attributes = attrs()
+                                            .set(link_attribute, pagination.urlForPage(page))
+                                            .set('aria-label', 'MSC.goToPage'|trans([page]))
+                                            .addClass('link')
+                                            .mergeWith(link_attributes|default)
+                                        %}
+                                        <{{ link_element }}{{ link_attributes }}>{% block pagination_link_label %}{{ page }}{% endblock %}</a>
+                                    {% endif %}
                                 </li>
                             {% endblock %}
                         {% endfor %}

--- a/core-bundle/contao/templates/twig/backend/component/_pagination.html.twig
+++ b/core-bundle/contao/templates/twig/backend/component/_pagination.html.twig
@@ -44,8 +44,8 @@
                                 <li>
                                     {% if pagination.current == page %}
                                         {% set active_attributes = attrs()
-                                            .addClass('active')
                                             .set('aria-current', 'page')
+                                            .addClass('active')
                                             .mergeWith(active_attributes|default)
                                         %}
                                         <strong{{ active_attributes }}>{% block pagination_active_label %}{{ page }}{% endblock %}</strong>

--- a/core-bundle/contao/templates/twig/backend/component/_pagination.html.twig
+++ b/core-bundle/contao/templates/twig/backend/component/_pagination.html.twig
@@ -56,7 +56,7 @@
                                             .addClass('link')
                                             .mergeWith(link_attributes|default)
                                         %}
-                                        <{{ link_element }}{{ link_attributes }}>{% block pagination_link_label %}{{ page }}{% endblock %}</a>
+                                        <{{ link_element }}{{ link_attributes }}>{% block pagination_link_label %}{{ page }}{% endblock %}</{{ link_element }}>
                                     {% endif %}
                                 </li>
                             {% endblock %}

--- a/core-bundle/contao/templates/twig/component/_pagination.html.twig
+++ b/core-bundle/contao/templates/twig/component/_pagination.html.twig
@@ -49,15 +49,22 @@
                         {% set href = pagination|default ? pagination.urlForPage(page) : '#' %}
                         {% block pagination_link %}
                             <li>
-                                {% set link_attributes = attrs()
-                                    .set('href', href)
-                                    .set('aria-label', 'MSC.goToPage'|trans([page]))
-                                    .set('aria-current', 'page', pagination.current|default == page)
-                                    .addClass('link')
-                                    .addClass('active', pagination.current|default == page)
-                                    .mergeWith(link_attributes|default)
-                                %}
-                                <a{{ link_attributes }}>{% block pagination_link_label %}{{ page }}{% endblock %}</a>
+                                {% if pagination.current|default == page %}
+                                    {% set active_attributes = attrs()
+                                        .addClass('active')
+                                        .set('aria-current', 'page')
+                                        .mergeWith(active_attributes|default)
+                                    %}
+                                    <strong{{ active_attributes }}>{% block pagination_active_label %}{{ page }}{% endblock %}</strong>
+                                {% else %}
+                                    {% set link_attributes = attrs()
+                                        .set('href', href)
+                                        .set('aria-label', 'MSC.goToPage'|trans([page]))
+                                        .addClass('link')
+                                        .mergeWith(link_attributes|default)
+                                    %}
+                                    <a{{ link_attributes }}>{% block pagination_link_label %}{{ page }}{% endblock %}</a>
+                                {% endif %}
                             </li>
                         {% endblock %}
                     {% endfor %}

--- a/core-bundle/contao/templates/twig/component/_pagination.html.twig
+++ b/core-bundle/contao/templates/twig/component/_pagination.html.twig
@@ -51,8 +51,8 @@
                             <li>
                                 {% if pagination.current|default == page %}
                                     {% set active_attributes = attrs()
-                                        .addClass('active')
                                         .set('aria-current', 'page')
+                                        .addClass('active')
                                         .mergeWith(active_attributes|default)
                                     %}
                                     <strong{{ active_attributes }}>{% block pagination_active_label %}{{ page }}{% endblock %}</strong>

--- a/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
@@ -314,7 +314,7 @@ class ImagesControllerTest extends ContentElementTestCase
                     <p>translated(contao_default:MSC.totalPages[1, 2])</p>
                     <ul>
                         <li>
-                            <a href="/foobar?page=1" aria-label="translated(contao_default:MSC.goToPage[1])" aria-current="page" class="link active">1</a>
+                            <strong class="active" aria-current="page">1</strong>
                         </li>
                         <li>
                             <a href="/foobar?page=2" aria-label="translated(contao_default:MSC.goToPage[2])" class="link">2</a>

--- a/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
@@ -314,7 +314,7 @@ class ImagesControllerTest extends ContentElementTestCase
                     <p>translated(contao_default:MSC.totalPages[1, 2])</p>
                     <ul>
                         <li>
-                            <strong class="active" aria-current="page">1</strong>
+                            <strong aria-current="page" class="active">1</strong>
                         </li>
                         <li>
                             <a href="/foobar?page=2" aria-label="translated(contao_default:MSC.goToPage[2])" class="link">2</a>


### PR DESCRIPTION
Fixes https://github.com/contao/website/issues/159

When modernising the pagination, the goal was to output the same markup as the old one. However, I missed one thing: the active element also uses `<strong>`, just like our navigation modules.

To make this consistent with how the pagination was previously and how the other navigation modules work, this PR fixes that by also using `<strong>` for the active element (especially since we decided to keep `<strong>` in the navigation modules and also introduce `<strong>` in the breadcrumb module).
