### PR TITLE
Support content elements in the root-page-dependent frontend module

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -738,6 +738,7 @@ services:
             - '@database_connection'
             - '@router'
             - '@translator'
+            - '@contao.data_container.record_labeler'
 
     contao.listener.widget.title_tag:
         class: Contao\CoreBundle\EventListener\Widget\TitleTagListener

--- a/core-bundle/contao/widgets/RootPageDependentSelect.php
+++ b/core-bundle/contao/widgets/RootPageDependentSelect.php
@@ -33,8 +33,9 @@ class RootPageDependentSelect extends SelectMenu
 			$this->strLabel = $rootPage->title;
 
 			$fields[] = \sprintf(
-				'<div class="tl_select_wrapper" data-controller="contao--choices"><select name="%s[]" id="ctrl_%s" class="tl_select%s"%s data-action="focus->contao--scroll-offset#store">%s</select></div>%s',
+				'<div class="tl_select_wrapper" data-controller="contao--choices"><select name="%s[%s]" id="ctrl_%s" class="tl_select%s"%s data-action="focus->contao--scroll-offset#store">%s</select></div>%s',
 				$this->strName,
+				$rootPage->id,
 				\sprintf('%s-%s', $this->strId, $rootPage->id),
 				$this->strClass ? ' ' . $this->strClass : '',
 				$this->getAttributes(),

--- a/core-bundle/contao/widgets/RootPageDependentSelect.php
+++ b/core-bundle/contao/widgets/RootPageDependentSelect.php
@@ -62,12 +62,12 @@ class RootPageDependentSelect extends SelectMenu
 	{
 		$options = array();
 
-		foreach ($this->arrOptions as $option)
+		foreach ($this->arrOptions as $key => $option)
 		{
-			$option['index'] = $rootPage->id;
-
 			if (isset($option['value']))
 			{
+				$option['index'] = $rootPage->id;
+
 				if ($this->isSelected($option))
 				{
 					$option['label'] = \sprintf(
@@ -83,6 +83,33 @@ class RootPageDependentSelect extends SelectMenu
 					$this->isSelected($option),
 					$option['label']
 				);
+			}
+			else
+			{
+				$optgroups = array();
+
+				foreach ($option as $optgroup)
+				{
+					$optgroup['index'] = $rootPage->id;
+
+					if ($this->isSelected($optgroup))
+					{
+						$optgroup['label'] = \sprintf(
+							'%s <span class="label-info">[%s]</span>',
+							$optgroup['label'],
+							$rootPage->title,
+						);
+					}
+
+					$optgroups[] = \sprintf(
+						'<option value="%s"%s>%s</option>',
+						self::specialcharsValue($optgroup['value']),
+						$this->isSelected($optgroup),
+						$optgroup['label']
+					);
+				}
+
+				$options[] = \sprintf('<optgroup label="%s">%s</optgroup>', StringUtil::specialchars($key), implode('', $optgroups));
 			}
 		}
 

--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -12,12 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Controller\FrontendModule;
 
+use Contao\ContentModel;
 use Contao\Controller;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsFrontendModule;
-use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\ModuleModel;
 use Contao\StringUtil;
-use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -26,7 +26,7 @@ class RootPageDependentModulesController extends AbstractFrontendModuleControlle
 {
     public function __invoke(Request $request, ModuleModel $model, string $section, array|null $classes = null): Response
     {
-        if ($this->container->get('contao.routing.scope_matcher')->isBackendRequest($request)) {
+        if ($this->isBackendScope($request)) {
             return $this->getBackendWildcard($model);
         }
 
@@ -34,21 +34,22 @@ class RootPageDependentModulesController extends AbstractFrontendModuleControlle
             return new Response();
         }
 
-        $modules = StringUtil::deserialize($model->rootPageDependentModules, true);
+        $elements = StringUtil::deserialize($model->rootPageDependentModules, true);
+        $id = $elements[$pageModel->rootId] ?? null;
 
-        if (empty($modules[$pageModel->rootId])) {
+        if (!$id) {
             return new Response();
         }
 
-        /** @var ContaoFramework $framework */
-        $framework = $this->container->get('contao.framework');
-        $moduleModel = $framework->getAdapter(ModuleModel::class);
+        if ($isElement = str_starts_with($id, 'content-')) {
+            $id = substr($id, 8);
+        }
 
-        if (!$module = $moduleModel->findById($modules[$pageModel->rootId])) {
+        if (!$contentModel = $this->getContaoAdapter($isElement ? ContentModel::class : ModuleModel::class)->findById($id)) {
             return new Response();
         }
 
-        $cssID = StringUtil::deserialize($module->cssID, true);
+        $cssID = StringUtil::deserialize($contentModel->cssID, true);
 
         if ($idAttribute = $request->attributes->get('templateProperties', [])['cssID'] ?? null) {
             $cssID[0] = substr($idAttribute, 5, -1);
@@ -56,17 +57,17 @@ class RootPageDependentModulesController extends AbstractFrontendModuleControlle
 
         $cssID[1] = trim(\sprintf('%s %s', $cssID[1] ?? '', implode(' ', (array) $model->classes)));
 
-        $module->cssID = $cssID;
+        $contentModel->cssID = $cssID;
 
-        $controller = $framework->getAdapter(Controller::class);
-        $content = $controller->getFrontendModule($module);
+        $controller = $this->getContaoAdapter(Controller::class);
+        $content = $isElement ? $controller->getContentElement($contentModel) : $controller->getFrontendModule($contentModel);
 
         $this->tagResponse($model);
 
         return new Response($content);
     }
 
-    public function getResponse(Template $template, ModuleModel $model, Request $request): Response
+    public function getResponse(FragmentTemplate $template, ModuleModel $model, Request $request): Response
     {
         throw new \LogicException('This method should never be called');
     }

--- a/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
+++ b/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
@@ -74,25 +74,6 @@ class RootPageDependentSelectListener
         return $options;
     }
 
-    #[AsCallback(table: 'tl_module', target: 'fields.rootPageDependentModules.save')]
-    public function saveCallback(mixed $value): string
-    {
-        $values = StringUtil::deserialize($value);
-
-        if (!\is_array($values)) {
-            return $value;
-        }
-
-        $newValues = [];
-        $availableRootPages = array_keys($this->getRootPages());
-
-        foreach ($values as $v) {
-            $newValues[array_shift($availableRootPages)] = $v;
-        }
-
-        return serialize($newValues);
-    }
-
     #[AsCallback(table: 'tl_module', target: 'fields.rootPageDependentModules.wizard')]
     public function wizardCallback(DataContainer $dc): string
     {
@@ -127,29 +108,5 @@ class RootPageDependentSelectListener
         }
 
         return serialize($wizards);
-    }
-
-    private function getRootPages(): array
-    {
-        $statement = $this->connection->prepare(
-            <<<'SQL'
-                SELECT
-                    p.id,
-                    p.title,
-                    p.language
-                FROM tl_page p
-                WHERE p.pid = 0
-                ORDER BY p.sorting ASC
-                SQL,
-        );
-
-        $rows = $statement->executeQuery();
-        $pages = [];
-
-        foreach ($rows->iterateAssociative() as $rootPage) {
-            $pages[$rootPage['id']] = \sprintf('%s (%s)', $rootPage['title'], $rootPage['language']);
-        }
-
-        return $pages;
     }
 }

--- a/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
+++ b/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
@@ -50,7 +50,7 @@ class RootPageDependentSelectListener
         $moduleGroup = $this->translator->trans('MSC.mw_modules', [], 'contao_default');
 
         $elements = $this->connection->executeQuery(
-            "SELECT * FROM tl_content WHERE ptable='tl_theme' AND pid=(SELECT pid FROM tl_module WHERE id=?)",
+            "SELECT * FROM tl_content WHERE ptable='tl_theme' AND pid=?",
             [$pid],
         );
 

--- a/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
+++ b/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\Widget;
 
+use Contao\CoreBundle\DataContainer\RecordLabeler;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Contao\Image;
@@ -29,6 +30,7 @@ class RootPageDependentSelectListener
         private readonly Connection $connection,
         private readonly UrlGeneratorInterface $router,
         private readonly TranslatorInterface $translator,
+        private readonly RecordLabeler $recordLabeler,
     ) {
     }
 
@@ -44,27 +46,29 @@ class RootPageDependentSelectListener
             return [];
         }
 
-        $rows = $this->connection->executeQuery(
-            <<<'SQL'
-                SELECT
-                    m.id,
-                    m.name,
-                    m.type
-                FROM tl_module m
-                WHERE
-                    m.type != 'root_page_dependent_modules'
-                    AND m.pid = ?
-                ORDER BY m.name
-                SQL,
+        $elementGroup = $this->translator->trans('MSC.mw_elements', [], 'contao_default');
+        $moduleGroup = $this->translator->trans('MSC.mw_modules', [], 'contao_default');
+
+        $elements = $this->connection->executeQuery(
+            "SELECT * FROM tl_content WHERE ptable='tl_theme' AND pid=(SELECT pid FROM tl_module WHERE id=?)",
             [$pid],
         );
 
-        foreach ($rows->iterateAssociative() as $module) {
+        foreach ($elements->iterateAssociative() as $element) {
+            $options[$elementGroup]['content-'.$element['id']] = $this->recordLabeler->getLabel('contao.db.tl_content.'.$element['id'], $element);
+        }
+
+        $modules = $this->connection->executeQuery(
+            'SELECT m.id, m.name, m.type FROM tl_module m WHERE m.type != \'root_page_dependent_modules\' AND m.pid = ? ORDER BY m.name',
+            [$pid],
+        );
+
+        foreach ($modules->iterateAssociative() as $module) {
             if ($hasTypes && !\in_array($module['type'], $types, true)) {
                 continue;
             }
 
-            $options[$module['id']] = $module['name'];
+            $options[$moduleGroup][$module['id']] = $module['name'];
         }
 
         return $options;
@@ -104,8 +108,15 @@ class RootPageDependentSelectListener
                 continue;
             }
 
+            $table = 'tl_module';
+
+            if (str_starts_with($id, 'content-')) {
+                $table = 'tl_content';
+                $id = substr($id, 8);
+            }
+
             $title = $this->translator->trans('tl_content.editalias', [$id], 'contao_content');
-            $href = $this->router->generate('contao_backend', ['do' => 'themes', 'table' => 'tl_module', 'act' => 'edit', 'id' => $id, 'popup' => '1', 'nb' => '1']);
+            $href = $this->router->generate('contao_backend', ['do' => 'themes', 'table' => $table, 'act' => 'edit', 'id' => $id, 'popup' => '1', 'nb' => '1']);
 
             $wizards[$rootPage] = \sprintf(
                 ' <a href="%s" onclick="Backend.openModalIframe({\'title\':\'%s\',\'url\':this.href});return false">%s</a>',

--- a/core-bundle/tests/Contao/RootPageDependentSelectTest.php
+++ b/core-bundle/tests/Contao/RootPageDependentSelectTest.php
@@ -84,7 +84,7 @@ class RootPageDependentSelectTest extends TestCase
         $expectedOutput = <<<'OUTPUT'
             <div class="tl_select_wrapper" data-controller="contao--choices">
                 <select
-                    name="rootPageDependentModules[]"
+                    name="rootPageDependentModules[1]"
                     id="ctrl_rootPageDependentModules-1"
                     class="tl_select"
                     data-action="focus->contao--scroll-offset#store">
@@ -96,7 +96,7 @@ class RootPageDependentSelectTest extends TestCase
             </div>
             <div class="tl_select_wrapper" data-controller="contao--choices">
                 <select
-                    name="rootPageDependentModules[]"
+                    name="rootPageDependentModules[2]"
                     id="ctrl_rootPageDependentModules-2"
                     class="tl_select"
                     data-action="focus->contao--scroll-offset#store">
@@ -108,7 +108,7 @@ class RootPageDependentSelectTest extends TestCase
             </div>
             <div class="tl_select_wrapper" data-controller="contao--choices">
                 <select
-                    name="rootPageDependentModules[]"
+                    name="rootPageDependentModules[3]"
                     id="ctrl_rootPageDependentModules-3"
                     class="tl_select"
                     data-action="focus->contao--scroll-offset#store">
@@ -116,6 +116,125 @@ class RootPageDependentSelectTest extends TestCase
                     <option value="10">Module-10</option>
                     <option value="20">Module-20</option>
                     <option value="30">Module-30</option>
+                </select>
+            </div>
+            OUTPUT;
+
+        $minifiedExpectedOutput = preg_replace(['/\s\s|\n/', '/\s</'], ['', '<'], $expectedOutput);
+
+        $this->assertSame($minifiedExpectedOutput, $widget->generate());
+    }
+
+    public function testRendersMultipleSelectsWithContentElements(): void
+    {
+        $rootPages = [
+            $this->mockPageModel(['id' => 1, 'title' => 'Root Page 1', 'language' => 'en']),
+            $this->mockPageModel(['id' => 2, 'title' => 'Root Page 2', 'language' => 'de']),
+            $this->mockPageModel(['id' => 3, 'title' => 'Root Page 3', 'language' => 'fr']),
+        ];
+
+        $pageAdapter = $this->createAdapterMock(['findByType']);
+        $pageAdapter
+            ->expects($this->once())
+            ->method('findByType')
+            ->with('root', ['order' => 'sorting'])
+            ->willReturn(new Collection($rootPages, 'tl_page'))
+        ;
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->expects($this->once())
+            ->method('trans')
+            ->with('tl_module.rootPageDependentModulesBlankOptionLabel', [], 'contao_tl_module')
+            ->willReturn('Choose module for "%s"')
+        ;
+
+        $requestStack = new RequestStack([new Request()]);
+
+        $container = $this->getContainerWithContaoConfiguration();
+        $container->set('contao.framework', $this->createContaoFrameworkStub([PageModel::class => $pageAdapter]));
+        $container->set('translator', $translator);
+        $container->set('request_stack', $requestStack);
+
+        System::setContainer($container);
+
+        $fieldConfig = [
+            'name' => 'rootPageDependentModules',
+            'options' => [
+                'MSC.mw_elements' => [
+                    'content-10' => 'Element-10',
+                    'content-20' => 'Element-20',
+                    'content-30' => 'Element-30',
+                ],
+                'MSC.mw_modules' => [
+                    '10' => 'Module-10',
+                    '20' => 'Module-20',
+                    '30' => 'Module-30',
+                ],
+            ],
+            'eval' => [
+                'includeBlankOption' => true,
+            ],
+        ];
+
+        $widget = new RootPageDependentSelect(RootPageDependentSelect::getAttributesFromDca($fieldConfig, $fieldConfig['name']));
+
+        $expectedOutput = <<<'OUTPUT'
+            <div class="tl_select_wrapper" data-controller="contao--choices">
+                <select
+                    name="rootPageDependentModules[1]"
+                    id="ctrl_rootPageDependentModules-1"
+                    class="tl_select"
+                    data-action="focus->contao--scroll-offset#store">
+                    <option value="">Choose module for "Root Page 1"</option>
+                    <optgroup label="MSC.mw_elements">
+                        <option value="content-10">Element-10</option>
+                        <option value="content-20">Element-20</option>
+                        <option value="content-30">Element-30</option>
+                    </optgroup>
+                    <optgroup label="MSC.mw_modules">
+                        <option value="10">Module-10</option>
+                        <option value="20">Module-20</option>
+                        <option value="30">Module-30</option>
+                    </optgroup>
+                </select>
+            </div>
+            <div class="tl_select_wrapper" data-controller="contao--choices">
+                <select
+                    name="rootPageDependentModules[2]"
+                    id="ctrl_rootPageDependentModules-2"
+                    class="tl_select"
+                    data-action="focus->contao--scroll-offset#store">
+                    <option value="">Choose module for "Root Page 2"</option>
+                    <optgroup label="MSC.mw_elements">
+                        <option value="content-10">Element-10</option>
+                        <option value="content-20">Element-20</option>
+                        <option value="content-30">Element-30</option>
+                    </optgroup>
+                    <optgroup label="MSC.mw_modules">
+                        <option value="10">Module-10</option>
+                        <option value="20">Module-20</option>
+                        <option value="30">Module-30</option>
+                    </optgroup>
+                </select>
+            </div>
+            <div class="tl_select_wrapper" data-controller="contao--choices">
+                <select
+                    name="rootPageDependentModules[3]"
+                    id="ctrl_rootPageDependentModules-3"
+                    class="tl_select"
+                    data-action="focus->contao--scroll-offset#store">
+                    <option value="">Choose module for "Root Page 3"</option>
+                    <optgroup label="MSC.mw_elements">
+                        <option value="content-10">Element-10</option>
+                        <option value="content-20">Element-20</option>
+                        <option value="content-30">Element-30</option>
+                    </optgroup>
+                    <optgroup label="MSC.mw_modules">
+                        <option value="10">Module-10</option>
+                        <option value="20">Module-20</option>
+                        <option value="30">Module-30</option>
+                    </optgroup>
                 </select>
             </div>
             OUTPUT;

--- a/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 
 class RootPageDependentModulesControllerTest extends TestCase
@@ -110,7 +111,7 @@ class RootPageDependentModulesControllerTest extends TestCase
         $this->expectException(\LogicException::class);
 
         $controller->getResponse(
-            new FragmentTemplate('', static fn () => ''),
+            new FragmentTemplate('', static fn () => new Response()),
             $this->createStub(ModuleModel::class),
             new Request(),
         );

--- a/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
@@ -18,10 +18,10 @@ use Contao\CoreBundle\Cache\CacheTagManager;
 use Contao\CoreBundle\Controller\FrontendModule\RootPageDependentModulesController;
 use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\ModuleModel;
 use Contao\PageModel;
 use Contao\System;
-use Contao\Template;
 use Contao\TemplateLoader;
 use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -110,7 +110,7 @@ class RootPageDependentModulesControllerTest extends TestCase
         $this->expectException(\LogicException::class);
 
         $controller->getResponse(
-            $this->createStub(Template::class),
+            new FragmentTemplate('', static fn () => ''),
             $this->createStub(ModuleModel::class),
             new Request(),
         );

--- a/core-bundle/tests/EventListener/Widget/RootPageDependentSelectListenerTest.php
+++ b/core-bundle/tests/EventListener/Widget/RootPageDependentSelectListenerTest.php
@@ -77,37 +77,6 @@ class RootPageDependentSelectListenerTest extends TestCase
         $this->assertCount(3, unserialize($listener->wizardCallback($dataContainer)));
     }
 
-    public function testDoesNotSaveUnserializableData(): void
-    {
-        $listener = new RootPageDependentSelectListener(
-            $this->createStub(Connection::class),
-            $this->createStub(UrlGeneratorInterface::class),
-            $this->createStub(TranslatorInterface::class),
-        );
-
-        $this->assertSame('foobar', $listener->saveCallback('foobar'));
-    }
-
-    public function testSavesValuesRelatedToRootPage(): void
-    {
-        $connection = $this->mockGetRootPages();
-
-        $listener = new RootPageDependentSelectListener(
-            $connection,
-            $this->createStub(UrlGeneratorInterface::class),
-            $this->createStub(TranslatorInterface::class),
-        );
-
-        $this->assertSame(
-            serialize([
-                1 => 10,
-                2 => 20,
-                3 => 30,
-            ]),
-            $listener->saveCallback(serialize([10, 20, 30])),
-        );
-    }
-
     public function testReturnsAllTypesOfModulesAsOption(): void
     {
         $this->populateGlobalsArray([]);

--- a/core-bundle/tests/EventListener/Widget/RootPageDependentSelectListenerTest.php
+++ b/core-bundle/tests/EventListener/Widget/RootPageDependentSelectListenerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener\Widget;
 
+use Contao\CoreBundle\DataContainer\RecordLabeler;
 use Contao\CoreBundle\EventListener\Widget\RootPageDependentSelectListener;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\DataContainer;
@@ -19,8 +20,8 @@ use Contao\Image;
 use Contao\System;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Result;
-use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -41,6 +42,7 @@ class RootPageDependentSelectListenerTest extends TestCase
             $this->createStub(Connection::class),
             $this->createStub(UrlGeneratorInterface::class),
             $this->createStub(TranslatorInterface::class),
+            $this->createStub(RecordLabeler::class),
         );
 
         $dataContainer = $this->createClassWithPropertiesStub(DataContainer::class);
@@ -64,6 +66,7 @@ class RootPageDependentSelectListenerTest extends TestCase
             $this->createStub(Connection::class),
             $this->createStub(UrlGeneratorInterface::class),
             $translator,
+            $this->createStub(RecordLabeler::class),
         );
 
         $dataContainer = $this->createClassWithPropertiesStub(DataContainer::class);
@@ -91,19 +94,79 @@ class RootPageDependentSelectListenerTest extends TestCase
             ->willReturn(['pid' => 1])
         ;
 
-        $connection = $this->mockGetModules();
+        $connection = $this->mockConnection([], [
+            ['id' => 10, 'name' => 'name-10', 'type' => 'foo'],
+            ['id' => 20, 'name' => 'name-20', 'type' => 'bar'],
+            ['id' => 30, 'name' => 'name-30', 'type' => 'baz'],
+        ]);
 
         $listener = new RootPageDependentSelectListener(
             $connection,
             $this->createStub(UrlGeneratorInterface::class),
-            $this->createStub(TranslatorInterface::class),
+            $this->createTranslatorStub(),
+            $this->createStub(RecordLabeler::class),
         );
 
         $this->assertSame(
             [
-                10 => 'name-10',
-                20 => 'name-20',
-                30 => 'name-30',
+                'MSC.mw_modules' => [
+                    10 => 'name-10',
+                    20 => 'name-20',
+                    30 => 'name-30',
+                ],
+            ],
+            $listener->optionsCallback($dataContainer),
+        );
+
+        $this->unsetGlobalsArray();
+    }
+
+    public function testReturnsElementsAndModulesAsOption(): void
+    {
+        $this->populateGlobalsArray([]);
+
+        $dataContainer = $this->createClassWithPropertiesMock(DataContainer::class);
+        $dataContainer->table = 'tl_module';
+        $dataContainer->field = 'field';
+
+        $dataContainer
+            ->expects($this->once())
+            ->method('getCurrentRecord')
+            ->willReturn(['pid' => 1])
+        ;
+
+        $connection = $this->mockConnection(
+            [
+                ['id' => 10, 'title' => 'title-10', 'type' => 'foo'],
+                ['id' => 20, 'title' => 'title-20', 'type' => 'bar'],
+                ['id' => 30, 'title' => 'title-30', 'type' => 'baz'],
+            ],
+            [
+                ['id' => 10, 'name' => 'name-10', 'type' => 'foo'],
+                ['id' => 20, 'name' => 'name-20', 'type' => 'bar'],
+                ['id' => 30, 'name' => 'name-30', 'type' => 'baz'],
+            ],
+        );
+
+        $listener = new RootPageDependentSelectListener(
+            $connection,
+            $this->createStub(UrlGeneratorInterface::class),
+            $this->createTranslatorStub(),
+            $this->createRecordLabelerStub(),
+        );
+
+        $this->assertSame(
+            [
+                'MSC.mw_elements' => [
+                    'content-10' => 'title-10',
+                    'content-20' => 'title-20',
+                    'content-30' => 'title-30',
+                ],
+                'MSC.mw_modules' => [
+                    10 => 'name-10',
+                    20 => 'name-20',
+                    30 => 'name-30',
+                ],
             ],
             $listener->optionsCallback($dataContainer),
         );
@@ -134,18 +197,25 @@ class RootPageDependentSelectListenerTest extends TestCase
             ->willReturn(['pid' => 1])
         ;
 
-        $connection = $this->mockGetModules();
+        $connection = $this->mockConnection([], [
+            ['id' => 10, 'name' => 'name-10', 'type' => 'foo'],
+            ['id' => 20, 'name' => 'name-20', 'type' => 'bar'],
+            ['id' => 30, 'name' => 'name-30', 'type' => 'baz'],
+        ]);
 
         $listener = new RootPageDependentSelectListener(
             $connection,
             $this->createStub(UrlGeneratorInterface::class),
-            $this->createStub(TranslatorInterface::class),
+            $this->createTranslatorStub(),
+            $this->createStub(RecordLabeler::class),
         );
 
         $this->assertSame(
             [
-                10 => 'name-10',
-                20 => 'name-20',
+                'MSC.mw_modules' => [
+                    10 => 'name-10',
+                    20 => 'name-20',
+                ],
             ],
             $listener->optionsCallback($dataContainer),
         );
@@ -163,56 +233,62 @@ class RootPageDependentSelectListenerTest extends TestCase
         unset($GLOBALS['TL_DCA']['tl_module']['fields']);
     }
 
-    private function mockGetRootPages(): Connection&MockObject
+    private function mockConnection(array $elements, array $modules): Connection&MockObject
     {
-        $result = $this->createMock(Result::class);
-        $result
+        $contentResult = $this->createMock(Result::class);
+        $contentResult
             ->expects($this->once())
             ->method('iterateAssociative')
-            ->willReturn(new \ArrayIterator([
-                ['id' => 1, 'title' => 'title-1', 'language' => 'language-1'],
-                ['id' => 2, 'title' => 'title-2', 'language' => 'language-2'],
-                ['id' => 3, 'title' => 'title-3', 'language' => 'language-3'],
-            ]))
+            ->willReturn(new \ArrayIterator($elements))
         ;
 
-        $statement = $this->createMock(Statement::class);
-        $statement
+        $moduleResult = $this->createMock(Result::class);
+        $moduleResult
             ->expects($this->once())
-            ->method('executeQuery')
-            ->willReturn($result)
+            ->method('iterateAssociative')
+            ->willReturn(new \ArrayIterator($modules))
         ;
 
         $connection = $this->createMock(Connection::class);
         $connection
-            ->expects($this->once())
-            ->method('prepare')
-            ->willReturn($statement)
+            ->expects($this->exactly(2))
+            ->method('executeQuery')
+            ->willReturnMap([
+                [
+                    "SELECT * FROM tl_content WHERE ptable='tl_theme' AND pid=?",
+                    [1],
+                    $contentResult,
+                ],
+                [
+                    'SELECT m.id, m.name, m.type FROM tl_module m WHERE m.type != \'root_page_dependent_modules\' AND m.pid = ? ORDER BY m.name',
+                    [1],
+                    $moduleResult,
+                ],
+            ])
         ;
 
         return $connection;
     }
 
-    private function mockGetModules(): Connection&MockObject
+    private function createTranslatorStub(): TranslatorInterface&Stub
     {
-        $result = $this->createMock(Result::class);
-        $result
-            ->expects($this->once())
-            ->method('iterateAssociative')
-            ->willReturn(new \ArrayIterator([
-                ['id' => 10, 'name' => 'name-10', 'type' => 'foo'],
-                ['id' => 20, 'name' => 'name-20', 'type' => 'bar'],
-                ['id' => 30, 'name' => 'name-30', 'type' => 'baz'],
-            ]))
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator
+            ->method('trans')
+            ->willReturnArgument(0)
         ;
 
-        $connection = $this->createMock(Connection::class);
-        $connection
-            ->expects($this->once())
-            ->method('executeQuery')
-            ->willReturn($result)
+        return $translator;
+    }
+
+    private function createRecordLabelerStub(): RecordLabeler&Stub
+    {
+        $recordLabeler = $this->createStub(RecordLabeler::class);
+        $recordLabeler
+            ->method('getLabel')
+            ->willReturnCallback(static fn (string $id, array $element) => $element['title'])
         ;
 
-        return $connection;
+        return $recordLabeler;
     }
 }


### PR DESCRIPTION
The "root page dependent" frontend module currently does not support content elements, but only frontend modules. Which means anything built with content elements only (e.g. Isotope eCommerce for Contao 5! 😉) will not be able to have "root page dependent things" in the layout.

This PR fixes support in the existing widget only. We probably should have a content element with similar functionality, but that would be a new feature for me. It would also likely need the same widget etc., which means the module support would need to be updated anyway.

PS: I really dislike the concept of this widget because it only works in conjunction with the event listener which prefills usable data. Does anyone have a concept of re-using that widget for a different purpose?