### PR TITLE
Trim the grid view label to remove empty whitespace

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4236,7 +4236,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					$label = $this->generateRecordLabel($row[$i]);
 
 					$record['label'] = \is_array($label) ? ($label[0] ?? '') : $label;
-					$record['preview'] = \is_array($label) ? ($label[1] ?? '') : '';
+					$record['preview'] = \is_array($label) ? trim($label[1] ?? '') : '';
 					$record['state'] = \is_array($label) ? ($label[2] ?? '') : '';
 
 					$record['allow_dragging'] = $blnIsSortable && System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::DC_PREFIX . $this->strTable, new UpdateAction($this->strTable, $row[$i]));


### PR DESCRIPTION
This removes empty whitespace in the grid view. In my case, the fieldset start and stop widget output was only `\n` which resulted in a viewable box.

<img width="410" height="271" alt="Bildschirmfoto 2026-03-26 um 09 15 02" src="https://github.com/user-attachments/assets/38ba184d-ed74-4ba7-ae57-0b05830f32ba" />
