### PR TITLE
Allow a lower `--time-limit` for messenger workers

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -169,10 +169,10 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->arrayNode('options')
-                                ->info('messenger:consume options. Make sure to always include "--time-limit=60".')
-                                ->example(['--sleep=5', '--time-limit=60'])
+                                ->info('messenger:consume options. Make sure to always include "--time-limit=55".')
+                                ->example(['--sleep=5', '--time-limit=55'])
                                 ->scalarPrototype()->end()
-                                ->defaultValue(['--time-limit=56'])
+                                ->defaultValue(['--time-limit=55'])
                                 ->validate()
                                     ->ifTrue(
                                         static function (array $options): bool {

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -177,7 +177,7 @@ class Configuration implements ConfigurationInterface
                                     ->ifTrue(
                                         static function (array $options): bool {
                                             foreach ($options as $option) {
-                                                if (preg_match('/^--time-limit=([0-9]+)$/', $option, $matches) && isset($matches[1]) && $matches[1] <= 60) {
+                                                if (preg_match('/^--time-limit=([0-9]+)$/', $option, $matches) && $matches[1] <= 60) {
                                                     return false;
                                                 }
                                             }

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -172,7 +172,7 @@ class Configuration implements ConfigurationInterface
                                 ->info('messenger:consume options. Make sure to always include "--time-limit=60".')
                                 ->example(['--sleep=5', '--time-limit=60'])
                                 ->scalarPrototype()->end()
-                                ->defaultValue(['--time-limit=60'])
+                                ->defaultValue(['--time-limit=56'])
                                 ->validate()
                                     ->ifTrue(
                                         static function (array $options): bool {

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -174,8 +174,18 @@ class Configuration implements ConfigurationInterface
                                 ->scalarPrototype()->end()
                                 ->defaultValue(['--time-limit=60'])
                                 ->validate()
-                                    ->ifTrue(static fn (array $options) => !\in_array('--time-limit=60', $options, true))
-                                    ->thenInvalid('Custom messenger:consume options must include "--time-limit=60".')
+                                    ->ifTrue(
+                                        static function (array $options): bool {
+                                            foreach ($options as $option) {
+                                                if (preg_match('/^--time-limit=([0-9]+)$/', $option, $matches) && isset($matches[1]) && $matches[1] <= 60) {
+                                                    return false;
+                                                }
+                                            }
+
+                                            return true;
+                                        },
+                                    )
+                                    ->thenInvalid('Custom messenger:consume options must include a "--time-limit" of 60 seconds or less.')
                                 ->end()
                             ->end()
                             ->arrayNode('autoscale')

--- a/core-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -265,7 +265,7 @@ class ConfigurationTest extends TestCase
                         ],
                         [
                             'transports' => ['prio_normal'],
-                            'options' => ['--sleep=10', '--time-limit=56'],
+                            'options' => ['--sleep=10', '--time-limit=55'],
                             'autoscale' => [
                                 'desired_size' => 10,
                                 'max' => 20,
@@ -273,7 +273,7 @@ class ConfigurationTest extends TestCase
                         ],
                         [
                             'transports' => ['prio_high'],
-                            'options' => ['--sleep=5', '--time-limit=56'],
+                            'options' => ['--sleep=5', '--time-limit=55'],
                             'autoscale' => [
                                 'desired_size' => 5,
                                 'max' => 30,
@@ -292,7 +292,7 @@ class ConfigurationTest extends TestCase
                 'workers' => [
                     [
                         'transports' => ['prio_low'],
-                        'options' => ['--time-limit=56'],
+                        'options' => ['--time-limit=55'],
                         'autoscale' => [
                             'enabled' => false,
                             'min' => 1,
@@ -300,7 +300,7 @@ class ConfigurationTest extends TestCase
                     ],
                     [
                         'transports' => ['prio_normal'],
-                        'options' => ['--sleep=10', '--time-limit=56'],
+                        'options' => ['--sleep=10', '--time-limit=55'],
                         'autoscale' => [
                             'desired_size' => 10,
                             'max' => 20,
@@ -310,7 +310,7 @@ class ConfigurationTest extends TestCase
                     ],
                     [
                         'transports' => ['prio_high'],
-                        'options' => ['--sleep=5', '--time-limit=56'],
+                        'options' => ['--sleep=5', '--time-limit=55'],
                         'autoscale' => [
                             'desired_size' => 5,
                             'max' => 30,
@@ -334,7 +334,7 @@ class ConfigurationTest extends TestCase
                         'workers' => [
                             [
                                 'transports' => ['prio_normal'],
-                                'options' => ['--sleep=10', '--time-limit=56'],
+                                'options' => ['--sleep=10', '--time-limit=55'],
                                 'autoscale' => [
                                     'enabled' => true,
                                 ],
@@ -357,7 +357,7 @@ class ConfigurationTest extends TestCase
                         'workers' => [
                             [
                                 'transports' => ['prio_normal'],
-                                'options' => ['--sleep=10', '--time-limit=56'],
+                                'options' => ['--sleep=10', '--time-limit=55'],
                                 'autoscale' => [
                                     'enabled' => true,
                                     'desired_size' => 10,

--- a/core-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -265,7 +265,7 @@ class ConfigurationTest extends TestCase
                         ],
                         [
                             'transports' => ['prio_normal'],
-                            'options' => ['--sleep=10', '--time-limit=60'],
+                            'options' => ['--sleep=10', '--time-limit=56'],
                             'autoscale' => [
                                 'desired_size' => 10,
                                 'max' => 20,
@@ -273,7 +273,7 @@ class ConfigurationTest extends TestCase
                         ],
                         [
                             'transports' => ['prio_high'],
-                            'options' => ['--sleep=5', '--time-limit=60'],
+                            'options' => ['--sleep=5', '--time-limit=56'],
                             'autoscale' => [
                                 'desired_size' => 5,
                                 'max' => 30,
@@ -292,7 +292,7 @@ class ConfigurationTest extends TestCase
                 'workers' => [
                     [
                         'transports' => ['prio_low'],
-                        'options' => ['--time-limit=60'],
+                        'options' => ['--time-limit=56'],
                         'autoscale' => [
                             'enabled' => false,
                             'min' => 1,
@@ -300,7 +300,7 @@ class ConfigurationTest extends TestCase
                     ],
                     [
                         'transports' => ['prio_normal'],
-                        'options' => ['--sleep=10', '--time-limit=60'],
+                        'options' => ['--sleep=10', '--time-limit=56'],
                         'autoscale' => [
                             'desired_size' => 10,
                             'max' => 20,
@@ -310,7 +310,7 @@ class ConfigurationTest extends TestCase
                     ],
                     [
                         'transports' => ['prio_high'],
-                        'options' => ['--sleep=5', '--time-limit=60'],
+                        'options' => ['--sleep=5', '--time-limit=56'],
                         'autoscale' => [
                             'desired_size' => 5,
                             'max' => 30,
@@ -334,7 +334,7 @@ class ConfigurationTest extends TestCase
                         'workers' => [
                             [
                                 'transports' => ['prio_normal'],
-                                'options' => ['--sleep=10', '--time-limit=60'],
+                                'options' => ['--sleep=10', '--time-limit=56'],
                                 'autoscale' => [
                                     'enabled' => true,
                                 ],
@@ -357,7 +357,7 @@ class ConfigurationTest extends TestCase
                         'workers' => [
                             [
                                 'transports' => ['prio_normal'],
-                                'options' => ['--sleep=10', '--time-limit=60'],
+                                'options' => ['--sleep=10', '--time-limit=56'],
                                 'autoscale' => [
                                     'enabled' => true,
                                     'desired_size' => 10,

--- a/manager-bundle/skeleton/config/config.yaml
+++ b/manager-bundle/skeleton/config/config.yaml
@@ -70,7 +70,7 @@ contao:
                 transports:
                     - contao_prio_high
                 options:
-                    - --time-limit=56
+                    - --time-limit=55
                     - --sleep=5
                 autoscale:
                     desired_size: 5
@@ -79,7 +79,7 @@ contao:
                 transports:
                     - contao_prio_normal
                 options:
-                    - --time-limit=56
+                    - --time-limit=55
                     - --sleep=10
                 autoscale:
                     desired_size: 10
@@ -88,7 +88,7 @@ contao:
                 transports:
                     - contao_prio_low
                 options:
-                    - --time-limit=56
+                    - --time-limit=55
                     - --sleep=20
                 autoscale:
                     desired_size: 20

--- a/manager-bundle/skeleton/config/config.yaml
+++ b/manager-bundle/skeleton/config/config.yaml
@@ -70,7 +70,7 @@ contao:
                 transports:
                     - contao_prio_high
                 options:
-                    - --time-limit=60
+                    - --time-limit=56
                     - --sleep=5
                 autoscale:
                     desired_size: 5
@@ -79,7 +79,7 @@ contao:
                 transports:
                     - contao_prio_normal
                 options:
-                    - --time-limit=60
+                    - --time-limit=56
                     - --sleep=10
                 autoscale:
                     desired_size: 10
@@ -88,7 +88,7 @@ contao:
                 transports:
                     - contao_prio_low
                 options:
-                    - --time-limit=60
+                    - --time-limit=56
                     - --sleep=20
                 autoscale:
                     desired_size: 20


### PR DESCRIPTION
Fixes #9404

With the changes of https://github.com/symfony/symfony/pull/64084, https://github.com/symfony/symfony/pull/64086 & https://github.com/Toflar/cronjob-supervisor/pull/18 the total execution time of `contao:cron` can finally be brought to under 60000ms, _if_ you are allowed to lower the `--time-limit` for each `messenger:consume` command for our workers.

This PR changes the validation accordingly - but also sets the default to 56 seconds. The latter is super arbitrary - as this is the value that brings down the total execution time of `contao:cron` to just under 60000ms on _my local system_. Depending on the environment you can do with more - or you might even need less.

But if preferred, we can also leave the default at `60` (or `59` because due to overhead the total execution time will never be exactly 59999ms) - and if you care about the total execution time of `contao:cron` (due to #9404) then you could at least adjust the workers now. @contao/developers wdyt?