### PR TITLE
Replace breadcrumb insert tags for JSON-LD in the module and for HTML in the template

### DIFF
--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -62,7 +62,6 @@ class ModuleBreadcrumb extends Module
 		$container = System::getContainer();
 		$blnShowUnpublished = $container->get('contao.security.token_checker')->isPreviewMode();
 		$request = $container->get('request_stack')->getCurrentRequest();
-		$insertTagParser = $container->get('contao.insert_tag.parser');
 
 		// Get all pages up to the root page
 		$parents = array_reverse($objPage->trail);
@@ -109,7 +108,7 @@ class ModuleBreadcrumb extends Module
 			switch ($pages[$i]->type)
 			{
 				case 'redirect':
-					$href = $insertTagParser->replaceInline($pages[$i]->url);
+					$href = $pages[$i]->url;
 
 					if (strncasecmp($href, 'mailto:', 7) === 0)
 					{
@@ -215,6 +214,7 @@ class ModuleBreadcrumb extends Module
 
 			$position = 0;
 			$htmlDecoder = $container->get('contao.string.html_decoder');
+			$insertTagParser = $container->get('contao.insert_tag.parser');
 
 			foreach ($items as $item)
 			{
@@ -228,8 +228,8 @@ class ModuleBreadcrumb extends Module
 					'@type' => 'ListItem',
 					'position' => ++$position,
 					'item' => array(
-						'@id' => $item['href'],
-						'name' => $htmlDecoder->inputEncodedToPlainText($item['link'])
+						'@id' => $insertTagParser->replaceInline($item['href']),
+						'name' => $insertTagParser->replaceInline($htmlDecoder->inputEncodedToPlainText($item['link']))
 					)
 				);
 			}

--- a/core-bundle/contao/templates/twig/mod_breadcrumb.html.twig
+++ b/core-bundle/contao/templates/twig/mod_breadcrumb.html.twig
@@ -22,7 +22,7 @@
                 {% if item.isActive %}
                     <li class="active" aria-current="page">{{ item.link|insert_tag }}</li>
                 {% else %}
-                    <li><a href="{{ item.href }}">{{ item.link }}</a></li>
+                    <li><a href="{{ item.href|insert_tag }}">{{ item.link|insert_tag }}</a></li>
                 {% endif %}
             {% endfor %}
         </ul>


### PR DESCRIPTION
See https://github.com/contao/contao/pull/9785#issuecomment-4326387613

> I think we should do the following:
> 
> * Only replace the insert tags in the _template_ for the HTML output.
> * Replace the insert tags in the _controller_ (i.e. `ModuleBreadcrumb` in this case) for the JSON-LD data.
