### PR TITLE
Add an escaped value cache in the `HtmlAttributes` class

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -475,8 +475,10 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
         $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, null, $this->doubleEncoding || 1 === preg_match('/["\'<>]/', $value));
         $value = str_replace(['{{', '}}'], ['&#123;&#123;', '&#125;&#125;'], $value);
 
-        if (\count($escapedValues) < self::ESCAPED_VALUE_CACHE_LIMIT) {
-            $escapedValues[$cacheKey] = $value;
+        $escapedValues[$cacheKey] = $value;
+
+        if (\count($escapedValues) > self::ESCAPED_VALUE_CACHE_LIMIT) {
+            unset($escapedValues[array_key_first($escapedValues)]);
         }
 
         return $value;

--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -20,6 +20,8 @@ use Contao\StringUtil;
  */
 class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggregate, \ArrayAccess
 {
+    private const ESCAPED_VALUE_CACHE_LIMIT = 4096;
+
     /**
      * @var array<array-key, string>
      */
@@ -458,13 +460,26 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
 
     private function escapeValue(string $name, string $value): string
     {
+        static $escapedValues = [];
+
         if (!preg_match('//u', $value) || str_contains($value, "\x00")) {
             throw new \RuntimeException(\sprintf('The value of property "%s" is not a valid UTF-8 string.', $name));
         }
 
-        $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, null, $this->doubleEncoding || 1 === preg_match('/["\'<>]/', $value));
+        $cacheKey = ($this->doubleEncoding ? '1' : '0')."\0".$value;
 
-        return str_replace(['{{', '}}'], ['&#123;&#123;', '&#125;&#125;'], $value);
+        if (isset($escapedValues[$cacheKey])) {
+            return $escapedValues[$cacheKey];
+        }
+
+        $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, null, $this->doubleEncoding || 1 === preg_match('/["\'<>]/', $value));
+        $value = str_replace(['{{', '}}'], ['&#123;&#123;', '&#125;&#125;'], $value);
+
+        if (\count($escapedValues) < self::ESCAPED_VALUE_CACHE_LIMIT) {
+            $escapedValues[$cacheKey] = $value;
+        }
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
This change optimizes`HtmlAttributes` rendering by caching repeated escaping of attribute values.
`HtmlAttributes::toString()` (and thus `escapeValue`) is called repeatedly during backend rendering, especially while rendering operation buttons and icons. Each call currently rebuilds the full attribute string and re-escapes every attribute value over and over again. Profiling showed tens of thousands of calls on the very same valuees on backend requests. This helps quite a bit 😇  We can also increase the size but I just wanted to make sure we're not leaking memory for long running processes somehow.