### PR TITLE
Support CSV values in fragment data

### DIFF
--- a/core-bundle/src/Twig/Runtime/FragmentRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FragmentRuntime.php
@@ -74,14 +74,11 @@ final class FragmentRuntime implements RuntimeExtensionInterface
         return $contentElementReference;
     }
 
-    /**
-     * @param class-string<ContentModel|ModuleModel> $class
-     */
     private function getModel(string $table, int|string $typeOrId, array $data = []): ContentModel|ModuleModel|null
     {
         $class = $GLOBALS['TL_MODELS'][$table] ?? null;
 
-        if (!$class || !\class_exists($class)) {
+        if (!$class || !class_exists($class)) {
             return null;
         }
 

--- a/core-bundle/src/Twig/Runtime/FragmentRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FragmentRuntime.php
@@ -38,7 +38,7 @@ final class FragmentRuntime implements RuntimeExtensionInterface
         return $this->framework
             ->getAdapter(Controller::class)
             ->getFrontendModule(
-                0 !== $typeOrId ? $this->getModel(ModuleModel::class, $typeOrId, $data) : 0,
+                0 !== $typeOrId ? $this->getModel('tl_module', $typeOrId, $data) : 0,
                 $context['_slot_name'] ?? 'main',
             )
         ;
@@ -51,7 +51,7 @@ final class FragmentRuntime implements RuntimeExtensionInterface
         } elseif (\is_string($typeOrId) && \is_array($data['nested_fragments'] ?? null)) {
             $modelOrReference = $this->getContentReference($typeOrId, $data);
         } else {
-            $modelOrReference = $this->getModel(ContentModel::class, $typeOrId, $data);
+            $modelOrReference = $this->getModel('tl_content', $typeOrId, $data);
         }
 
         return $this->framework->getAdapter(Controller::class)->getContentElement($modelOrReference);
@@ -66,7 +66,7 @@ final class FragmentRuntime implements RuntimeExtensionInterface
 
         unset($data['nested_fragments']);
 
-        $model = $this->getModel(ContentModel::class, $type, $data);
+        $model = $this->getModel('tl_content', $type, $data);
 
         $contentElementReference = new ContentElementReference($model, 'main', [], true);
         $contentElementReference->setNestedFragments($nestedFragments);
@@ -77,8 +77,14 @@ final class FragmentRuntime implements RuntimeExtensionInterface
     /**
      * @param class-string<ContentModel|ModuleModel> $class
      */
-    private function getModel(string $class, int|string $typeOrId, array $data = []): ContentModel|ModuleModel|null
+    private function getModel(string $table, int|string $typeOrId, array $data = []): ContentModel|ModuleModel|null
     {
+        $class = $GLOBALS['TL_MODELS'][$table] ?? null;
+
+        if (!$class || !\class_exists($class)) {
+            return null;
+        }
+
         if (is_numeric($typeOrId)) {
             /** @var Adapter<ContentModel|ModuleModel> $adapter */
             $adapter = $this->framework->getAdapter($class);
@@ -92,9 +98,12 @@ final class FragmentRuntime implements RuntimeExtensionInterface
             return null;
         }
 
+        $this->framework->getAdapter(Controller::class)->loadDataContainer($table);
+
         foreach ($data as $k => $v) {
             if (null !== $v && !\is_scalar($v)) {
-                $v = serialize($v);
+                $csv = $GLOBALS['TL_DCA'][$table]['fields'][$k]['eval']['csv'] ?? null;
+                $v = $csv ? implode($csv, $v) : serialize($v);
             }
 
             $model->$k = $v;

--- a/core-bundle/tests/Twig/Runtime/FragmentRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/FragmentRuntimeTest.php
@@ -21,6 +21,19 @@ use Contao\ModuleModel;
 
 class FragmentRuntimeTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $GLOBALS['TL_MODELS'] = [
+            'tl_content' => ContentModel::class,
+            'tl_module' => ModuleModel::class,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_MODELS']);
+    }
+
     public function testRenderModuleFromType(): void
     {
         $controllerAdapter = $this->createAdapterMock(['getFrontendModule']);


### PR DESCRIPTION
If you manually instantiate a frontend module or content element, we currently serialize all array values automatically.

```twig
{{ content_element('foo', {
    foo: [1, 2, 3, 4]
} }}
```

However, if the DCA field uses CSV values instead of serialized array, the element will likely not render correctly. 

Additionally, this PR fixes the missing lookup of the model class in `$GLOBALS['TL_MODELS']`