### PR TITLE
Fix the cancel URL in 2FA elements

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/two_factor.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/two_factor.html.twig
@@ -28,7 +28,7 @@
                 </div>
                 <div class="submit_container">
                     <button type="submit" class="submit">{{ 'MSC.enable'|trans }}</button>
-                    <a href="{{ content_url(target_page) }}" class="submit">{{ 'MSC.cancelBT'|trans }}</a>
+                    <a href="{{ content_url(contao.page) }}" class="submit">{{ 'MSC.cancelBT'|trans }}</a>
                 </div>
             </div>
         </form>

--- a/core-bundle/src/Controller/ContentElement/TwoFactorController.php
+++ b/core-bundle/src/Controller/ContentElement/TwoFactorController.php
@@ -110,7 +110,7 @@ class TwoFactorController extends AbstractContentElementController
         $template->set('enforce_two_factor', $pageModel->enforceTwoFactor);
         $template->set('show_backup_codes', $showBackupCodes);
         $template->set('trusted_devices', $this->trustedDeviceManager->getTrustedDevices($user));
-        $template->set('enable_url', $this->generateContentUrl($pageModel, [], UrlGeneratorInterface::ABSOLUTE_URL).'?2fa=enable');
+        $template->set('enable_url', $this->generateContentUrl($pageModel, ['2fa' => 'enable'], UrlGeneratorInterface::ABSOLUTE_URL));
         $template->set('target_page', $targetPage);
 
         return $template->getResponse();

--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -69,12 +69,8 @@ class TwoFactorController extends AbstractFrontendModuleController
 
         $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY', null, 'Full authentication is required to configure the two-factor authentication.');
 
-        $adapter = $this->getContaoAdapter(PageModel::class);
-        $redirectPage = $model->jumpTo > 0 ? $adapter->findById($model->jumpTo) : null;
-        $return = $this->generateContentUrl($redirectPage instanceof PageModel ? $redirectPage : $pageModel, [], UrlGeneratorInterface::ABSOLUTE_URL);
-
         $template->enforceTwoFactor = $pageModel->enforceTwoFactor;
-        $template->targetPath = $return;
+        $template->targetPath = $this->generateContentUrl($pageModel);
 
         $translator = $this->container->get('translator');
 
@@ -83,14 +79,20 @@ class TwoFactorController extends AbstractFrontendModuleController
             $template->message = $translator->trans('MSC.twoFactorEnforced', [], 'contao_default');
         }
 
-        $enable = 'enable' === $request->get('2fa');
+        $enable = 'enable' === $request->query->get('2fa');
 
         if (!$user->useTwoFactor && $pageModel->enforceTwoFactor) {
             $enable = true;
         }
 
-        if ($enable && ($response = $this->enableTwoFactor($template, $request, $user, $return))) {
-            return $response;
+        if ($enable) {
+            $adapter = $this->getContaoAdapter(PageModel::class);
+            $redirectPage = $model->jumpTo > 0 ? $adapter->findById($model->jumpTo) : null;
+            $return = $this->generateContentUrl($redirectPage instanceof PageModel ? $redirectPage : $pageModel, [], UrlGeneratorInterface::ABSOLUTE_URL);
+
+            if ($response = $this->enableTwoFactor($template, $request, $user, $return)) {
+                return $response;
+            }
         }
 
         $formId = $request->request->get('FORM_SUBMIT');
@@ -115,7 +117,7 @@ class TwoFactorController extends AbstractFrontendModuleController
         }
 
         $template->isEnabled = (bool) $user->useTwoFactor;
-        $template->href = $this->generateContentUrl($pageModel, [], UrlGeneratorInterface::ABSOLUTE_URL).'?2fa=enable';
+        $template->href = $this->generateContentUrl($pageModel, ['2fa' => 'enable'], UrlGeneratorInterface::ABSOLUTE_URL);
         $template->trustedDevices = $this->container->get('contao.security.two_factor.trusted_device_manager')->getTrustedDevices($user);
 
         return $template->getResponse();

--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -242,7 +242,7 @@ class TwoFactorControllerTest extends TestCase
 
         $request = new Request();
         $request->attributes->set('pageModel', $page);
-        $request->request->set('2fa', 'enable');
+        $request->query->set('2fa', 'enable');
 
         $container
             ->get('contao.routing.content_url_generator')
@@ -272,9 +272,9 @@ class TwoFactorControllerTest extends TestCase
 
         $urlGenerator = $this->createMock(ContentUrlGenerator::class);
         $urlGenerator
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('generate')
-            ->with($page, [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->with($page)
             ->willReturn('https://localhost.wip/foobar')
         ;
 
@@ -287,7 +287,7 @@ class TwoFactorControllerTest extends TestCase
 
         $request = new Request();
         $request->attributes->set('pageModel', $page);
-        $request->request->set('2fa', 'enable');
+        $request->query->set('2fa', 'enable');
 
         $controller($request, $module, 'main');
     }
@@ -309,9 +309,9 @@ class TwoFactorControllerTest extends TestCase
 
         $urlGenerator = $this->createMock(ContentUrlGenerator::class);
         $urlGenerator
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('generate')
-            ->with($page, [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->with($page)
             ->willReturn('https://localhost.wip/foobar')
         ;
 
@@ -324,7 +324,7 @@ class TwoFactorControllerTest extends TestCase
 
         $request = new Request();
         $request->attributes->set('pageModel', $page);
-        $request->request->set('2fa', 'enable');
+        $request->query->set('2fa', 'enable');
         $request->request->set('FORM_SUBMIT', 'tl_two_factor');
         $request->request->set('verify', '123456');
 
@@ -353,9 +353,9 @@ class TwoFactorControllerTest extends TestCase
 
         $urlGenerator = $this->createMock(ContentUrlGenerator::class);
         $urlGenerator
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('generate')
-            ->with($page, [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->with($page)
             ->willReturn('https://localhost.wip/foobar')
         ;
 
@@ -368,7 +368,7 @@ class TwoFactorControllerTest extends TestCase
 
         $request = new Request();
         $request->attributes->set('pageModel', $page);
-        $request->request->set('2fa', 'enable');
+        $request->query->set('2fa', 'enable');
         $request->request->set('FORM_SUBMIT', 'tl_two_factor');
         $request->request->set('verify', '123456');
 

--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -32,7 +32,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;


### PR DESCRIPTION
The 2FA module currently displays a message and a "enable" button if you open it initially. By clicking "enable", you'll get a form with the QR code, an "activate" button and a "cancel" button. Both of those buttons will redirect you to the configured target page. I don't think that makes sense, when I cancel, I want to return back to the "enable" button and message.

Additionaly improved generating query parameters in a page URL.