### PR TITLE
Support searching and filtering virtual fields in `DC_Table`

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -5358,9 +5358,13 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			return Database::quoteIdentifier($field);
 		}
 
-		$path = '$."' . str_replace(array('\\', '"'), array('\\\\', '\\"'), $field) . '"';
+		$path = System::getContainer()
+			->get('database_connection')
+			->getDatabasePlatform()
+			->quoteStringLiteral('$.' . json_encode($field, JSON_THROW_ON_ERROR))
+		;
 
-		return "JSON_UNQUOTE(JSON_EXTRACT(" . Database::quoteIdentifier($virtualFields[$field]) . ", '" . $path . "'))";
+		return "JSON_UNQUOTE(JSON_EXTRACT(" . Database::quoteIdentifier($virtualFields[$field]) . ", " . $path . '))';
 	}
 
 	/**

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4721,6 +4721,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 
 			$strPattern = "$strReplacePrefix LOWER(CAST(%s AS CHAR)) $strReplaceSuffix REGEXP LOWER(?)";
+			$searchField = $this->getFilterFieldExpression($fld);
 
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']))
 			{
@@ -4729,12 +4730,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				$fkField = Database::quoteIdentifier($fkField);
 
 				$fk = System::getContainer()->get('contao.data_container.foreign_key_parser')->parse($GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']);
-				$this->procedure[] = "(" . \sprintf($strPattern, Database::quoteIdentifier($fld)) . " OR " . \sprintf($strPattern, "(SELECT " . $fk->getColumnExpression() . " FROM " . $fk->getTableName() . " WHERE " . $fk->getTableName() . ".$fkField=" . $this->strTable . "." . Database::quoteIdentifier($fld) . ")") . ")";
+				$this->procedure[] = "(" . \sprintf($strPattern, $searchField) . " OR " . \sprintf($strPattern, "(SELECT " . $fk->getColumnExpression() . " FROM " . $fk->getTableName() . " WHERE " . $fk->getTableName() . ".$fkField=" . $this->strTable . "." . Database::quoteIdentifier($fld) . ")") . ")";
 				$this->values[] = $searchValue;
 			}
 			else
 			{
-				$this->procedure[] = \sprintf($strPattern, Database::quoteIdentifier($fld));
+				$this->procedure[] = \sprintf($strPattern, $searchField);
 			}
 
 			$this->values[] = $searchValue;
@@ -5129,7 +5130,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		{
 			foreach ($sortingFields as $field)
 			{
-				$what = Database::quoteIdentifier($field);
+				$what = $this->getFilterFieldExpression($field);
 
 				if (isset($session['filter'][$filter][$field]))
 				{
@@ -5187,7 +5188,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						// CSV lists (see #2890)
 						if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['csv']))
 						{
-							$this->procedure[] = $db->findInSet('?', $field, true);
+							$this->procedure[] = "FIND_IN_SET(?, $what)";
 							$this->values[] = $session['filter'][$filter][$field];
 						}
 						else
@@ -5249,7 +5250,8 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				$arrValues[] = $this->ptable;
 			}
 
-			$what = Database::quoteIdentifier($field);
+			$what = $this->getFilterFieldExpression($field);
+			$whatWithAlias = $what . ' AS ' . Database::quoteIdentifier($field);
 
 			// Optimize the SQL query (see #8485)
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag']))
@@ -5257,19 +5259,19 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				// Sort by day
 				if (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(self::SORT_DAY_ASC, self::SORT_DAY_DESC, self::SORT_DAY_BOTH)))
 				{
-					$what = "IF($what!='', FLOOR(UNIX_TIMESTAMP(FROM_UNIXTIME($what , '%Y-%m-%d'))), '') AS $what";
+					$whatWithAlias = "IF($what!='', FLOOR(UNIX_TIMESTAMP(FROM_UNIXTIME($what , '%Y-%m-%d'))), '') AS " . Database::quoteIdentifier($field);
 				}
 
 				// Sort by month
 				elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(self::SORT_MONTH_ASC, self::SORT_MONTH_DESC, self::SORT_MONTH_BOTH)))
 				{
-					$what = "IF($what!='', FLOOR(UNIX_TIMESTAMP(FROM_UNIXTIME($what , '%Y-%m-01'))), '') AS $what";
+					$whatWithAlias = "IF($what!='', FLOOR(UNIX_TIMESTAMP(FROM_UNIXTIME($what , '%Y-%m-01'))), '') AS " . Database::quoteIdentifier($field);
 				}
 
 				// Sort by year
 				elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(self::SORT_YEAR_ASC, self::SORT_YEAR_DESC, self::SORT_YEAR_BOTH)))
 				{
-					$what = "IF($what!='', FLOOR(UNIX_TIMESTAMP(FROM_UNIXTIME($what , '%Y-01-01'))), '') AS $what";
+					$whatWithAlias = "IF($what!='', FLOOR(UNIX_TIMESTAMP(FROM_UNIXTIME($what , '%Y-01-01'))), '') AS " . Database::quoteIdentifier($field);
 				}
 			}
 
@@ -5297,7 +5299,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 
 			$objFields = $db
-				->prepare("SELECT DISTINCT " . $what . " FROM " . $this->strTable . ((\is_array($arrProcedure) && isset($arrProcedure[0])) ? ' WHERE ' . implode(' AND ', $arrProcedure) : ''))
+				->prepare("SELECT DISTINCT " . $whatWithAlias . " FROM " . $this->strTable . ((\is_array($arrProcedure) && isset($arrProcedure[0])) ? ' WHERE ' . implode(' AND ', $arrProcedure) : ''))
 				->execute(...$arrValues);
 
 			$active = isset($session['filter'][$filter][$field]);
@@ -5341,6 +5343,24 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				'filters' => $filters,
 			))
 		;
+	}
+
+	/**
+	 * Returns the SQL expression used for search and filter operations.
+	 * Supports regular columns and JSON searching in virtual fields.
+	 */
+	private function getFilterFieldExpression(string $field): string
+	{
+		$virtualFields = DcaExtractor::getInstance($this->strTable)->getVirtualFields();
+
+		if (!isset($virtualFields[$field]))
+		{
+			return Database::quoteIdentifier($field);
+		}
+
+		$path = '$."' . str_replace(array('\\', '"'), array('\\\\', '\\"'), $field) . '"';
+
+		return "JSON_UNQUOTE(JSON_EXTRACT(" . Database::quoteIdentifier($virtualFields[$field]) . ", '" . $path . "'))";
 	}
 
 	/**

--- a/core-bundle/contao/library/Contao/DcaExtractor.php
+++ b/core-bundle/contao/library/Contao/DcaExtractor.php
@@ -412,6 +412,7 @@ class DcaExtractor extends Controller
 		}
 
 		$arrRelations = array();
+		$supportsVirtualFieldSearchAndFilter = is_a(DataContainer::getDriverForTable($this->strTable), DC_Table::class, true);
 
 		// Check whether there are fields (see #4826)
 		if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields']))
@@ -470,12 +471,12 @@ class DcaExtractor extends Controller
 				}
 
 				// Validate the config for virtual fields
-				if ($config['filter'] ?? false)
+				if (($config['filter'] ?? false) && !$supportsVirtualFieldSearchAndFilter)
 				{
 					throw new InvalidConfigException(\sprintf('Enabling "filter" on virtual field %s.%s is not supported.', $this->strTable, $field));
 				}
 
-				if ($config['search'] ?? false)
+				if (($config['search'] ?? false) && !$supportsVirtualFieldSearchAndFilter)
 				{
 					throw new InvalidConfigException(\sprintf('Enabling "search" on virtual field %s.%s is not supported.', $this->strTable, $field));
 				}

--- a/core-bundle/contao/library/Contao/DcaExtractor.php
+++ b/core-bundle/contao/library/Contao/DcaExtractor.php
@@ -412,7 +412,6 @@ class DcaExtractor extends Controller
 		}
 
 		$arrRelations = array();
-		$supportsVirtualFieldSearchAndFilter = is_a(DataContainer::getDriverForTable($this->strTable), DC_Table::class, true);
 
 		// Check whether there are fields (see #4826)
 		if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields']))
@@ -468,17 +467,6 @@ class DcaExtractor extends Controller
 				if (!\in_array($config['targetColumn'], $this->arrVirtualTargets, true))
 				{
 					throw new InvalidConfigException(\sprintf('The target column of the virtual field %s.%s does not exist.', $this->strTable, $field));
-				}
-
-				// Validate the config for virtual fields
-				if (($config['filter'] ?? false) && !$supportsVirtualFieldSearchAndFilter)
-				{
-					throw new InvalidConfigException(\sprintf('Enabling "filter" on virtual field %s.%s is not supported.', $this->strTable, $field));
-				}
-
-				if (($config['search'] ?? false) && !$supportsVirtualFieldSearchAndFilter)
-				{
-					throw new InvalidConfigException(\sprintf('Enabling "search" on virtual field %s.%s is not supported.', $this->strTable, $field));
 				}
 
 				if ($config['eval']['fallback'] ?? false)


### PR DESCRIPTION
It had to happen of course: Built a small feature for a customer 2 months ago using the new virtual fields. Now they asked why they cannot search/filter for that. I had two options: 

- Either make the virtual column a real one and write a migration that would migrate the data from the JSON field back to a real column and enable search and filter or
- see how complex it would really be to implement support for that in `DC_Table`.

So I gave this a quick shot and it actually turned out to be pretty simple 😇 
Remarks:

- ~~Limited this to `DC_Table` (and derivatives) only for now~~
- Yes, `JSON_UNQUOTE` and `JSON_EXTRACT` are supported in our minimum required MySQL version 5.7 (or equivalent MariaDB version as per our docs)
- The changes of `$db->findInSet('?', $field, true);` to `"FIND_IN_SET(?, $what)";` are intentional because the parameter is already quoted and there's no need to use this little helper function.

Technically a feature so not sure what to do with it. I'd be happy to have this merged as is into 5.7 but if we want to make the devs wait for 6.x, we can also do that - up to @contao/developers.