### PR TITLE
Add an `attributes` variable to the `player.html.twig` template

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/player.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/player.html.twig
@@ -19,7 +19,10 @@
 {% endblock %}
 
 {% block media %}
-    <{{ figure.media.type }}{{ figure.media.attributes }}>
+    {% set media_attributes = attrs(figure.media.attributes)
+        .mergeWith(media_attributes|default)
+    %}
+    <{{ figure.media.type }}{{ media_attributes }}>
         {% for source_attributes in figure.media.sources %}
             {% do csp_source('media-src', source_attributes.src) %}
             <source{{ source_attributes }}>


### PR DESCRIPTION
Currently it is not easily possible to adjust the HTML attributes of a `<video>` or `<audio>` element. This PR introduces a new `media_attributes` variable, so that you can use e.g.

```twig
{% extends "@Contao/content_element/player.html.twig" %}

{% block media %}
    {% set media_attributes = attrs()
        .set('preload', 'none')
        .mergeWith(media_attributes|default)
    %}
    {{ parent() }}
{% endblock %}
```

instead of having to do

```twig
{% extends "@Contao/content_element/player.html.twig" %}

{% block media %}
    {% set media_attributes = attrs(figure.media.attributes)
        .set('preload', 'none')
    %}
    <{{ figure.media.type }}{{ media_attributes }}>
        {% for source_attributes in figure.media.sources %}
            {% do csp_source('media-src', source_attributes.src) %}
            <source{{ source_attributes }}>
        {% endfor %}
        {% for track_attributes in figure.media.tracks|default %}
            {% do csp_source('media-src', track_attributes.src) %}
            <track{{ track_attributes }}>
        {% endfor %}
    </{{ figure.media.type }}>
{% endblock %}
```

or manually reworking the `figure` object in the template.