### PR TITLE
Add a trace to the maximum insert tag nesting level exception

### DIFF
--- a/core-bundle/src/InsertTag/InsertTagParser.php
+++ b/core-bundle/src/InsertTag/InsertTagParser.php
@@ -58,8 +58,6 @@ class InsertTagParser implements ResetInterface
 
     private const MAX_RECURSION = 64;
 
-    private int $recursionCount = 0;
-
     private array $recursionTrace = [];
 
     /**
@@ -316,7 +314,6 @@ class InsertTagParser implements ResetInterface
 
     public function reset(): void
     {
-        $this->recursionCount = 0;
         $this->recursionTrace = [];
         InsertTags::reset();
     }
@@ -460,12 +457,11 @@ class InsertTagParser implements ResetInterface
             $tag = $this->unresolveTag($tag);
         }
 
-        if ($this->recursionCount >= self::MAX_RECURSION) {
+        if (\count($this->recursionTrace) >= self::MAX_RECURSION) {
             throw new \RuntimeException(\sprintf('Maximum insert tag nesting level of %s reached. Trace: %s', self::MAX_RECURSION, self::formatRecursionTrace([...$this->recursionTrace, $tag->serialize()])));
         }
 
         $this->recursionTrace[] = $tag->serialize();
-        ++$this->recursionCount;
 
         try {
             $result = $subscription->service->{$subscription->method}($tag);
@@ -498,7 +494,6 @@ class InsertTagParser implements ResetInterface
 
             return $result;
         } finally {
-            --$this->recursionCount;
             array_pop($this->recursionTrace);
         }
     }
@@ -565,17 +560,15 @@ class InsertTagParser implements ResetInterface
             $tag = $this->unresolveTag($tag);
         }
 
-        if ($this->recursionCount > self::MAX_RECURSION) {
+        if (\count($this->recursionTrace) > self::MAX_RECURSION) {
             throw new \RuntimeException(\sprintf('Maximum insert tag recursion level of %s reached. Trace: %s', self::MAX_RECURSION, self::formatRecursionTrace([...$this->recursionTrace, $tag->serialize()])));
         }
 
         $this->recursionTrace[] = $tag->serialize();
-        ++$this->recursionCount;
 
         try {
             return $subscription->service->{$subscription->method}($tag, $content);
         } finally {
-            --$this->recursionCount;
             array_pop($this->recursionTrace);
         }
     }

--- a/core-bundle/src/InsertTag/InsertTagParser.php
+++ b/core-bundle/src/InsertTag/InsertTagParser.php
@@ -58,7 +58,9 @@ class InsertTagParser implements ResetInterface
 
     private const MAX_RECURSION = 64;
 
-    private static int $recursionCount = 0;
+    private int $recursionCount = 0;
+
+    private array $recursionTrace = [];
 
     /**
      * @var array<string, InsertTagSubscription>
@@ -314,7 +316,8 @@ class InsertTagParser implements ResetInterface
 
     public function reset(): void
     {
-        self::$recursionCount = 0;
+        $this->recursionCount = 0;
+        $this->recursionTrace = [];
         InsertTags::reset();
     }
 
@@ -457,11 +460,12 @@ class InsertTagParser implements ResetInterface
             $tag = $this->unresolveTag($tag);
         }
 
-        if (self::$recursionCount >= self::MAX_RECURSION) {
-            throw new \RuntimeException(\sprintf('Maximum insert tag nesting level of %s reached', self::MAX_RECURSION));
+        if ($this->recursionCount >= self::MAX_RECURSION) {
+            throw new \RuntimeException(\sprintf('Maximum insert tag nesting level of %s reached. Trace: %s', self::MAX_RECURSION, self::formatRecursionTrace([...$this->recursionTrace, $tag->serialize()])));
         }
 
-        ++self::$recursionCount;
+        $this->recursionTrace[] = $tag->serialize();
+        ++$this->recursionCount;
 
         try {
             $result = $subscription->service->{$subscription->method}($tag);
@@ -494,7 +498,8 @@ class InsertTagParser implements ResetInterface
 
             return $result;
         } finally {
-            --self::$recursionCount;
+            --$this->recursionCount;
+            array_pop($this->recursionTrace);
         }
     }
 
@@ -560,17 +565,40 @@ class InsertTagParser implements ResetInterface
             $tag = $this->unresolveTag($tag);
         }
 
-        if (self::$recursionCount > self::MAX_RECURSION) {
-            throw new \RuntimeException(\sprintf('Maximum insert tag recursion level of %s reached', self::MAX_RECURSION));
+        if ($this->recursionCount > self::MAX_RECURSION) {
+            throw new \RuntimeException(\sprintf('Maximum insert tag recursion level of %s reached. Trace: %s', self::MAX_RECURSION, self::formatRecursionTrace([...$this->recursionTrace, $tag->serialize()])));
         }
 
-        ++self::$recursionCount;
+        $this->recursionTrace[] = $tag->serialize();
+        ++$this->recursionCount;
 
         try {
             return $subscription->service->{$subscription->method}($tag, $content);
         } finally {
-            --self::$recursionCount;
+            --$this->recursionCount;
+            array_pop($this->recursionTrace);
         }
+    }
+
+    private static function formatRecursionTrace(array $trace): string
+    {
+        if (!$trace) {
+            return '';
+        }
+
+        $seen = [];
+
+        foreach ($trace as $index => $entry) {
+            if (isset($seen[$entry])) {
+                $trace = [...\array_slice($trace, 0, $index + 1), '... (repeats)'];
+
+                break;
+            }
+
+            $seen[$entry] = $index;
+        }
+
+        return implode(' -> ', $trace);
     }
 
     private function resolveNestedTags(InsertTag $tag): ResolvedInsertTag

--- a/core-bundle/tests/InsertTag/InsertTagParserTest.php
+++ b/core-bundle/tests/InsertTag/InsertTagParserTest.php
@@ -430,7 +430,7 @@ class InsertTagParserTest extends TestCase
             ),
         );
 
-        $this->expectExceptionMessage('Maximum insert tag nesting level of 64 reached');
+        $this->expectExceptionMessage('Maximum insert tag nesting level of 64 reached. Trace: {{recursion}} -> {{recursion}} -> ... (repeats)');
         $parser->replaceInline('{{recursion}}');
     }
 
@@ -457,7 +457,53 @@ class InsertTagParserTest extends TestCase
             ),
         );
 
-        $this->expectExceptionMessage('Maximum insert tag nesting level of 64 reached');
+        $this->expectExceptionMessage('Maximum insert tag nesting level of 64 reached. Trace: {{recursion}} -> {{recursion}} -> ... (repeats)');
         $parser->replaceInline('{{recursion::{{recursion}}}}');
+    }
+
+    public function testInfiniteMutualRecursion(): void
+    {
+        $parser = new InsertTagParser($this->createMock(ContaoFramework::class), $this->createMock(LoggerInterface::class), $this->createMock(FragmentHandler::class));
+        $parser->addSubscription(
+            new InsertTagSubscription(
+                new class($parser) implements InsertTagResolverNestedResolvedInterface {
+                    public function __construct(private readonly InsertTagParser $parser)
+                    {
+                    }
+
+                    public function __invoke(ResolvedInsertTag $insertTag): InsertTagResult
+                    {
+                        return new InsertTagResult($this->parser->replaceInline('{{bar}}'));
+                    }
+                },
+                '__invoke',
+                'foo',
+                null,
+                true,
+                false,
+            ),
+        );
+        $parser->addSubscription(
+            new InsertTagSubscription(
+                new class($parser) implements InsertTagResolverNestedResolvedInterface {
+                    public function __construct(private readonly InsertTagParser $parser)
+                    {
+                    }
+
+                    public function __invoke(ResolvedInsertTag $insertTag): InsertTagResult
+                    {
+                        return new InsertTagResult($this->parser->replaceInline('{{foo}}'));
+                    }
+                },
+                '__invoke',
+                'bar',
+                null,
+                true,
+                false,
+            ),
+        );
+
+        $this->expectExceptionMessage('Maximum insert tag nesting level of 64 reached. Trace: {{foo}} -> {{bar}} -> {{foo}} -> ... (repeats)');
+        $parser->replaceInline('{{foo}}');
     }
 }


### PR DESCRIPTION
Today morning, I've received `Maximum insert tag recursion level of 64 reached.` error messages in Sentry. This is a pretty complex page so it was a nightmare to find out where that nesting happened and why because the error message does not even contain the insert tag that triggered this issue.

So I set out to add this to the error message and while I was doing that, I found that I might also want to include the path that's actually repeating so error messages are now clear and speaking 😎 

At first, I've also made the `$recursionTrace` static but then I wondered why `$recursionCount` is static in the first place. Our `InsertTagParser` is a service and there's no need to leak out the object instance. I figured this is probably just because it was copied from the old `InsertTags` class where it had to be static because it was not a service. So I've converted that to a class property as well to have a consistent style.