### PR TITLE
Save some calls on `HtmlAttributes`

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -116,7 +116,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
         $name = strtolower($name);
 
         if (!isset($validatedNames[$name])) {
-            if (!preg_match('(^[^>\s/][^>\s/=]*$)', $name) || !preg_match('//u', $name) || str_contains($name, "\x00")) {
+            if (!preg_match('(^[^>\t\n\r\f /\x00][^>\t\n\r\f /\x00=]*$)u', $name)) {
                 throw new \InvalidArgumentException(\sprintf('An HTML attribute name must be valid UTF-8 and not contain the characters >, /, = or whitespace, got "%s".', $name));
             }
 

--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -22,6 +22,8 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
 {
     private const ESCAPED_VALUE_CACHE_LIMIT = 4096;
 
+    private const VALIDATED_NAME_CACHE_LIMIT = 256;
+
     /**
      * @var array<array-key, string>
      */
@@ -97,6 +99,8 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
      */
     public function set(string $name, \Stringable|bool|float|int|string|null $value = true, mixed $condition = true): self
     {
+        static $validatedNames = [];
+
         if (!$this->test($condition)) {
             return $this;
         }
@@ -111,8 +115,16 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
 
         $name = strtolower($name);
 
-        if (!preg_match('(^[^>\s/][^>\s/=]*$)', $name) || !preg_match('//u', $name) || str_contains($name, "\x00")) {
-            throw new \InvalidArgumentException(\sprintf('An HTML attribute name must be valid UTF-8 and not contain the characters >, /, = or whitespace, got "%s".', $name));
+        if (!isset($validatedNames[$name])) {
+            if (!preg_match('(^[^>\s/][^>\s/=]*$)', $name) || !preg_match('//u', $name) || str_contains($name, "\x00")) {
+                throw new \InvalidArgumentException(\sprintf('An HTML attribute name must be valid UTF-8 and not contain the characters >, /, = or whitespace, got "%s".', $name));
+            }
+
+            $validatedNames[$name] = true;
+
+            if (\count($validatedNames) > self::VALIDATED_NAME_CACHE_LIMIT) {
+                unset($validatedNames[array_key_first($validatedNames)]);
+            }
         }
 
         // Unset if value is set to false
@@ -122,7 +134,13 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
             return $this;
         }
 
-        $this->attributes[$name] = true === $value ? '' : (string) $value;
+        $normalizedValue = true === $value ? '' : (string) $value;
+
+        if (($this->attributes[$name] ?? null) === $normalizedValue) {
+            return $this;
+        }
+
+        $this->attributes[$name] = $normalizedValue;
 
         // Normalize class names and style attributes
         if ('class' === $name) {


### PR DESCRIPTION
Saves us quite a bit of useless repeated `preg_match()` calls on the ever-repeating same attribute names and also prevents calls on `addClass()` and `addStyle()` if values remain unchanged.

<img width="352" height="424" alt="Bildschirmfoto 2026-04-29 um 12 24 18" src="https://github.com/user-attachments/assets/e2eac476-3706-4c5d-b7e6-5d29d9310775" />
