### PR TITLE
Get rid of the remaining `global $objPage` usages

### DIFF
--- a/calendar-bundle/contao/classes/Calendar.php
+++ b/calendar-bundle/contao/classes/Calendar.php
@@ -251,6 +251,7 @@ class Calendar extends Frontend
 					}
 
 					// Override the global page object (#2946)
+					// TODO: find a solution that works with the PageFinder
 					$GLOBALS['objPage'] = $this->getPageWithDetails(CalendarModel::findById($event['pid'])->jumpTo);
 
 					// Override the assets and files context (#6563)

--- a/calendar-bundle/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/contao/dca/tl_calendar_events.php
@@ -610,6 +610,7 @@ class tl_calendar_events extends Backend
 		$origObjPage = $GLOBALS['objPage'] ?? null;
 
 		// Override the global page object, so we can replace the insert tags
+		// TODO: find a solution that works with the PageFinder
 		$GLOBALS['objPage'] = $page;
 
 		$title = implode(

--- a/core-bundle/contao/controllers/FrontendIndex.php
+++ b/core-bundle/contao/controllers/FrontendIndex.php
@@ -46,6 +46,7 @@ class FrontendIndex extends Frontend
 	{
 		global $objPage;
 
+		// TODO: find a solution that works with the PageFinder
 		$objPage = $pageModel;
 
 		// Inherit the settings from the parent pages

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -807,6 +807,7 @@ class tl_page extends Backend
 		$origObjPage = $GLOBALS['objPage'] ?? null;
 
 		// Override the global page object, so we can replace the insert tags
+		// TODO: find a solution that works with the PageFinder
 		$GLOBALS['objPage'] = $page;
 
 		$title = implode(

--- a/core-bundle/contao/pages/PageError401.php
+++ b/core-bundle/contao/pages/PageError401.php
@@ -36,6 +36,7 @@ class PageError401 extends Frontend
 	{
 		global $objPage;
 
+		// TODO: find a solution that works with the PageFinder
 		$obj401 = $this->prepare($objRootPage);
 		$objPage = $obj401->loadDetails();
 

--- a/core-bundle/contao/pages/PageError403.php
+++ b/core-bundle/contao/pages/PageError403.php
@@ -36,6 +36,7 @@ class PageError403 extends Frontend
 	{
 		global $objPage;
 
+		// TODO: find a solution that works with the PageFinder
 		$obj403 = $this->prepare($objRootPage);
 		$objPage = $obj403->loadDetails();
 

--- a/core-bundle/contao/pages/PageError404.php
+++ b/core-bundle/contao/pages/PageError404.php
@@ -36,6 +36,7 @@ class PageError404 extends Frontend
 	{
 		global $objPage;
 
+		// TODO: find a solution that works with the PageFinder
 		$obj404 = $this->prepare($page);
 		$objPage = $obj404->loadDetails();
 

--- a/core-bundle/src/Controller/InsertTagsController.php
+++ b/core-bundle/src/Controller/InsertTagsController.php
@@ -41,6 +41,7 @@ class InsertTagsController
         $this->framework->initialize();
 
         // Backwards compatibility
+        // TODO: find a solution that works with the PageFinder
         $pageModelBefore = $GLOBALS['objPage'] ?? null;
         $GLOBALS['objPage'] = $pageModel;
 

--- a/news-bundle/contao/dca/tl_news.php
+++ b/news-bundle/contao/dca/tl_news.php
@@ -522,6 +522,7 @@ class tl_news extends Backend
 		$origObjPage = $GLOBALS['objPage'] ?? null;
 
 		// Override the global page object, so we can replace the insert tags
+		// TODO: find a solution that works with the PageFinder
 		$GLOBALS['objPage'] = $page;
 
 		$title = implode(


### PR DESCRIPTION
This is a follow-up on #7430 that marks all the places where we overwrite the global page object, which does not work with the page finder service.