### PR TITLE
Optimize the `operations.html.twig` template

### DIFF
--- a/core-bundle/contao/templates/twig/backend/data_container/operations.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/operations.html.twig
@@ -7,7 +7,9 @@
 <div class="operations"{% if globalOperations %} id="tl_buttons" data-controller="contao--operations-menu" data-action="contextmenu->contao--operations-menu#open"{% endif %}>
     <ul data-contao--operations-menu-target="menu">
         {% for operation in operations %}
-            {% set is_link = operation.href|default or (operation.html is defined and ('<a ' in operation.html or '<button ' in operation.html)) %}
+            {% set href = operation.href|default %}
+            {% set html = operation.html|default(null) %}
+            {% set is_link = href or (html is not null and ('<a ' in html or '<button ' in html)) %}
             {% set has_submenu = has_submenu or is_link %}
             {% if has_primary and not operation.primary|default(false) %}
                 {% set show_button = true %}
@@ -41,43 +43,51 @@
 </div>
 
 {% macro operation(operation, menu = false, show_labels = false, add_separator = false) %}
+    {% set html = operation.html|default(null) %}
+    {% set href = operation.href|default %}
+    {% set title = operation.title|default %}
+    {% set label = operation.label|default %}
+    {% set icon = operation.icon|default %}
+    {% set icon_attributes = operation.iconAttributes|default(null) %}
+    {% set method = operation.method|default('GET') %}
+
     {% set list_attributes = attrs(operation.listAttributes|default)
         .addClass('separator', add_separator)
     %}
-    {% if operation.html is defined and (not menu or '<a ' in operation.html or '<button ' in operation.html) %}
+    {% if html is not null and (not menu or '<a ' in html or '<button ' in html) %}
         {% set list_attributes = list_attributes.set('data-contao--operations-menu-target', 'title', menu and not show_labels) %}
-        <li{{ list_attributes }}>{{ operation.html|raw }}</li>
-    {% elseif operation.href|default %}
-        {% set list_attributes = list_attributes.set('data-contao--operations-menu-target', 'title', menu and not operation.title|default) %}
+        <li{{ list_attributes }}>{{ html|raw }}</li>
+    {% elseif href %}
+        {% set list_attributes = list_attributes.set('data-contao--operations-menu-target', 'title', menu and not title) %}
         <li{{ list_attributes }}>
             {% set operation_attributes = attrs(operation.attributes|default)
-                .set('title', operation.title|default, ((menu or show_labels) and operation.title|default != operation.label|default))
-                .addClass('has-icon', operation.icon|default)
+                .set('title', title, ((menu or show_labels) and title != label))
+                .addClass('has-icon', icon)
             %}
             {% do operation_attributes.set('data-action', operation_attributes['data-action']|default('') ~ ' contao--operations-menu#close') %}
-            {% if operation.method|default('GET') != 'GET' %}
-                <form action="{{ operation.href }}" method="POST">
-                    {% if operation.method != 'POST' %}<input type="hidden" name="_method" value="{{ operation.method }}">{% endif %}
+            {% if method != 'GET' %}
+                <form action="{{ href }}" method="POST">
+                    {% if method != 'POST' %}<input type="hidden" name="_method" value="{{ method }}">{% endif %}
                     <input type="hidden" name="REQUEST_TOKEN" value="{{ contao.request_token }}">
                     <button type="submit"{{ operation_attributes }}>
-                        {% if operation.icon|default %}{{ backend_icon(operation.icon, (menu or show_labels) ? '' : operation.title|default(operation.label|default), operation.iconAttributes|default(null)) }}{% endif %}
-                        {% if menu or show_labels %}{{ operation.label|default }}{% endif %}
+                        {% if icon %}{{ backend_icon(icon, (menu or show_labels) ? '' : title|default(label), icon_attributes) }}{% endif %}
+                        {% if menu or show_labels %}{{ label }}{% endif %}
                     </button>
                 </form>
             {% else %}
                 {% set operation_attributes = operation_attributes
-                    .set('href', operation.href)
+                    .set('href', href)
                 %}
                 <a{{ operation_attributes }}>
-                    {% if operation.icon|default %}{{ backend_icon(operation.icon, (menu or show_labels) ? '' : operation.title|default(operation.label|default)|trans, operation.iconAttributes|default(null)) }}{% endif %}
-                    {% if menu or show_labels %}{{ operation.label|default|trans }}{% endif %}
+                    {% if icon %}{{ backend_icon(icon, (menu or show_labels) ? '' : title|default(label)|trans, icon_attributes) }}{% endif %}
+                    {% if menu or show_labels %}{{ label|trans }}{% endif %}
                 </a>
             {% endif %}
         </li>
-    {% elseif operation.icon|default and not menu %}
+    {% elseif icon and not menu %}
         <li{{ list_attributes }}>
-            {{ backend_icon(operation.icon, (menu or show_labels) ? '' : operation.title|default(operation.label|default), operation.iconAttributes|default(null)) }}
-            {% if menu or show_labels %}{{ operation.label|default }}{% endif %}
+            {{ backend_icon(icon, (menu or show_labels) ? '' : title|default(label), icon_attributes) }}
+            {% if menu or show_labels %}{{ label }}{% endif %}
         </li>
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
This change optimizes the backend data container operations Twig template by reducing repeated dynamic attribute lookups inside the frequently called `operation()` macro.
The template renders operation buttons and menus for backend data container views, and the macro can be invoked thousands of times on large listings. Previously, fields such as `operation.href`, `operation.html`, etc. were resolved repeatedly throughout the macro. Each of those accesses is compiled by Twig into `CoreExtension::getAttribute()` calls, which showed up prominently in profiling.
The macro now reads those operation values once into local Twig variables and reuses them for the remaining rendering logic.

This keeps the generated markup and behavior unchanged, but reduces the amount of runtime work per operation render. In the compiled template, the `CoreExtension::getAttribute()` calls for this template dropped by over 50% after the change and I also think the template is better readable 😇 