### PR TITLE
Set the asset version strategy dynamically in the manager bundle

### DIFF
--- a/manager-bundle/skeleton/config/config.yaml
+++ b/manager-bundle/skeleton/config/config.yaml
@@ -8,9 +8,6 @@ parameters:
 
 # Framework configuration
 framework:
-    assets:
-        enabled: true
-        version_strategy: contao.asset.mtime_version_strategy
     esi: { enabled: true }
     translator: { fallbacks: ['%locale%'] }
     secret: '%env(APP_SECRET)%'

--- a/manager-bundle/skeleton/config/config.yaml
+++ b/manager-bundle/skeleton/config/config.yaml
@@ -8,6 +8,7 @@ parameters:
 
 # Framework configuration
 framework:
+    assets: true
     esi: { enabled: true }
     translator: { fallbacks: ['%locale%'] }
     secret: '%env(APP_SECRET)%'

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -215,6 +215,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             case 'framework':
                 $extensionConfigs = $this->checkMailerTransport($extensionConfigs, $container);
                 $extensionConfigs = $this->addDefaultMailer($extensionConfigs);
+                $extensionConfigs = $this->addDefaultVersionStrategy($extensionConfigs);
 
                 if (!isset($_SERVER['APP_SECRET'])) {
                     if ($container->hasParameter('secret')) {
@@ -625,5 +626,22 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
     private function encodeUrlParameter(string $parameter): string
     {
         return str_replace('%', '%%', rawurlencode($parameter));
+    }
+
+    private function addDefaultVersionStrategy(array $extensionConfigs): array
+    {
+        foreach ($extensionConfigs as $config) {
+            if (isset($config['assets']['version_strategy']) || isset($config['assets']['json_manifest_path'])) {
+                return $extensionConfigs;
+            }
+        }
+
+        $extensionConfigs[] = [
+            'assets' => [
+                'version_strategy' => 'contao.asset.mtime_version_strategy',
+            ],
+        ];
+
+        return $extensionConfigs;
     }
 }

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -779,12 +779,17 @@ class PluginTest extends ContaoTestCase
         $this->assertSame('sendmail', $container->getParameter('mailer_transport'));
     }
 
-    public function testAddsDefaultMailer(): void
+    public function testAddsDefaultMailerAndMtimeVersionStrategy(): void
     {
         $expect = [
             [
                 'mailer' => [
                     'dsn' => '%env(MAILER_DSN)%',
+                ],
+            ],
+            [
+                'assets' => [
+                    'version_strategy' => 'contao.asset.mtime_version_strategy',
                 ],
             ],
         ];
@@ -795,12 +800,15 @@ class PluginTest extends ContaoTestCase
         $this->assertSame($expect, $extensionConfig);
     }
 
-    public function testDoesNotAddDefaultMailerIfDefined(): void
+    public function testDoesNotAddDefaultMailerOrMitmeVersionStrategy(): void
     {
         $extensionConfigs = [
             [
                 'mailer' => [
                     'dsn' => 'smtp://localhost',
+                ],
+                'assets' => [
+                    'json_manifest_path' => '/foo/manifest.json',
                 ],
             ],
         ];
@@ -818,6 +826,9 @@ class PluginTest extends ContaoTestCase
                     'transports' => [
                         'default' => 'smtp://localhost',
                     ],
+                ],
+                'assets' => [
+                    'json_manifest_path' => '/foo/manifest.json',
                 ],
             ],
         ];


### PR DESCRIPTION
Follow-up to #9383, fixes https://github.com/contao/contao/pull/9383#issuecomment-4280499761

Instead of defining the default version strategy in the skeleton, we need to do it in the Contao Manager Plugin and add the setting dynamically.