### PR TITLE
Allow to delete jobs in the backend module

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1180,6 +1180,11 @@ services:
         arguments:
             - '@security.access.decision_manager'
 
+    contao.security.data_container.job_access_voter:
+        class: Contao\CoreBundle\Security\Voter\DataContainer\JobAccessVoter
+        arguments:
+            - '@security.access.decision_manager'
+
     contao.security.data_container.layout_access_voter:
         class: Contao\CoreBundle\Security\Voter\DataContainer\LayoutAccessVoter
         arguments:

--- a/core-bundle/contao/dca/tl_job.php
+++ b/core-bundle/contao/dca/tl_job.php
@@ -24,7 +24,6 @@ $GLOBALS['TL_DCA']['tl_job'] = array
 		'closed'                      => true,
 		'notEditable'                 => true,
 		'notCopyable'                 => true,
-		'notDeletable'                => true,
 		'permissions'                 => array(),
 		'backendSearchIgnore'         => true,
 		'sql' => array
@@ -57,6 +56,7 @@ $GLOBALS['TL_DCA']['tl_job'] = array
 		'operations' => array
 		(
 			'children',
+			'delete',
 			'show' => false,
 		)
 	),

--- a/core-bundle/src/EventListener/DataContainer/JobsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/JobsListener.php
@@ -103,6 +103,16 @@ class JobsListener
         $GLOBALS['TL_DCA']['tl_job']['list']['sorting']['filter'][] = $query;
     }
 
+    #[AsCallback(table: 'tl_job', target: 'config.ondelete')]
+    public function onDeleteCallback(DC_Table $dc): void
+    {
+        if (($currentRecord = $dc->getCurrentRecord()) === null) {
+            return;
+        }
+
+        $this->jobs->removeAttachments($currentRecord['uuid']);
+    }
+
     /**
      * @return int 0 if no Contao back end user was given
      */

--- a/core-bundle/src/EventListener/DataContainer/JobsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/JobsListener.php
@@ -106,7 +106,7 @@ class JobsListener
     #[AsCallback(table: 'tl_job', target: 'config.ondelete')]
     public function onDeleteCallback(DC_Table $dc): void
     {
-        if (($currentRecord = $dc->getCurrentRecord()) === null) {
+        if (null === ($currentRecord = $dc->getCurrentRecord())) {
             return;
         }
 

--- a/core-bundle/src/Job/Jobs.php
+++ b/core-bundle/src/Job/Jobs.php
@@ -155,6 +155,17 @@ class Jobs
         return $attachments;
     }
 
+    public function removeAttachments(Job|string $jobOrUuid): void
+    {
+        $jobUuid = $jobOrUuid instanceof Job ? $jobOrUuid->getUuid() : $jobOrUuid;
+
+        if (!$this->jobAttachmentsStorage->directoryExists($jobUuid)) {
+            return;
+        }
+
+        $this->jobAttachmentsStorage->deleteDirectory($jobUuid);
+    }
+
     public function getAttachment(Job|string $jobOrUuid, string $identifier): Attachment|null
     {
         $job = $jobOrUuid instanceof Job ? $jobOrUuid : $this->getByUuid($jobOrUuid);
@@ -268,10 +279,7 @@ class Jobs
     public function removeJob(Job $job): void
     {
         $this->connection->delete('tl_job', ['uuid' => $job->getUuid()]);
-
-        if ($this->jobAttachmentsStorage->directoryExists($job->getUuid())) {
-            $this->jobAttachmentsStorage->deleteDirectory($job->getUuid());
-        }
+        $this->removeAttachments($job);
     }
 
     public function prune(int $period): void

--- a/core-bundle/src/Job/Jobs.php
+++ b/core-bundle/src/Job/Jobs.php
@@ -265,6 +265,15 @@ class Jobs
         return $child;
     }
 
+    public function removeJob(Job $job): void
+    {
+        $this->connection->delete('tl_job', ['uuid' => $job->getUuid()]);
+
+        if ($this->jobAttachmentsStorage->directoryExists($job->getUuid())) {
+            $this->jobAttachmentsStorage->deleteDirectory($job->getUuid());
+        }
+    }
+
     public function prune(int $period): void
     {
         if ($period <= 0) {

--- a/core-bundle/src/Security/Voter/DataContainer/JobAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/JobAccessVoter.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Security\Voter\DataContainer;
 
 use Contao\BackendUser;
-use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
@@ -42,10 +41,6 @@ class JobAccessVoter extends AbstractDataContainerVoter
 
     protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        if (!$this->accessDecisionManager->decide($token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE], 'jobs')) {
-            return false;
-        }
-
         if ($this->accessDecisionManager->decide($token, ['ROLE_ADMIN'])) {
             return true;
         }

--- a/core-bundle/src/Security/Voter/DataContainer/JobAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/JobAccessVoter.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Voter\DataContainer;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\CoreBundle\Security\DataContainer\CreateAction;
+use Contao\CoreBundle\Security\DataContainer\DeleteAction;
+use Contao\CoreBundle\Security\DataContainer\ReadAction;
+use Contao\CoreBundle\Security\DataContainer\UpdateAction;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+
+/**
+ * @internal
+ */
+class JobAccessVoter extends AbstractDataContainerVoter
+{
+    public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)
+    {
+    }
+
+    public function supportsType(string $subjectType): bool
+    {
+        return \in_array($subjectType, [ReadAction::class, DeleteAction::class], true);
+    }
+
+    protected function getTable(): string
+    {
+        return 'tl_job';
+    }
+
+    protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    {
+        if (!$this->accessDecisionManager->decide($token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE], 'jobs')) {
+            return false;
+        }
+
+        if ($this->accessDecisionManager->decide($token, ['ROLE_ADMIN'])) {
+            return true;
+        }
+
+        $user = $token->getUser();
+
+        if (!$user instanceof BackendUser) {
+            return false;
+        }
+
+        // User can delete only his own jobs
+        if ($action instanceof DeleteAction) {
+            return (int) $action->getCurrent()['owner'] === (int) $user->id;
+        }
+
+        // User can read only his own jobs and public ones
+        if ($action instanceof ReadAction) {
+            $current = $action->getCurrent();
+
+            return $current['public'] || (int) $current['owner'] === (int) $user->id;
+        }
+
+        return true;
+    }
+}

--- a/core-bundle/tests/EventListener/DataContainer/JobsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/JobsListenerTest.php
@@ -11,6 +11,7 @@ use Contao\DataContainer;
 use Contao\DC_Table;
 use Contao\System;
 use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -196,6 +197,7 @@ class JobsListenerTest extends AbstractJobsTestCase
         $this->assertSame('attachments.html.twig output', $columnsNew[5]);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testDeleteCallback(): void
     {
         $framework = $this->createContaoFrameworkStub([System::class => $this->createAdapterStub(['loadLanguageFile'])]);

--- a/core-bundle/tests/EventListener/DataContainer/JobsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/JobsListenerTest.php
@@ -200,7 +200,7 @@ class JobsListenerTest extends AbstractJobsTestCase
     {
         $framework = $this->createContaoFrameworkStub([System::class => $this->createAdapterStub(['loadLanguageFile'])]);
 
-        $jobs = $this->createStub(Jobs::class);
+        $jobs = $this->createMock(Jobs::class);
         $jobs
             ->expects($this->once())
             ->method('removeAttachments')

--- a/core-bundle/tests/EventListener/DataContainer/JobsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/JobsListenerTest.php
@@ -196,6 +196,44 @@ class JobsListenerTest extends AbstractJobsTestCase
         $this->assertSame('attachments.html.twig output', $columnsNew[5]);
     }
 
+    public function testDeleteCallback(): void
+    {
+        $framework = $this->createContaoFrameworkStub([System::class => $this->createAdapterStub(['loadLanguageFile'])]);
+
+        $jobs = $this->createStub(Jobs::class);
+        $jobs
+            ->expects($this->once())
+            ->method('removeAttachments')
+        ;
+
+        $listener = new JobsListener(
+            $jobs,
+            $this->createMock(Security::class),
+            $this->createStub(Connection::class),
+            $this->getRequestStack(Request::create('/contao?do=jobs')),
+            $framework,
+            $this->createStub(Environment::class),
+        );
+
+        $dcTable = $this->createStub(DC_Table::class);
+        $dcTable
+            ->method('getCurrentRecord')
+            ->willReturn(null)
+        ;
+
+        // The empty current record should return early
+        $listener->onDeleteCallback($dcTable);
+
+        $dcTable = $this->createStub(DC_Table::class);
+        $dcTable
+            ->method('getCurrentRecord')
+            ->willReturn(['uuid' => '6461058f-ebed-4249-80ae-496b502fb6af'])
+        ;
+
+        // The valid current record should call removeAttachments()
+        $listener->onDeleteCallback($dcTable);
+    }
+
     private function getRequestStack(Request|null $request = null): RequestStack
     {
         $requestStack = new RequestStack();

--- a/core-bundle/tests/Job/JobsTest.php
+++ b/core-bundle/tests/Job/JobsTest.php
@@ -43,6 +43,17 @@ class JobsTest extends AbstractJobsTestCase
         $this->assertSame($userLoggedIn ? 42 : Owner::SYSTEM, $job->getOwner()->getId());
     }
 
+    public function testRemoveJob(): void
+    {
+        $jobs = $this->getJobs();
+
+        $job = $jobs->createJob('job-type');
+        $this->assertInstanceOf(Job::class, $jobs->getByUuid($job->getUuid()));
+
+        $jobs->removeJob($job);
+        $this->assertNull($jobs->getByUuid($job->getUuid()));
+    }
+
     #[DataProvider('withProgressFromAmountsProvider')]
     public function testWithProgressFromFixedAmounts(int|null $total, int $amount, float $expectedProgress): void
     {
@@ -294,6 +305,10 @@ class JobsTest extends AbstractJobsTestCase
         $this->assertSame('my-attachment-key', $attachment->getFilesystemItem()->getName());
         $this->assertCount(2, iterator_to_array($this->vfs->listContents($job->getUuid())));
         $this->assertCount(2, $jobs->getAttachments($job->getUuid()));
+
+        $jobs->removeAttachments($job->getUuid());
+        $this->assertCount(0, iterator_to_array($this->vfs->listContents($job->getUuid())));
+        $this->assertCount(0, $jobs->getAttachments($job->getUuid()));
     }
 
     public function testPrune(): void

--- a/core-bundle/tests/Security/Voter/DataContainer/JobAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/JobAccessVoterTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Security\Voter\DataContainer;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\CoreBundle\Security\DataContainer\CreateAction;
+use Contao\CoreBundle\Security\DataContainer\DeleteAction;
+use Contao\CoreBundle\Security\DataContainer\ReadAction;
+use Contao\CoreBundle\Security\DataContainer\UpdateAction;
+use Contao\CoreBundle\Security\Voter\DataContainer\JobAccessVoter;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\FrontendUser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class JobAccessVoterTest extends TestCase
+{
+    public function testVoter(): void
+    {
+        $voter = new JobAccessVoter($this->createStub(AccessDecisionManagerInterface::class));
+
+        $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_job'));
+        $this->assertFalse($voter->supportsType(CreateAction::class));
+        $this->assertTrue($voter->supportsType(ReadAction::class));
+        $this->assertFalse($voter->supportsType(UpdateAction::class));
+        $this->assertTrue($voter->supportsType(DeleteAction::class));
+    }
+
+    public function testAbstainsForAdmin(): void
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->never())
+            ->method('getUser')
+        ;
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($token, ['ROLE_ADMIN'])
+            ->willReturn(true)
+        ;
+
+        $voter = new JobAccessVoter($accessDecisionManager);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote(
+                $token,
+                new ReadAction('tl_job', ['id' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_job'],
+            ),
+        );
+    }
+
+    public function testDeniesAccessIfUserIsNotABackendUser(): void
+    {
+        $user = $this->createClassWithPropertiesStub(FrontendUser::class);
+
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($token, ['ROLE_ADMIN'])
+            ->willReturn(false)
+        ;
+
+        $voter = new JobAccessVoter($accessDecisionManager);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new ReadAction('tl_job', ['id' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_job'],
+            ),
+        );
+    }
+
+    #[DataProvider('voteOnActionProvider')]
+    public function testVoteOnAction(array $user, DeleteAction|ReadAction $action, int $expectedVote): void
+    {
+        $user = $this->createClassWithPropertiesStub(BackendUser::class, $user);
+
+        $token = $this->createStub(TokenInterface::class);
+        $token
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($token, ['ROLE_ADMIN'])
+            ->willReturn(false)
+        ;
+
+        $voter = new JobAccessVoter($accessDecisionManager);
+
+        $this->assertSame(
+            $expectedVote,
+            $voter->vote($token, $action, [ContaoCorePermissions::DC_PREFIX.'tl_job']),
+        );
+    }
+
+    public static function voteOnActionProvider(): iterable
+    {
+        yield [
+            ['id' => 42],
+            new DeleteAction('tl_job', ['owner' => 42]),
+            VoterInterface::ACCESS_ABSTAIN,
+        ];
+
+        yield [
+            ['id' => 42],
+            new DeleteAction('tl_job', ['owner' => 21]),
+            VoterInterface::ACCESS_DENIED,
+        ];
+
+        yield [
+            ['id' => 42],
+            new ReadAction('tl_job', ['public' => true]),
+            VoterInterface::ACCESS_ABSTAIN,
+        ];
+
+        yield [
+            ['id' => 42],
+            new ReadAction('tl_job', ['owner' => 42]),
+            VoterInterface::ACCESS_ABSTAIN,
+        ];
+
+        yield [
+            ['id' => 42],
+            new ReadAction('tl_job', ['owner' => 21]),
+            VoterInterface::ACCESS_DENIED,
+        ];
+    }
+}

--- a/core-bundle/tests/Security/Voter/DataContainer/JobAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/JobAccessVoterTest.php
@@ -141,19 +141,19 @@ class JobAccessVoterTest extends TestCase
 
         yield [
             ['id' => 42],
-            new ReadAction('tl_job', ['public' => true]),
+            new ReadAction('tl_job', ['owner' => 0, 'public' => true]),
             VoterInterface::ACCESS_ABSTAIN,
         ];
 
         yield [
             ['id' => 42],
-            new ReadAction('tl_job', ['owner' => 42]),
+            new ReadAction('tl_job', ['owner' => 42, 'public' => false]),
             VoterInterface::ACCESS_ABSTAIN,
         ];
 
         yield [
             ['id' => 42],
-            new ReadAction('tl_job', ['owner' => 21]),
+            new ReadAction('tl_job', ['owner' => 21, 'public' => false]),
             VoterInterface::ACCESS_DENIED,
         ];
     }


### PR DESCRIPTION
It works almost fine, but after deleting a record, it redirects to the wrong URL:

```
contao?do=jobs -> delete -> contao?do=jobs&table=tl_job
```

In this view, no records are displayed:

<img width="1256" height="300" alt="CleanShot 2026-04-02 at 08 46 30" src="https://github.com/user-attachments/assets/08e0db7b-e031-410e-9a0a-7a27dc399672" />

This is probably related to the `ptable` and `ctable` definitions pointing to the same table. I am not sure what's the idea behind those and how to fix that.

@Toflar can you shed some light on this perhaps?