### PR TITLE
Do not add the `onclick` attribute if there is no href

### DIFF
--- a/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
@@ -227,7 +227,7 @@ class DataContainerOperationsBuilder extends AbstractDataContainerOperationsBuil
             return $toggle;
         }
 
-        if ('show' === $name) {
+        if ($href && 'show' === $name) {
             $config['attributes']->set(
                 'onclick',
                 \sprintf(


### PR DESCRIPTION
Fixes #9670

`$href` is nullable - and when empty, no operation is rendered anyway, thus we can skip adding the `onclick` attribute altogether.