### PR TITLE
Support self-closing tags in the `Input::stripAttributes()` method

### DIFF
--- a/core-bundle/contao/library/Contao/Input.php
+++ b/core-bundle/contao/library/Contao/Input.php
@@ -702,6 +702,12 @@ class Input
 							return true;
 						}
 
+						// Self-closing tag (see #9817)
+						if ($strAttribute === '/')
+						{
+							return true;
+						}
+
 						$arrCandidates = array($strAttribute);
 
 						// Check for wildcard attributes like data-*
@@ -730,14 +736,15 @@ class Input
 
 				foreach ($arrAttributes as $strAttributeName => $strAttributeValue)
 				{
+					// Self-closing tag (see #9817)
+					if ($strAttributeName === '/')
+					{
+						$strReturn .= ' /';
+						break;
+					}
+
 					// The value was already encoded by the getAttributesFromTag() method
 					$strReturn .= ' ' . $strAttributeName . '="' . $strAttributeValue . '"';
-				}
-
-				// Self-closing tag (see #9817)
-				if (' /' === $matches[2])
-				{
-					$strReturn .= ' /';
 				}
 
 				$strReturn .= '>';
@@ -758,7 +765,7 @@ class Input
 	private static function getAttributesFromTag($strAttributes)
 	{
 		// Match every attribute name value pair
-		if (!preg_match_all('@\s+([a-z][a-z0-9_:-]*)(?:\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]*))?@i', $strAttributes, $matches, PREG_SET_ORDER))
+		if (!preg_match_all('@\s+([a-z][a-z0-9_:-]*)(?:\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]*))?|/$@i', $strAttributes, $matches, PREG_SET_ORDER))
 		{
 			return array();
 		}
@@ -767,6 +774,12 @@ class Input
 
 		foreach ($matches as $arrMatch)
 		{
+			if ($arrMatch[0] === '/')
+			{
+				$arrAttributes['/'] = null;
+				break;
+			}
+
 			$strAttribute = strtolower($arrMatch[1]);
 
 			// Skip attributes that end with dashes or use a double dash

--- a/core-bundle/contao/library/Contao/Input.php
+++ b/core-bundle/contao/library/Contao/Input.php
@@ -734,6 +734,12 @@ class Input
 					$strReturn .= ' ' . $strAttributeName . '="' . $strAttributeValue . '"';
 				}
 
+				// Self-closing tag (see #9817)
+				if (' /' === $matches[2])
+				{
+					$strReturn .= ' /';
+				}
+
 				$strReturn .= '>';
 
 				return $strReturn;

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -423,8 +423,33 @@ class InputTest extends TestCase
         ];
 
         yield 'Allows self-closing tags' => [
-            '<p><img /></p>',
-            '<p><img /></p>',
+            '<p><img src="img.png" /></p>',
+            '<p><img src="img.png" /></p>',
+        ];
+
+        yield 'Self-closing no space' => [
+            '<img src="img.png"/>',
+            '<img src="img.png" />',
+        ];
+
+        yield 'Self-closing no quotes' => [
+            '<img src=img.png />',
+            '<img src="img.png" />',
+        ];
+
+        yield 'Self-closing no attributes' => [
+            '<img />',
+            '<img />',
+        ];
+
+        yield 'Self-closing no attributes no space' => [
+            '<img/>',
+            '<img />',
+        ];
+
+        yield 'Not self-closing' => [
+            '<img src=img.png/>',
+            '<img src="img.png/">',
         ];
 
         yield 'Removes attributes' => [
@@ -564,7 +589,7 @@ class InputTest extends TestCase
 
         yield [
             '<form action="javascript:alert(document.domain)"><input type="submit" value="XSS" /></form>',
-            '<form><input></form>',
+            '<form><input /></form>',
         ];
 
         yield [

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -422,6 +422,11 @@ class InputTest extends TestCase
             'Text &#60;with&#62; <span> tags',
         ];
 
+        yield 'Allows self-closing tags' => [
+            '<p><img /></p>',
+            '<p><img /></p>',
+        ];
+
         yield 'Removes attributes' => [
             'foo <span onerror=alert(1)> bar',
             'foo <span> bar',


### PR DESCRIPTION
Fixes #9817
