### PR TITLE
Normalize paths in the `generateScriptTag()` and `generateStyleTag()` methods

### DIFF
--- a/core-bundle/contao/library/Contao/Template.php
+++ b/core-bundle/contao/library/Contao/Template.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
 use MatthiasMullie\Minify\CSS;
 use MatthiasMullie\Minify\JS;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\VarDumper\VarDumper;
 
@@ -458,19 +459,21 @@ abstract class Template extends Controller
 		{
 			$container = System::getContainer();
 			$projectDir = $container->getParameter('kernel.project_dir');
+			$projectPath = Path::join($projectDir, $href);
 
-			if (file_exists($projectDir . '/' . $href))
+			if (file_exists($projectPath))
 			{
-				$mtime = filemtime($projectDir . '/' . $href);
+				$mtime = filemtime($projectPath);
 			}
 			else
 			{
 				$webDir = StringUtil::stripRootDir($container->getParameter('contao.web_dir'));
+				$webPath = Path::join($projectDir, $webDir, $href);
 
 				// Handle public bundle resources in the contao.web_dir folder
-				if (file_exists($projectDir . '/' . $webDir . '/' . $href))
+				if (file_exists($webPath))
 				{
-					$mtime = filemtime($projectDir . '/' . $webDir . '/' . $href);
+					$mtime = filemtime($webPath);
 				}
 			}
 		}
@@ -524,19 +527,21 @@ abstract class Template extends Controller
 		{
 			$container = System::getContainer();
 			$projectDir = $container->getParameter('kernel.project_dir');
+			$projectPath = Path::join($projectDir, $src);
 
-			if (file_exists($projectDir . '/' . $src))
+			if (file_exists($projectPath))
 			{
-				$mtime = filemtime($projectDir . '/' . $src);
+				$mtime = filemtime($projectPath);
 			}
 			else
 			{
 				$webDir = StringUtil::stripRootDir($container->getParameter('contao.web_dir'));
+				$webPath = Path::join($projectDir, $webDir, $src);
 
 				// Handle public bundle resources in the contao.web_dir folder
-				if (file_exists($projectDir . '/' . $webDir . '/' . $src))
+				if (file_exists($webPath))
 				{
-					$mtime = filemtime($projectDir . '/' . $webDir . '/' . $src);
+					$mtime = filemtime($webPath);
 				}
 			}
 		}


### PR DESCRIPTION
Contao 5 generally supports having the front end without the `<base href>`. There is one small issue when using the front end without it though: if you happen to use `Template::generateScriptTag()` or `Template::generateStyleTag()`, it will output the path verbatim, so if you give the method a relative path, the output will also be a relative path - which will break on URLs like `example.com/foo/bar`.

To fix this you have to give these methods an absolute path (i.e. starting with `/`) - but there is one cosmetic issue: when taking advantage of `$mtime = null` to automatically append the file's mtime for cache busting, the resulting path when doing `file_exists()` and `filemtime()` will have a double slash, e.g. `/path/to/project//files/foo/bar.js`. This isn't really an issue on Windows at least (and I am guessing also not an issue on *nix file systems), but I think we should normalize the path to be safe (and it's always better to join paths via `Path::join()` to avoid any other potential issues).