### PR TITLE
Use `contao` sanitizer for comments

### DIFF
--- a/comments-bundle/contao/templates/twig/com_default.html.twig
+++ b/comments-bundle/contao/templates/twig/com_default.html.twig
@@ -2,7 +2,7 @@
     <p class="info">{{ by }} {% if website %}<a href="{{ website }}" target="_blank" rel="nofollow noreferrer noopener">{{ name }}</a>{% else %}{{ name }}{% endif %} | <time datetime="{{ datetime }}" class="date">{{ date }}</time></p>
 
     <div class="comment">
-        {{ comment|sanitize_html }}
+        {{ comment|sanitize_html('contao') }}
     </div>
 
     {% if addReply %}


### PR DESCRIPTION
Comments can be edited in the back end with a TinyMCE - but when you add any styles from Contao's default TinyMCE these will not take effect in the front end because the comments themselves are currently run through Symfony's default sanitizer instead of Contao's.