### PR TITLE
Do not extend from the deprecated WebAuthn credential repository class

### DIFF
--- a/core-bundle/src/Repository/WebauthnCredentialRepository.php
+++ b/core-bundle/src/Repository/WebauthnCredentialRepository.php
@@ -22,6 +22,9 @@ use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
+ * @template T of WebauthnCredential
+ * @template-extends  ServiceEntityRepository<T>
+ *
  * @internal
  */
 class WebauthnCredentialRepository extends ServiceEntityRepository implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource

--- a/core-bundle/src/Repository/WebauthnCredentialRepository.php
+++ b/core-bundle/src/Repository/WebauthnCredentialRepository.php
@@ -22,7 +22,7 @@ use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
- * @template-extends  ServiceEntityRepository<WebauthnCredential>
+ * @template-extends ServiceEntityRepository<WebauthnCredential>
  *
  * @internal
  */

--- a/core-bundle/src/Repository/WebauthnCredentialRepository.php
+++ b/core-bundle/src/Repository/WebauthnCredentialRepository.php
@@ -23,6 +23,7 @@ use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
  * @template T of WebauthnCredential
+ *
  * @template-extends  ServiceEntityRepository<T>
  *
  * @internal

--- a/core-bundle/src/Repository/WebauthnCredentialRepository.php
+++ b/core-bundle/src/Repository/WebauthnCredentialRepository.php
@@ -14,16 +14,17 @@ namespace Contao\CoreBundle\Repository;
 
 use Contao\CoreBundle\Entity\WebauthnCredential;
 use Contao\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
-use Webauthn\Bundle\Repository\DoctrineCredentialSourceRepository;
+use Webauthn\Bundle\Repository\CanSaveCredentialSource;
+use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
 use Webauthn\PublicKeyCredentialSource;
+use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
- * @template-extends DoctrineCredentialSourceRepository<WebauthnCredential>
- *
  * @internal
  */
-class WebauthnCredentialRepository extends DoctrineCredentialSourceRepository
+class WebauthnCredentialRepository extends ServiceEntityRepository implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -38,7 +39,7 @@ class WebauthnCredentialRepository extends DoctrineCredentialSourceRepository
         return $this->getEntityManager()
             ->createQueryBuilder()
             ->select('c')
-            ->from($this->class, 'c')
+            ->from(WebauthnCredential::class, 'c')
             ->where('c.userHandle = :user_handle')
             ->setParameter(':user_handle', $user->getPasskeyUserHandle())
             ->getQuery()
@@ -62,14 +63,28 @@ class WebauthnCredentialRepository extends DoctrineCredentialSourceRepository
             );
         }
 
-        parent::saveCredentialSource($publicKeyCredentialSource);
+        $this->getEntityManager()->persist($publicKeyCredentialSource);
+        $this->getEntityManager()->flush();
+    }
+
+    public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array
+    {
+        return $this->getEntityManager()
+            ->createQueryBuilder()
+            ->from(WebauthnCredential::class, 'c')
+            ->select('c')
+            ->where('c.userHandle = :userHandle')
+            ->setParameter(':userHandle', $publicKeyCredentialUserEntity->id)
+            ->getQuery()
+            ->execute()
+        ;
     }
 
     public function findOneByCredentialId(string $publicKeyCredentialId): WebauthnCredential|null
     {
         return $this->getEntityManager()
             ->createQueryBuilder()
-            ->from($this->class, 'c')
+            ->from(WebauthnCredential::class, 'c')
             ->select('c')
             ->where('c.publicKeyCredentialId = :publicKeyCredentialId')
             ->setParameter(':publicKeyCredentialId', base64_encode($publicKeyCredentialId))
@@ -83,7 +98,7 @@ class WebauthnCredentialRepository extends DoctrineCredentialSourceRepository
     {
         return $this->getEntityManager()
             ->createQueryBuilder()
-            ->from($this->class, 'c')
+            ->from(WebauthnCredential::class, 'c')
             ->select('c')
             ->where('c.id = :id')
             ->setParameter(':id', $id)
@@ -104,7 +119,7 @@ class WebauthnCredentialRepository extends DoctrineCredentialSourceRepository
         return $this->getEntityManager()
             ->createQueryBuilder()
             ->select('c')
-            ->from($this->class, 'c')
+            ->from(WebauthnCredential::class, 'c')
             ->where('c.userHandle = :user_handle')
             ->setParameter(':user_handle', $user->getPasskeyUserHandle())
             ->orderBy('c.createdAt', 'desc')

--- a/core-bundle/src/Repository/WebauthnCredentialRepository.php
+++ b/core-bundle/src/Repository/WebauthnCredentialRepository.php
@@ -22,9 +22,7 @@ use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
- * @template T of WebauthnCredential
- *
- * @template-extends  ServiceEntityRepository<T>
+ * @template-extends  ServiceEntityRepository<WebauthnCredential>
  *
  * @internal
  */


### PR DESCRIPTION
WebAuthn Framework 5.3 is slated to be released soon (?), but there is currently a [BC break](https://github.com/web-auth/webauthn-framework/issues/832) in its development version. Regardless of whether this BC break is fixed or not, it makes sense to not extend from the now deprecated `DoctrineCredentialSourceRepository` class. As you can see in this PR, the necessary changes are fairly minimal anyway.

_Note:_ there is also [another issue](https://github.com/web-auth/webauthn-framework/issues/833) with version 5.3.x, but I am not sure yet if there is something we need to adjust within Contao.