### PR TITLE
Fix the job owner display in the backend

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/JobsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/JobsListener.php
@@ -49,7 +49,6 @@ class JobsListener
 
         $columns[2] = $this->twig->render('@Contao/backend/jobs/progress.html.twig', ['job' => $job]);
         $columns[3] = $this->twig->render('@Contao/backend/jobs/status.html.twig', ['job' => $job]);
-        $columns[4] = $row['owner'] ?: '-';
 
         $columns[5] = $this->twig->render('@Contao/backend/jobs/attachments.html.twig', [
             'job' => $job,


### PR DESCRIPTION
Previously:

<img width="896" height="288" alt="CleanShot 2026-05-06 at 12 57 17" src="https://github.com/user-attachments/assets/06b94642-413b-4f14-93ec-8a633fe1d081" />

After:

<img width="902" height="278" alt="CleanShot 2026-05-06 at 12 57 29" src="https://github.com/user-attachments/assets/65e005bc-c179-4dfe-893f-b640284b29a4" />
