### PR TITLE
Fix a potential type error in calendar events generator

### DIFF
--- a/calendar-bundle/src/Generator/CalendarEventsGenerator.php
+++ b/calendar-bundle/src/Generator/CalendarEventsGenerator.php
@@ -62,7 +62,7 @@ class CalendarEventsGenerator
             }
 
             foreach ($eventModels as $eventModel) {
-                $this->addEvent($events, $eventModel, $eventModel->startTime, $eventModel->endTime, $rangeEnd->getTimestamp(), $id, $noSpan);
+                $this->addEvent($events, $eventModel, (int) $eventModel->startTime, (int) $eventModel->endTime, $rangeEnd->getTimestamp(), $id, $noSpan);
 
                 // Recurring events
                 if ($eventModel->recurring) {


### PR DESCRIPTION
```
[2026-03-27T11:49:06.905068+01:00] request.CRITICAL: Uncaught PHP Exception TypeError: "Contao\CalendarBundle\Generator\CalendarEventsGenerator::addEvent(): Argument #3 ($start) must be of type int, string given, called in /home/website/vendor/contao/calendar-bundle/src/Generator/CalendarEventsGenerator.php on line 65" at CalendarEventsGenerator.php line 130 {"exception":"[object] (TypeError(code: 0): Contao\\CalendarBundle\\Generator\\CalendarEventsGenerator::addEvent(): Argument #3 ($start) must be of type int, string given, called in /home/website/vendor/contao/calendar-bundle/src/Generator/CalendarEventsGenerator.php on line 65 at /home/website/vendor/contao/calendar-bundle/src/Generator/CalendarEventsGenerator.php:130)"}
```