### PR TITLE
Add the charset to the news feed content type

### DIFF
--- a/news-bundle/src/Controller/Page/NewsFeedController.php
+++ b/news-bundle/src/Controller/Page/NewsFeedController.php
@@ -90,7 +90,7 @@ class NewsFeedController extends AbstractController implements DynamicRouteInter
         $formatter = $this->specification->getStandard($pageModel->feedFormat)->getFormatter();
 
         $response = new Response($formatter->toString($feed));
-        $response->headers->set('Content-Type', $contentType);
+        $response->headers->set('Content-Type', $contentType.'; charset='.$this->charset);
 
         $this->setCacheHeaders($response, $pageModel);
 

--- a/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
+++ b/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
@@ -221,16 +221,16 @@ class NewsFeedControllerTest extends ContaoTestCase
 
     public static function getXMLFeedFormats(): iterable
     {
-        yield 'RSS' => ['rss', '.xml', 'https://example.org/latest-news.xml', 'application/rss+xml'];
-        yield 'Atom' => ['atom', '.xml', 'https://example.org/latest-news.xml', 'application/atom+xml'];
-        yield 'RSS (debug)' => ['rss', '.xml', 'https://example.org/latest-news.xml', 'application/xml', true];
-        yield 'Atom (debug)' => ['atom', '.xml', 'https://example.org/latest-news.xml', 'application/xml', true];
+        yield 'RSS' => ['rss', '.xml', 'https://example.org/latest-news.xml', 'application/rss+xml; charset=UTF-8'];
+        yield 'Atom' => ['atom', '.xml', 'https://example.org/latest-news.xml', 'application/atom+xml; charset=UTF-8'];
+        yield 'RSS (debug)' => ['rss', '.xml', 'https://example.org/latest-news.xml', 'application/xml; charset=UTF-8', true];
+        yield 'Atom (debug)' => ['atom', '.xml', 'https://example.org/latest-news.xml', 'application/xml; charset=UTF-8', true];
     }
 
     public static function getJSONFeedFormats(): iterable
     {
-        yield 'JSON' => ['json', '.json', 'https://example.org/latest-news.json', 'application/feed+json'];
-        yield 'JSON (debug)' => ['json', '.json', 'https://example.org/latest-news.json', 'application/json', true];
+        yield 'JSON' => ['json', '.json', 'https://example.org/latest-news.json', 'application/feed+json; charset=UTF-8'];
+        yield 'JSON (debug)' => ['json', '.json', 'https://example.org/latest-news.json', 'application/json; charset=UTF-8', true];
     }
 
     private function getController(bool $isDebug = false): NewsFeedController


### PR DESCRIPTION
Currently we do not define a `charset` in the `Content-Type` of our RSS feed responses, since the character set is already defined in the XML itself. However, when the feed is viewed directly in the browser one might think that something is broken as the browser might render

```xml
<description>&lt;p&gt;LÃ¶rÃ¤m ipsÃ¼m dÃ¶lÃ¶r.&lt;/p&gt;</description>
```

instead of

```xml
<description>&lt;p&gt;Löräm ipsüm dölör.&lt;/p&gt;</description>
```

when the `Content-Type` is `application/rss+xml` instead of `application/xml`.

This PR always adds the `charset` to the `Content-Type` response header, which will let the browser interpret the `application/rss+xml` response content character set correctly as UTF-8.