### PR TITLE
Resolve insert tags in the redirect page URL in the breadcrumb module

### DIFF
--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -62,6 +62,7 @@ class ModuleBreadcrumb extends Module
 		$container = System::getContainer();
 		$blnShowUnpublished = $container->get('contao.security.token_checker')->isPreviewMode();
 		$request = $container->get('request_stack')->getCurrentRequest();
+		$insertTagParser = $container->get('contao.insert_tag.parser');
 
 		// Get all pages up to the root page
 		$parents = array_reverse($objPage->trail);
@@ -108,7 +109,7 @@ class ModuleBreadcrumb extends Module
 			switch ($pages[$i]->type)
 			{
 				case 'redirect':
-					$href = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($pages[$i]->url);
+					$href = $insertTagParser->replaceInline($pages[$i]->url);
 
 					if (strncasecmp($href, 'mailto:', 7) === 0)
 					{

--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -108,7 +108,7 @@ class ModuleBreadcrumb extends Module
 			switch ($pages[$i]->type)
 			{
 				case 'redirect':
-					$href = $pages[$i]->url;
+					$href = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($pages[$i]->url);
 
 					if (strncasecmp($href, 'mailto:', 7) === 0)
 					{


### PR DESCRIPTION
When using external redirects with insert tags in the url, for example for anchor links to the main page, which is probably the most common case, while also having child pages under that redirect page, on those child pages the breadcrumb link href to the redirect page will contain the url with the insert tag not replaced. 
This is the case for both the JSON-LD aswell as the `<a>`.

<img width="330" height="394" alt="image" src="https://github.com/user-attachments/assets/0e2624d1-9c08-4cc4-b4a2-e1aef7e0d60e" />
<img width="481" height="151" alt="image" src="https://github.com/user-attachments/assets/9be89e31-dab2-4333-a3b3-af92cbd2ac79" />
<br>
With this change, the link is resolved correctly in both places.