### PR TITLE
Cache the Contao context in the `ContaoStrategy` class

### DIFF
--- a/core-bundle/src/Security/Authentication/ContaoStrategy.php
+++ b/core-bundle/src/Security/Authentication/ContaoStrategy.php
@@ -20,6 +20,10 @@ use Symfony\Component\Security\Http\FirewallMapInterface;
 
 class ContaoStrategy implements AccessDecisionStrategyInterface, \Stringable
 {
+    private int|null $contaoContextRequestId = null;
+
+    private bool|null $contaoContext = null;
+
     public function __construct(
         private readonly AccessDecisionStrategyInterface $defaultStrategy,
         private readonly AccessDecisionStrategyInterface $contaoStrategy,
@@ -55,17 +59,30 @@ class ContaoStrategy implements AccessDecisionStrategyInterface, \Stringable
         $request = $this->requestStack->getMainRequest();
 
         if (!$request || !$this->firewallMap instanceof FirewallMap) {
+            $this->contaoContextRequestId = null;
+            $this->contaoContext = false;
+
             return false;
         }
+
+        $requestId = spl_object_id($request);
+
+        if ($this->contaoContextRequestId === $requestId && null !== $this->contaoContext) {
+            return $this->contaoContext;
+        }
+
+        $this->contaoContextRequestId = $requestId;
 
         $config = $this->firewallMap->getFirewallConfig($request);
 
         if (!$config instanceof FirewallConfig) {
+            $this->contaoContext = false;
+
             return false;
         }
 
         $context = $config->getContext();
 
-        return 'contao_frontend' === $context || 'contao_backend' === $context;
+        return $this->contaoContext = 'contao_frontend' === $context || 'contao_backend' === $context;
     }
 }


### PR DESCRIPTION
Every single voter access (`isGranted()` call) is handled via our `ContaoStrategy` which currently determines the current context on every single call. Our strategy then calls `FirewallMap::getFirewallConfig()` over and over again which accumulates to > 10k method calls in my system. But the context cannot change for the same request instance so all of these calls can be saved.

I did not add a cache array for multiple requests as it's only the main request of which there's usually just one in the backend. Then we don't have to deal with cleaning up the cache array. I guess this here is the easiest variant and 5% of the time spent in my request are gone 😇 