### PR TITLE
Support accessing and manipulating virtual fields in user objects

### DIFF
--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -389,15 +389,8 @@ abstract class Model
 			$arrData[$strKey] = static::convertToPhpValue($strKey, $varValue);
 		}
 
-		$container = System::getContainer();
-
 		// Expand virtual fields
-		if ($container->has('contao.data_container.virtual_fields_handler'))
-		{
-			$arrData = $container->get('contao.data_container.virtual_fields_handler')->expandFields($arrData, static::$strTable);
-		}
-
-		$this->arrData = $arrData;
+		$this->arrData = System::getContainer()->get('contao.data_container.virtual_fields_handler')->expandFields($arrData, static::$strTable);
 
 		return $this;
 	}
@@ -555,13 +548,8 @@ abstract class Model
 		$arrFields = $objDatabase->getFieldNames(static::$strTable);
 		$arrRow = $this->row();
 
-		$container = System::getContainer();
-
 		// Combine virtual fields
-		if ($container->has('contao.data_container.virtual_fields_handler'))
-		{
-			$arrRow = $container->get('contao.data_container.virtual_fields_handler')->combineFields($arrRow, static::$strTable);
-		}
+		$arrRow = System::getContainer()->get('contao.data_container.virtual_fields_handler')->combineFields($arrRow, static::$strTable);
 
 		// The model is in the registry
 		if (Registry::getInstance()->isRegistered($this))

--- a/core-bundle/contao/library/Contao/User.php
+++ b/core-bundle/contao/library/Contao/User.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Doctrine\DBAL\Types\Types;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -266,6 +267,14 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 				$this->arrData[$strKey] = $strModelClass::convertToPhpValue($strKey, $varData);
 			}
 
+			$container = System::getContainer();
+
+			// Expand virtual fields
+			if ($container->has('contao.data_container.virtual_fields_handler'))
+			{
+				$this->arrData = $container->get('contao.data_container.virtual_fields_handler')->expandFields($this->arrData, $this->strTable);
+			}
+
 			return true;
 		}
 
@@ -278,11 +287,21 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	public function save()
 	{
 		$db = Database::getInstance();
+		$container = System::getContainer();
+
+		// Combine virtual fields
+		if ($container->has('contao.data_container.virtual_fields_handler'))
+		{
+			$arrData = $container->get('contao.data_container.virtual_fields_handler')->combineFields($this->arrData, $this->strTable);
+		}
 
 		$arrFields = $db->getFieldNames($this->strTable);
-		$arrSet = array_intersect_key($this->arrData, array_flip($arrFields));
+		$arrSet = array_intersect_key($arrData, array_flip($arrFields));
+		$arrTypes = array_map(fn (string $k) => \in_array($k, DcaExtractor::getInstance($this->strTable)->getVirtualTargets()) ? Types::JSON : null, array_keys($arrSet));
 
-		$db->prepare("UPDATE " . $this->strTable . " %s WHERE id=?")->set($arrSet)->execute($this->id);
+		$db->prepare("UPDATE " . $this->strTable . " %s WHERE id=?")
+			->set($arrSet)
+			->query('', array(...array_values($arrSet), $this->id), $arrTypes);
 	}
 
 	/**

--- a/core-bundle/contao/library/Contao/User.php
+++ b/core-bundle/contao/library/Contao/User.php
@@ -267,13 +267,8 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 				$this->arrData[$strKey] = $strModelClass::convertToPhpValue($strKey, $varData);
 			}
 
-			$container = System::getContainer();
-
 			// Expand virtual fields
-			if ($container->has('contao.data_container.virtual_fields_handler'))
-			{
-				$this->arrData = $container->get('contao.data_container.virtual_fields_handler')->expandFields($this->arrData, $this->strTable);
-			}
+			$this->arrData = System::getContainer()->get('contao.data_container.virtual_fields_handler')->expandFields($this->arrData, $this->strTable);
 
 			return true;
 		}
@@ -287,13 +282,9 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	public function save()
 	{
 		$db = Database::getInstance();
-		$container = System::getContainer();
 
 		// Combine virtual fields
-		if ($container->has('contao.data_container.virtual_fields_handler'))
-		{
-			$arrData = $container->get('contao.data_container.virtual_fields_handler')->combineFields($this->arrData, $this->strTable);
-		}
+		$arrData = System::getContainer()->get('contao.data_container.virtual_fields_handler')->combineFields($this->arrData, $this->strTable);
 
 		$arrFields = $db->getFieldNames($this->strTable);
 		$arrSet = array_intersect_key($arrData, array_flip($arrFields));


### PR DESCRIPTION
Fixes #9772 

Adds support for accessing and manipulating virtual fields in `Contao\User` objects - the same way as in `Contao\Model`.