### PR TITLE
Fix the button styling in the Template Studio header

### DIFF
--- a/core-bundle/contao/templates/twig/backend/template_studio/index.html.twig
+++ b/core-bundle/contao/templates/twig/backend/template_studio/index.html.twig
@@ -17,8 +17,10 @@
     %}
     <main{{ template_studio_attributes }}>
         {# Headline #}
-        <h1 id="main_headline">
-            {{ headline }}
+        <div class="content-top">
+            <h1 id="main_headline">
+                {{ headline }}
+            </h1>
             {% set fullscreen_button_attributes = attrs()
                 .addClass('fullscreen')
                 .set('data-action', 'contao--template-studio#enterFullscreen')
@@ -36,7 +38,7 @@
                 </svg>
             </button>
             {{ include('@Contao/backend/component/_favorites.html.twig') }}
-        </h1>
+        </div>
 
         <section id="template-studio" class="content chrome" data-contao--template-studio-target="content" data-turbo="true">
             <div id="template-studio--nav">


### PR DESCRIPTION
https://github.com/contao/contao/pull/9734 broke the button styling in the template studio header.
This PR fixes that.

Before
<img width="271" height="158" alt="image" src="https://github.com/user-attachments/assets/725014d3-1577-4717-9fbc-7742f9a7f396" />


After
<img width="345" height="157" alt="image" src="https://github.com/user-attachments/assets/61ca934a-6092-4d2f-86e4-44e98a9a63e1" />
