### PR TITLE
Use the null-safe operator for `getBaseUrl()` and `getBasePath()`

### DIFF
--- a/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
+++ b/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
@@ -411,11 +411,11 @@ class LegacyInsertTag implements InsertTagResolverNestedResolvedInterface
                         break;
 
                     case 'base_url':
-                        $result = $this->container->get('request_stack')->getCurrentRequest()->getBaseUrl();
+                        $result = $this->container->get('request_stack')->getCurrentRequest()?->getBaseUrl() ?? '';
                         break;
 
                     case 'base_path':
-                        $result = $this->container->get('request_stack')->getCurrentRequest()->getBasePath();
+                        $result = $this->container->get('request_stack')->getCurrentRequest()?->getBasePath() ?? '';
                         break;
                 }
 


### PR DESCRIPTION
This is to prevent issues when working with content elements on CLI. The links in that case are irrelevant to me (not interested in the content) but I'm getting errors at the moment.