### PR TITLE
Add `insert_tag_raw` to the `mootools` variable

### DIFF
--- a/core-bundle/contao/templates/twig/fe_page.html.twig
+++ b/core-bundle/contao/templates/twig/fe_page.html.twig
@@ -114,7 +114,7 @@
     {{ contao_sections('bottom') }}
 {% endblock %}
 
-{{ mootools|raw }}
+{{ mootools|insert_tag_raw|raw }}
 {{ jsonLdScripts|raw }}
 
 </body>


### PR DESCRIPTION
According to `{{ head|insert_tag_raw|raw }}`, we should add `|insert_tag_raw` to `{{ mootools }}` as well, because both might contain the `{{asset}}` insert tag.