### PR TITLE
Cast bigint columns to integer

### DIFF
--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -495,8 +495,7 @@ abstract class Model
 
 		return match (self::$arrColumnCastTypes[static::$strTable][$strKey] ?? null)
 		{
-			Types::INTEGER, Types::SMALLINT => (int) $varValue,
-			Types::BIGINT => (string) $varValue === (string) (int) $varValue ? (int) $varValue : $varValue,
+			Types::INTEGER, Types::SMALLINT, Types::BIGINT => \is_int($number = +$varValue) ? $number : $varValue,
 			Types::FLOAT => (float) $varValue,
 			Types::BOOLEAN => (bool) $varValue,
 			default => $varValue,

--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -451,7 +451,7 @@ abstract class Model
 			{
 				$type = strtolower($column->getType()->getName());
 
-				if (\in_array($type, array(Types::INTEGER, Types::SMALLINT, Types::FLOAT, Types::BOOLEAN), true))
+				if (\in_array($type, array(Types::INTEGER, Types::SMALLINT, Types::BIGINT, Types::FLOAT, Types::BOOLEAN), true))
 				{
 					$types[$table->getName()][$column->getName()] = $type;
 				}
@@ -496,6 +496,7 @@ abstract class Model
 		return match (self::$arrColumnCastTypes[static::$strTable][$strKey] ?? null)
 		{
 			Types::INTEGER, Types::SMALLINT => (int) $varValue,
+			Types::BIGINT => (string) $varValue === (string) (int) $varValue ? (int) $varValue : $varValue,
 			Types::FLOAT => (float) $varValue,
 			Types::BOOLEAN => (bool) $varValue,
 			default => $varValue,

--- a/core-bundle/tests/Contao/ModelTest.php
+++ b/core-bundle/tests/Contao/ModelTest.php
@@ -69,6 +69,8 @@ class ModelTest extends TestCase
                     'int_null' => Types::INTEGER,
                     'smallint_not_null' => Types::SMALLINT,
                     'smallint_null' => Types::SMALLINT,
+                    'bigint_not_null' => Types::BIGINT,
+                    'bigint_null' => Types::BIGINT,
                     'float_not_null' => Types::FLOAT,
                     'float_null' => Types::FLOAT,
                     'bool_not_null' => Types::BOOLEAN,
@@ -90,6 +92,8 @@ class ModelTest extends TestCase
                     'int_null' => Types::INTEGER,
                     'smallint_not_null' => Types::SMALLINT,
                     'smallint_null' => Types::SMALLINT,
+                    'bigint_not_null' => Types::BIGINT,
+                    'bigint_null' => Types::BIGINT,
                     'float_not_null' => Types::FLOAT,
                     'float_null' => Types::FLOAT,
                     'bool_not_null' => Types::BOOLEAN,
@@ -132,6 +136,22 @@ class ModelTest extends TestCase
 
         yield ['smallint_null', '12', 12];
 
+        yield ['bigint_not_null', (string) PHP_INT_MAX, PHP_INT_MAX];
+
+        yield ['bigint_null', (string) PHP_INT_MAX, PHP_INT_MAX];
+
+        yield ['bigint_not_null', '9223372036854775808', '9223372036854775808'];
+
+        yield ['bigint_null', '9223372036854775808', '9223372036854775808'];
+
+        yield ['bigint_not_null', (string) PHP_INT_MIN, PHP_INT_MIN];
+
+        yield ['bigint_null', (string) PHP_INT_MIN, PHP_INT_MIN];
+
+        yield ['bigint_not_null', '-9223372036854775809', '-9223372036854775809'];
+
+        yield ['bigint_null', '-9223372036854775809', '-9223372036854775809'];
+
         yield ['float_not_null', '12.3', 12.3];
 
         yield ['float_null', '12.3', 12.3];
@@ -145,6 +165,8 @@ class ModelTest extends TestCase
         yield ['int_null', null, null];
 
         yield ['smallint_null', null, null];
+
+        yield ['bigint_null', null, null];
 
         yield ['float_null', null, null];
 
@@ -192,6 +214,8 @@ class ModelTest extends TestCase
         $table->addColumn('int_null', Types::INTEGER, ['notnull' => false]);
         $table->addColumn('smallint_not_null', Types::SMALLINT, ['notnull' => true]);
         $table->addColumn('smallint_null', Types::SMALLINT, ['notnull' => false]);
+        $table->addColumn('bigint_not_null', Types::BIGINT, ['notnull' => true]);
+        $table->addColumn('bigint_null', Types::BIGINT, ['notnull' => false]);
         $table->addColumn('float_not_null', Types::FLOAT, ['notnull' => true]);
         $table->addColumn('float_null', Types::FLOAT, ['notnull' => false]);
         $table->addColumn('bool_not_null', Types::BOOLEAN, ['notnull' => true]);


### PR DESCRIPTION
See https://github.com/contao/contao/pull/9700#issuecomment-4142138669

This casts `bigint` columns to integers too if they are in the integer range supported by PHP.

Unsigned `bigint` values larger than `PHP_INT_MAX` are kept as strings.

Is this the right approach? Or would it be better to only ever cast `SIGNED BIGINT` columns to integers and cast `UNSIGNED BIGINT` to strings instead so that the type for the same column is always the same independent of the actual value?