### PR TITLE
Ignore `symfony/polyfill-php84` within the dependency check

### DIFF
--- a/depcheck.php
+++ b/depcheck.php
@@ -80,6 +80,9 @@ return (new Configuration())
     ->ignoreErrorsOnPackage('symfony/polyfill-intl-idn', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('symfony/polyfill-mbstring', [ErrorType::UNUSED_DEPENDENCY])
 
+    // Polyfill for PHP 8.4
+    ->ignoreErrorsOnPackage('symfony/polyfill-php84', [ErrorType::UNUSED_DEPENDENCY])
+
     // The rate limiter is required for the functional tests.
     ->ignoreErrorsOnPackage('symfony/rate-limiter', [ErrorType::UNUSED_DEPENDENCY])
 

--- a/depcheck.php
+++ b/depcheck.php
@@ -80,7 +80,7 @@ return (new Configuration())
     ->ignoreErrorsOnPackage('symfony/polyfill-intl-idn', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('symfony/polyfill-mbstring', [ErrorType::UNUSED_DEPENDENCY])
 
-    // Polyfill for PHP 8.4
+    // Polyfills for PHP versions.
     ->ignoreErrorsOnPackage('symfony/polyfill-php84', [ErrorType::UNUSED_DEPENDENCY])
 
     // The rate limiter is required for the functional tests.

--- a/depcheck.php
+++ b/depcheck.php
@@ -80,8 +80,8 @@ return (new Configuration())
     ->ignoreErrorsOnPackage('symfony/polyfill-intl-idn', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('symfony/polyfill-mbstring', [ErrorType::UNUSED_DEPENDENCY])
 
-    // Polyfills for PHP versions.
-    ->ignoreErrorsOnPackage('symfony/polyfill-php84', [ErrorType::UNUSED_DEPENDENCY])
+    // Ignore polyfill check for Pdo\Mysql
+    ->ignoreErrorsOnPackage('symfony/polyfill-php84', [ErrorType::SHADOW_DEPENDENCY])
 
     // The rate limiter is required for the functional tests.
     ->ignoreErrorsOnPackage('symfony/rate-limiter', [ErrorType::UNUSED_DEPENDENCY])


### PR DESCRIPTION
### Description

Happens because of this:
https://github.com/symfony/polyfill-php84/commit/142ddfd67789d0b6d89ff7db082b33091f7deff7

Updates the dependency check, see https://github.com/contao/contao/actions/runs/24305488321/job/70966162790?pr=9734.

Or we require symfony/polyfill-php84, update affected lines and unrequire it in `main`.

