### PR TITLE
Fix the backend redirect in table=ptable modules

### DIFF
--- a/core-bundle/src/DataContainer/DcaUrlAnalyzer.php
+++ b/core-bundle/src/DataContainer/DcaUrlAnalyzer.php
@@ -240,6 +240,11 @@ class DcaUrlAnalyzer
         }
 
         foreach ($links as $i => $link) {
+            // Remove the table from query string, if the parent table is the same as the current table (e.g. jobs module)
+            if (isset($link['query']['table']) && ($GLOBALS['TL_DCA'][$table]['config']['ptable'] ?? null) === $table) {
+                unset($link['query']['table']);
+            }
+
             $links[$i]['url'] = $this->router->generate('contao_backend', $link['query']);
             unset($links[$i]['query']);
         }


### PR DESCRIPTION
There is a problem when deleting jobs in the backend, as after deleting a record it redirects back to the URL with `table` parameter which causes the list view to be empty:

<img width="978" height="364" alt="CleanShot 2026-04-15 at 17 54 23" src="https://github.com/user-attachments/assets/969f23d6-8cf4-43c5-9b18-bc5f629ab214" />

Basically, the URL changes as follows:

```
/contao?do=jobs
    ↓
(delete)
    ↓
/contao?do=jobs&table=tl_job ❌ wrong

/contao?do=jobs ✅ should be
```

The jobs is very specific as its `ptable` is the same as tabel name, so this could be the anchor point for fixing.

I am not entirely sure if the fix is correct, so it would be great if you can further review it.

/cc @Toflar @ausi 