### PR TITLE
Return `null` if a foreign key record does not exist

### DIFF
--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -442,7 +442,7 @@ class ValueFormatter implements ResetInterface
         if (!\array_key_exists($id, $this->foreignValueCache[$table][$field] ?? [])) {
             $value = $this->connection->fetchOne("SELECT $field FROM $table WHERE id=?", [$id]);
 
-            $this->foreignValueCache[$table][$field][$id] = false === $value ? $id : $value;
+            $this->foreignValueCache[$table][$field][$id] = false === $value ? null : $value;
         }
 
         return $this->foreignValueCache[$table][$field][$id];


### PR DESCRIPTION
If a foreign key query does not return a result, the value formatter should return `null` instead of `$id`.

### Contao 5.7

<img width="309" height="184" alt="" src="https://github.com/user-attachments/assets/a4ce1695-d119-4f96-b0ba-b2efca7bd268" />

### Before Contao 5.7

<img width="309" height="183" alt="" src="https://github.com/user-attachments/assets/b160f86d-6e54-46ca-a6af-96be6f0c286e" />
