### PR TITLE
Prevent assets added during framework initialization from being cleared

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -443,6 +443,9 @@ services:
             - '@translator'
             - '@contao.framework'
 
+    contao.listener.legacy_globals_backup:
+        class: Contao\CoreBundle\EventListener\LegacyGlobalsBackupListener
+
     contao.listener.legacy_route_parameters:
         class: Contao\CoreBundle\EventListener\LegacyRouteParametersListener
         arguments:

--- a/core-bundle/src/EventListener/LegacyGlobalsBackupListener.php
+++ b/core-bundle/src/EventListener/LegacyGlobalsBackupListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+/**
+ * Stores the legacy globals before a page is rendered.
+ *
+ * @internal
+ */
+#[AsEventListener(priority: -1024)]
+class LegacyGlobalsBackupListener
+{
+    public const ATTRIBUTE = '_globals_backup';
+
+    public function __invoke(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $event->getRequest()->attributes->set(self::ATTRIBUTE, [
+            $GLOBALS['TL_HEAD'] ?? [],
+            $GLOBALS['TL_BODY'] ?? [],
+            $GLOBALS['TL_MOOTOOLS'] ?? [],
+            $GLOBALS['TL_JQUERY'] ?? [],
+            $GLOBALS['TL_USER_CSS'] ?? [],
+            $GLOBALS['TL_FRAMEWORK_CSS'] ?? [],
+            $GLOBALS['TL_JAVASCRIPT'] ?? [],
+            $GLOBALS['TL_CSS'] ?? [],
+        ]);
+    }
+}

--- a/core-bundle/src/Routing/ResponseContext/ResponseContextAccessor.php
+++ b/core-bundle/src/Routing/ResponseContext/ResponseContextAccessor.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Routing\ResponseContext;
 
+use Contao\CoreBundle\EventListener\LegacyGlobalsBackupListener;
 use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,8 +32,8 @@ class ResponseContextAccessor
 
     public function setResponseContext(ResponseContext|null $responseContext): self
     {
-        // Unset some legacy globals (see #7659)
-        unset(
+        // Restore legacy globals to the state after framework init (see #7659)
+        [
             $GLOBALS['TL_HEAD'],
             $GLOBALS['TL_BODY'],
             $GLOBALS['TL_MOOTOOLS'],
@@ -41,7 +42,7 @@ class ResponseContextAccessor
             $GLOBALS['TL_FRAMEWORK_CSS'],
             $GLOBALS['TL_JAVASCRIPT'],
             $GLOBALS['TL_CSS'],
-        );
+        ] = $this->requestStack->getMainRequest()?->attributes->get(LegacyGlobalsBackupListener::ATTRIBUTE) ?? array_fill(0, 8, []);
 
         $request = $this->requestStack->getCurrentRequest();
         $request?->attributes->set(ResponseContext::REQUEST_ATTRIBUTE_NAME, $responseContext);


### PR DESCRIPTION
Fixes #9687

There was a reason why we stored the `$GLOBALS` state (for the specific `TL_CSS`, `TL_HEAD`, etc. fields) before rendering a page: you are able to do

```php
// contao/config/config.php
$GLOBALS['TL_CSS'][] = 'files/foo/bar.css';
```

in your `contao/config/config.php`. Since we are clearing these arrays when a new response context is set, those are lost - because this happens during the Contao framework init.

This PR fixes that by storing the state of these globals in a request event with a low priority, so that it can capture their contents right before a page is rendered (i.e. before a response context is created). The `ResponseContextAccessor` then resets the globals to this stored state whenever a new response context is created.

This will also capture any globally added assets added to `$GLOBALS` during a `RequestEvent`.