### PR TITLE
Add list attributes to the pagination template

### DIFF
--- a/core-bundle/contao/templates/twig/component/_pagination.html.twig
+++ b/core-bundle/contao/templates/twig/component/_pagination.html.twig
@@ -16,7 +16,7 @@
                     <p>{{ 'MSC.totalPages'|trans([pagination.current, pagination.pageCount]) }}</p>
                 {% endif %}
             {% endblock %}
-            <ul>
+            <ul{{ list_attributes|default }}>
                 {% if pagination|default %}
                     {% block pagination_first %}
                         {% if pagination.first %}


### PR DESCRIPTION
Currently you would have to override the whole `_pagination` template if you need to adjust the attributes of the `<ul>` of the pagination (e.g. if you use a CSS framework and need to add CSS classes to in order to layout the `<li>`). This PR introduces `list_attributes` that are output but empty by default, just like in our `_list` component.

> [!NOTE]
> In our `_list` component we also use a block, i.e.
> ```twig
> {% block list_attributes %}{{ list_attributes|default }}{% endblock %}
> ```
> Though I don't think this is really necessary here.