### PR TITLE
Conflict with `league/flysystem-bundle` 3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         "lcobucci/jwt": "^4.0 || ^5.0",
         "league/commonmark": "^2.2",
         "league/flysystem": "^3.7",
-        "league/flysystem-bundle": "^3.0",
+        "league/flysystem-bundle": "^3.0 <3.7",
         "league/flysystem-local": "^3.0",
         "matthiasmullie/minify": "^1.3",
         "monolog/monolog": "^2.0",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -80,7 +80,7 @@
         "lcobucci/jwt": "^4.0 || ^5.0",
         "league/commonmark": "^2.2",
         "league/flysystem": "^3.7",
-        "league/flysystem-bundle": "^3.0",
+        "league/flysystem-bundle": "^3.0 <3.7",
         "league/flysystem-local": "^3.0",
         "matthiasmullie/minify": "^1.3",
         "monolog/monolog": "^2.0",

--- a/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
+++ b/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
@@ -87,6 +87,7 @@ class FilesystemConfiguration
         $name ??= str_replace(['.', '/', '-'], '_', Container::underscore($mountPath));
         $adapterId = "contao.filesystem.adapter.$name";
 
+        // TODO: Fix compatibility with league/flysystem-bundle 3.7
         if ($adapterDefinition = $this->adapterDefinitionFactory->createDefinition($adapter, $options)) {
             // Native adapter
             $this->container


### PR DESCRIPTION
The changes from https://github.com/thephpleague/flysystem-bundle/pull/186 got released as `3.7.0` and as the `@internal` class `League\FlysystemBundle\Adapter\AdapterDefinitionFactory` was deleted there we need conflict with that version until we update our usage of that class.