### PR TITLE
Correctly format recursive arrays in the value formatter

### DIFF
--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -496,8 +496,7 @@ class ValueFormatter implements ResetInterface
 
             foreach ($value as $kk => $vv) {
                 if (\is_array($vv)) {
-                    $vals = array_values($vv);
-                    $value[$kk] = array_shift($vals).' ('.implode(', ', array_filter($vals)).')';
+                    $value[$kk] = '['.$this->flatten(array_filter($vv)).']';
                 }
             }
 

--- a/core-bundle/tests/DataContainer/ValueFormatterTest.php
+++ b/core-bundle/tests/DataContainer/ValueFormatterTest.php
@@ -145,6 +145,18 @@ class ValueFormatterTest extends TestCase
             'foo: bar, bar: baz (1, 2, 3)',
         ];
 
+        yield 'Serialized array (#5)' => [
+            serialize(['foo' => 'bar', 'bar' => ['baz', [1, 2, 3]]]),
+            [],
+            'foo: bar, bar: baz (1 (2, 3))',
+        ];
+
+        yield 'Serialized array (#6)' => [
+            serialize(['foo' => 'bar', 'bar' => ['foo' => 'bar', 'bar' => ['foo' => 'bar']]]),
+            [],
+            'foo: bar, bar: bar (bar ())',
+        ];
+
         yield 'Date' => [
             '1764689390',
             ['eval' => ['rgxp' => 'date']],

--- a/core-bundle/tests/DataContainer/ValueFormatterTest.php
+++ b/core-bundle/tests/DataContainer/ValueFormatterTest.php
@@ -130,7 +130,7 @@ class ValueFormatterTest extends TestCase
         yield 'Serialized array (#2)' => [
             serialize([['foo', 'bar', 'baz']]),
             [],
-            'foo (bar, baz)',
+            '[foo, bar, baz]',
         ];
 
         yield 'Serialized array (#3)' => [
@@ -142,19 +142,19 @@ class ValueFormatterTest extends TestCase
         yield 'Serialized array (#4)' => [
             serialize(['foo' => 'bar', 'bar' => ['baz', 1, 2, 3]]),
             [],
-            'foo: bar, bar: baz (1, 2, 3)',
+            'foo: bar, bar: [baz, 1, 2, 3]',
         ];
 
         yield 'Serialized array (#5)' => [
             serialize(['foo' => 'bar', 'bar' => ['baz', [1, 2, 3]]]),
             [],
-            'foo: bar, bar: baz (1 (2, 3))',
+            'foo: bar, bar: [baz, [1, 2, 3]]',
         ];
 
         yield 'Serialized array (#6)' => [
             serialize(['foo' => 'bar', 'bar' => ['foo' => 'bar', 'bar' => ['foo' => 'bar']]]),
             [],
-            'foo: bar, bar: bar (bar ())',
+            'foo: bar, bar: [foo: bar, bar: [foo: bar]]',
         ];
 
         yield 'Date' => [


### PR DESCRIPTION
The value formatter currently fails with an `array to string conversion` exception if a formatted array has recursive values. The PR fixes that by re-applying `flatten` for all nesting levels. This will result in a slightly different nesting array output, but I do prefer it anyway since the old syntax basically dropped all key information.