### PR TITLE
Remove the search for cache settings and add a filter for enabling instead

### DIFF
--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -513,13 +513,13 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 		),
 		'includeCache' => array
 		(
+			'filter'                  => true,
 			'inputType'               => 'checkbox',
 			'eval'                    => array('submitOnChange'=>true),
 			'sql'                     => array('type' => 'boolean', 'default' => false)
 		),
 		'cache' => array
 		(
-			'search'                  => true,
 			'inputType'               => 'select',
 			'options'                 => array(0, 5, 15, 30, 60, 300, 900, 1800, 3600, 10800, 21600, 43200, 86400, 259200, 604800, 2592000, 7776000, 15552000, 31536000),
 			'reference'               => &$GLOBALS['TL_LANG']['CACHE'],
@@ -534,7 +534,6 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 		),
 		'clientCache' => array
 		(
-			'search'                  => true,
 			'inputType'               => 'select',
 			'options'                 => array(0, 5, 15, 30, 60, 300, 900, 1800, 3600, 10800, 21600, 43200, 86400, 259200, 604800, 2592000),
 			'reference'               => &$GLOBALS['TL_LANG']['CACHE'],


### PR DESCRIPTION
As mentioned [here](https://github.com/contao/contao/pull/9397#issuecomment-4389686456), being able to search in `tl_page.cache` and `tl_page.clientCache` is not really useful, since you would have to know for which exact integers you would have to search for. Also I doubt that anybody ever wants to filter or search for specific cache timeouts.

However, what I personally do adjust myself often is enabling the filter on `tl_page.includeCache` - because when you notice in the front end that a page is or isn't cached, but don't know why, you can't just look at that particular page's setting. Instead you would have to manually go up the page tree, since it's an inherited property.

This PR would enable filtering for `tl_page.includeCache` by default and does make it easy to figure out which pages (or subtree) has cache settings enabled. I decided against doing this in `5.3` since this would cause the filter menu to have another line. In 5.7 it does not matter, since the filter menu is stacked vertically.