### PR TITLE
Handle fields with a foreign key and an array value in the value formatter

### DIFF
--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -304,7 +304,7 @@ class ValueFormatter implements ResetInterface
             $GLOBALS['TL_DCA'][$table]['fields'][$field]['foreignKey'] = $ptable.'.'.$showField;
         }
 
-        if (isset($GLOBALS['TL_DCA'][$table]['fields'][$field]['foreignKey'])) {
+        if (isset($GLOBALS['TL_DCA'][$table]['fields'][$field]['foreignKey']) && \is_scalar($value)) {
             if ('' === (string) $value) {
                 return '';
             }

--- a/core-bundle/tests/DataContainer/ValueFormatterTest.php
+++ b/core-bundle/tests/DataContainer/ValueFormatterTest.php
@@ -418,6 +418,51 @@ class ValueFormatterTest extends TestCase
         unset($GLOBALS['TL_DCA']);
     }
 
+    public function testFormatArrayValueIgnoresForeignKey(): void
+    {
+        $GLOBALS['TL_DCA']['tl_foo']['fields']['foo'] = [
+            'foreignKey' => 'tl_foo.name',
+        ];
+
+        $configAdapter = $this->createAdapterStub(['get']);
+        $dateAdapter = $this->createAdapterStub(['parse']);
+
+        $framework = $this->createContaoFrameworkStub([
+            Date::class => $dateAdapter,
+            Config::class => $configAdapter,
+        ]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->never())
+            ->method('fetchOne')
+        ;
+
+        $foreignKeyParser = $this->createMock(ForeignKeyParser::class);
+        $foreignKeyParser
+            ->expects($this->never())
+            ->method('parse')
+        ;
+
+        $valueFormatter = new ValueFormatter(
+            $framework,
+            $connection,
+            $foreignKeyParser,
+            $this->createStub(TranslatorInterface::class),
+        );
+
+        $result = $valueFormatter->format(
+            'tl_foo',
+            'foo',
+            serialize(['value' => 'foo', 'unit' => 'h1']),
+            $this->createStub(DataContainer::class),
+        );
+
+        $this->assertSame('foo, h1', $result);
+
+        unset($GLOBALS['TL_DCA']);
+    }
+
     #[DataProvider('formatFilterOptionsProvider')]
     public function testFormatFilterOptions(array $dca, array $values, array $expected): void
     {


### PR DESCRIPTION
Unfortunately, I have found yet another edge case in the new `ValueFormatter`. A field can have an array value, but have a `foreignKey` specified. This is especially used with the `inputUnit` or `timePeriod` widgets, where there is a text field and a select next to it with value that can be retrieved from `foreignKey`.