### PR TITLE
Don't use `$this->framework` in `DC_Table`

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4085,7 +4085,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			// Order by the foreign key
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['foreignKey']))
 			{
-				$dcaExtractor = $this->framework->createInstance(DcaExtractor::class, array($this->strTable));
+				$dcaExtractor = System::getContainer()->get('contao.framework')->createInstance(DcaExtractor::class, array($this->strTable));
 				$fkField = $dcaExtractor->getRelations()[$firstOrderBy]['field'] ?? 'id';
 				$fkField = Database::quoteIdentifier($fkField);
 
@@ -4349,6 +4349,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 
 		$db = Database::getInstance();
+		$framework = System::getContainer()->get('contao.framework');
 
 		if (\is_array($orderBy) && $orderBy[0])
 		{
@@ -4373,7 +4374,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 				if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['foreignKey']))
 				{
-					$dcaExtractor = $this->framework->createInstance(DcaExtractor::class, array($this->strTable));
+					$dcaExtractor = $framework->createInstance(DcaExtractor::class, array($this->strTable));
 					$fkField = $dcaExtractor->getRelations()[$key]['field'] ?? 'id';
 					$fkField = Database::quoteIdentifier($fkField);
 
@@ -4724,7 +4725,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']))
 			{
-				$dcaExtractor = $this->framework->createInstance(DcaExtractor::class, array($this->strTable));
+				$dcaExtractor = System::getContainer()->get('contao.framework')->createInstance(DcaExtractor::class, array($this->strTable));
 				$fkField = $dcaExtractor->getRelations()[$fld]['field'] ?? 'id';
 				$fkField = Database::quoteIdentifier($fkField);
 

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4085,7 +4085,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			// Order by the foreign key
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['foreignKey']))
 			{
-				$dcaExtractor = System::getContainer()->get('contao.framework')->createInstance(DcaExtractor::class, array($this->strTable));
+				$dcaExtractor = DcaExtractor::getInstance($this->strTable);
 				$fkField = $dcaExtractor->getRelations()[$firstOrderBy]['field'] ?? 'id';
 				$fkField = Database::quoteIdentifier($fkField);
 
@@ -4349,7 +4349,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 
 		$db = Database::getInstance();
-		$framework = System::getContainer()->get('contao.framework');
 
 		if (\is_array($orderBy) && $orderBy[0])
 		{
@@ -4374,7 +4373,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 				if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['foreignKey']))
 				{
-					$dcaExtractor = $framework->createInstance(DcaExtractor::class, array($this->strTable));
+					$dcaExtractor = DcaExtractor::getInstance($this->strTable);
 					$fkField = $dcaExtractor->getRelations()[$key]['field'] ?? 'id';
 					$fkField = Database::quoteIdentifier($fkField);
 
@@ -4725,7 +4724,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']))
 			{
-				$dcaExtractor = System::getContainer()->get('contao.framework')->createInstance(DcaExtractor::class, array($this->strTable));
+				$dcaExtractor = DcaExtractor::getInstance($this->strTable);
 				$fkField = $dcaExtractor->getRelations()[$fld]['field'] ?? 'id';
 				$fkField = Database::quoteIdentifier($fkField);
 


### PR DESCRIPTION
Follow-up on #9503

Fixes the `Call to a member function createInstance() on null` error.