### PR TITLE
Require `symfony/polyfill-php84` and update the usage of `Mysql::ATTR_MULTI_STATEMENTS`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,6 +142,7 @@
         "symfony/password-hasher": "^6.4",
         "symfony/polyfill-intl-idn": "^1.0",
         "symfony/polyfill-mbstring": "^1.0",
+        "symfony/polyfill-php84": "^1.34",
         "symfony/process": "^6.4",
         "symfony/property-access": "^6.4",
         "symfony/rate-limiter": "^6.4",

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -56,6 +56,7 @@
         "symfony/mailer": "^6.4",
         "symfony/monolog-bridge": "^6.4",
         "symfony/monolog-bundle": "^3.1",
+        "symfony/polyfill-php84": "^1.34",
         "symfony/process": "^6.4",
         "symfony/routing": "^6.4",
         "symfony/security-bundle": "^6.4",

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -251,6 +251,10 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
      */
     private function addDefaultPdoDriverOptions(array $extensionConfigs, ContainerBuilder $container): array
     {
+        if (!class_exists(Mysql::class)) {
+            return $extensionConfigs;
+        }
+
         [$driver, $options] = $this->parseDbalDriverAndOptions($extensionConfigs, $container);
 
         // Do not add PDO options if custom options have been defined

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -256,11 +256,10 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             return $extensionConfigs;
         }
 
-        $key = \defined('Pdo\Mysql::ATTR_MULTI_STATEMENTS') ? Mysql::ATTR_MULTI_STATEMENTS : \PDO::MYSQL_ATTR_MULTI_STATEMENTS;
         [$driver, $options] = $this->parseDbalDriverAndOptions($extensionConfigs, $container);
 
         // Do not add PDO options if custom options have been defined
-        if (isset($options[$key])) {
+        if (isset($options[Mysql::ATTR_MULTI_STATEMENTS])) {
             return $extensionConfigs;
         }
 
@@ -274,7 +273,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                 'connections' => [
                     'default' => [
                         'options' => [
-                            $key => false,
+                            Mysql::ATTR_MULTI_STATEMENTS => false,
                         ],
                     ],
                 ],

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -251,11 +251,6 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
      */
     private function addDefaultPdoDriverOptions(array $extensionConfigs, ContainerBuilder $container): array
     {
-        // Do not add PDO options if the constant does not exist
-        if (!\defined('PDO::MYSQL_ATTR_MULTI_STATEMENTS')) {
-            return $extensionConfigs;
-        }
-
         [$driver, $options] = $this->parseDbalDriverAndOptions($extensionConfigs, $container);
 
         // Do not add PDO options if custom options have been defined

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -477,7 +477,7 @@ class PluginTest extends ContaoTestCase
                     'connections' => [
                         'default' => [
                             'options' => [
-                                \defined('Pdo\Mysql::ATTR_MULTI_STATEMENTS') ? Mysql::ATTR_MULTI_STATEMENTS : \PDO::MYSQL_ATTR_MULTI_STATEMENTS => false,
+                                Mysql::ATTR_MULTI_STATEMENTS => false,
                             ],
                         ],
                     ],
@@ -555,7 +555,7 @@ class PluginTest extends ContaoTestCase
                         'default' => [
                             'driver' => 'pdo_mysql',
                             'options' => [
-                                \defined('Pdo\Mysql::ATTR_MULTI_STATEMENTS') ? Mysql::ATTR_MULTI_STATEMENTS : \PDO::MYSQL_ATTR_MULTI_STATEMENTS => true,
+                                Mysql::ATTR_MULTI_STATEMENTS => true,
                                 1002 => '',
                             ],
                         ],
@@ -608,7 +608,7 @@ class PluginTest extends ContaoTestCase
 
     public static function provideDatabaseDrivers(): iterable
     {
-        $key = \defined('Pdo\Mysql::ATTR_MULTI_STATEMENTS') ? Mysql::ATTR_MULTI_STATEMENTS : \PDO::MYSQL_ATTR_MULTI_STATEMENTS;
+        $key = Mysql::ATTR_MULTI_STATEMENTS;
 
         yield 'pdo with driver' => [
             [
@@ -683,7 +683,7 @@ class PluginTest extends ContaoTestCase
                 'dbal' => [
                     'connections' => [
                         'default' => [
-                            'options' => [\defined('Pdo\Mysql::ATTR_MULTI_STATEMENTS') ? Mysql::ATTR_MULTI_STATEMENTS : \PDO::MYSQL_ATTR_MULTI_STATEMENTS => false],
+                            'options' => [Mysql::ATTR_MULTI_STATEMENTS => false],
                             'default_table_options' => [
                                 'charset' => 'utf8mb4',
                                 'collate' => 'utf8mb4_unicode_ci',
@@ -1029,7 +1029,7 @@ class PluginTest extends ContaoTestCase
                     'connections' => [
                         'default' => [
                             'options' => [
-                                \defined('Pdo\Mysql::ATTR_MULTI_STATEMENTS') ? Mysql::ATTR_MULTI_STATEMENTS : \PDO::MYSQL_ATTR_MULTI_STATEMENTS => false,
+                                Mysql::ATTR_MULTI_STATEMENTS => false,
                                 1002 => '',
                             ],
                         ],


### PR DESCRIPTION
### Description

Alternative to #9735 but as a bugfix for our CI (we already require the polyfill as a shadow dependency via `symfony/monolog-bundle` and other dependencies)