### PR TITLE
Fix `hl` Template property type

### DIFF
--- a/core-bundle/contao/library/Contao/Template.php
+++ b/core-bundle/contao/library/Contao/Template.php
@@ -35,7 +35,7 @@ use Symfony\Component\VarDumper\VarDumper;
  * @property string       $class
  * @property string       $inColumn
  * @property string       $headline
- * @property array        $hl
+ * @property string       $hl
  * @property string       $content
  * @property string       $action
  * @property boolean      $enforceTwoFactor


### PR DESCRIPTION
For some reason the `$hl` virtual property for `Contao\Template` is defined to be of type `array` (since Contao [4.0.0-RC1](https://github.com/contao/contao/commit/8668413d1c833a6b3cd4b09346f3d8f3d37ea326#diff-8d0657c6986cb943dcdadf27a406965332bbcd1e6762d031d642a1f2403e3a11)) - while in fact it is always a `string`.
