### PR TITLE
Check for a successful response in `LegacyRouteParametersListener`

### DIFF
--- a/core-bundle/src/EventListener/LegacyRouteParametersListener.php
+++ b/core-bundle/src/EventListener/LegacyRouteParametersListener.php
@@ -35,7 +35,7 @@ class LegacyRouteParametersListener
 
     public function __invoke(ResponseEvent $event): void
     {
-        if (!$this->scopeMatcher->isFrontendMainRequest($event)) {
+        if (!$this->scopeMatcher->isFrontendMainRequest($event) || !$event->getResponse()->isSuccessful()) {
             return;
         }
 

--- a/core-bundle/tests/EventListener/LegacyRouteParametersListenerTest.php
+++ b/core-bundle/tests/EventListener/LegacyRouteParametersListenerTest.php
@@ -138,4 +138,42 @@ class LegacyRouteParametersListenerTest extends TestCase
         $listener = new LegacyRouteParametersListener($scopeMatcher, $framework);
         $listener($responseEvent);
     }
+
+    public function testDoesNotThrowUnusedArgumentsExceptionWithUnusedRoutParametersOnUnsuccessfulResponses(): void
+    {
+        $responseEvent = new ResponseEvent(
+            $this->createStub(KernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response(status: Response::HTTP_INTERNAL_SERVER_ERROR),
+        );
+
+        $scopeMatcher = $this->createMock(ScopeMatcher::class);
+        $scopeMatcher
+            ->expects($this->once())
+            ->method('isFrontendMainRequest')
+            ->with($responseEvent)
+            ->willReturn(true)
+        ;
+
+        $inputAdapter = $this->createAdapterMock(['getUnusedRouteParameters', 'setUnusedRouteParameters']);
+        $inputAdapter
+            ->expects($this->never())
+            ->method('getUnusedRouteParameters')
+        ;
+
+        $inputAdapter
+            ->expects($this->never())
+            ->method('setUnusedRouteParameters')
+        ;
+
+        $framework = $this->createMock(ContaoFramework::class);
+        $framework
+            ->expects($this->never())
+            ->method('getAdapter')
+        ;
+
+        $listener = new LegacyRouteParametersListener($scopeMatcher, $framework);
+        $listener($responseEvent);
+    }
 }

--- a/core-bundle/tests/EventListener/LegacyRouteParametersListenerTest.php
+++ b/core-bundle/tests/EventListener/LegacyRouteParametersListenerTest.php
@@ -139,7 +139,7 @@ class LegacyRouteParametersListenerTest extends TestCase
         $listener($responseEvent);
     }
 
-    public function testDoesNotThrowUnusedArgumentsExceptionWithUnusedRoutParametersOnUnsuccessfulResponses(): void
+    public function testDoesNotThrowUnusedArgumentsExceptionWithUnusedRouteParametersOnUnsuccessfulResponses(): void
     {
         $responseEvent = new ResponseEvent(
             $this->createStub(KernelInterface::class),

--- a/core-bundle/tests/EventListener/LegacyRouteParametersListenerTest.php
+++ b/core-bundle/tests/EventListener/LegacyRouteParametersListenerTest.php
@@ -94,7 +94,7 @@ class LegacyRouteParametersListenerTest extends TestCase
         $listener($event);
     }
 
-    public function testThrowsUnusedArgumentsExceptionWithUnusedRoutParameters(): void
+    public function testThrowsUnusedArgumentsExceptionWithUnusedRouteParameters(): void
     {
         $this->expectException(UnusedArgumentsException::class);
         $this->expectExceptionMessage('Unused arguments: foo');


### PR DESCRIPTION
Fixes #9746