### PR TITLE
Make PictureFactory::createConfig() public

### DIFF
--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -137,7 +137,7 @@ class PictureFactory implements PictureFactoryInterface
      *
      * @return array{0: PictureConfiguration, 1: array<string, string>, 2: ResizeOptions}
      */
-    private function createConfig(array|int|string|null $size): array
+    public function createConfig(array|int|string|null $size): array
     {
         if (!\is_array($size)) {
             $size = [0, 0, $size];

--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -132,12 +132,19 @@ class PictureFactory implements PictureFactoryInterface
         return $this->addImageAttributes($picture, $attributes);
     }
 
+    public function createPictureConfiguration(array|int|string|null $size): PictureGenerationConfig
+    {
+        [$config, , $options] = $this->createConfig(StringUtil::deserialize($size));
+
+        return new PictureGenerationConfig($config, $options);
+    }
+
     /**
      * Creates a picture configuration.
      *
      * @return array{0: PictureConfiguration, 1: array<string, string>, 2: ResizeOptions}
      */
-    public function createConfig(array|int|string|null $size): array
+    private function createConfig(array|int|string|null $size): array
     {
         if (!\is_array($size)) {
             $size = [0, 0, $size];

--- a/core-bundle/src/Image/PictureFactoryInterface.php
+++ b/core-bundle/src/Image/PictureFactoryInterface.php
@@ -33,8 +33,6 @@ interface PictureFactoryInterface
      * TODO: enable in Contao 6.
      *
      * Creates a picture configuration.
-     *
-     * @return array{0: PictureConfiguration, 1: array<string, string>, 2: ResizeOptions}
      */
-    /*public function createConfig(array|int|string|null $size): array;*/
+    /*public function createPictureConfiguration(array|int|string|null $size): PictureGenerationConfig;*/
 }

--- a/core-bundle/src/Image/PictureFactoryInterface.php
+++ b/core-bundle/src/Image/PictureFactoryInterface.php
@@ -28,4 +28,13 @@ interface PictureFactoryInterface
      * Creates a Picture object.
      */
     public function create(ImageInterface|string $path, PictureConfiguration|array|int|string|null $size = null, ResizeOptions|null $options = null): PictureInterface;
+
+    /**
+     * TODO: enable in Contao 6.
+     *
+     * Creates a picture configuration.
+     *
+     * @return array{0: PictureConfiguration, 1: array<string, string>, 2: ResizeOptions}
+     */
+    /*public function createConfig(array|int|string|null $size): array;*/
 }

--- a/core-bundle/src/Image/PictureFactoryInterface.php
+++ b/core-bundle/src/Image/PictureFactoryInterface.php
@@ -29,10 +29,10 @@ interface PictureFactoryInterface
      */
     public function create(ImageInterface|string $path, PictureConfiguration|array|int|string|null $size = null, ResizeOptions|null $options = null): PictureInterface;
 
-    /**
+    /*
      * TODO: enable in Contao 6.
      *
      * Creates a picture configuration.
      */
-    /*public function createPictureConfiguration(array|int|string|null $size): PictureGenerationConfig;*/
+    /* public function createPictureConfiguration(array|int|string|null $size): PictureGenerationConfig; */
 }

--- a/core-bundle/src/Image/PictureGenerationConfig.php
+++ b/core-bundle/src/Image/PictureGenerationConfig.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Image;
+
+use Contao\Image\PictureConfiguration;
+use Contao\Image\ResizeOptions;
+
+class PictureGenerationConfig
+{
+    public function __construct(
+        private readonly PictureConfiguration $pictureConfiguration,
+        private readonly ResizeOptions $resizeOptions,
+    ) {
+    }
+
+    public function getPictureConfiguration(): PictureConfiguration
+    {
+        return $this->pictureConfiguration;
+    }
+
+    public function getResizeOptions(): ResizeOptions
+    {
+        return $this->resizeOptions;
+    }
+}

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -260,6 +260,47 @@ class PictureFactoryTest extends TestCase
         $pictureFactory->create($path, 1);
     }
 
+    public function testCreatesAPictureConfigurationFromADatabaseSize(): void
+    {
+        $imageSizeProperties = [
+            'width' => 100,
+            'height' => 200,
+            'resizeMode' => ResizeConfiguration::MODE_BOX,
+            'zoom' => 50,
+            'sizes' => '100vw',
+            'densities' => '1x, 2x',
+            'cssClass' => 'my-size',
+            'lazyLoading' => true,
+            'formats' => '',
+            'skipIfDimensionsMatch' => true,
+        ];
+
+        $imageSizeModel = $this->mockClassWithProperties(ImageSizeModel::class, $imageSizeProperties);
+        $imageSizeModel
+            ->method('row')
+            ->willReturn($imageSizeProperties)
+        ;
+
+        $imageSizeAdapter = $this->mockConfiguredAdapter(['findById' => $imageSizeModel]);
+        $imageSizeItemAdapter = $this->mockConfiguredAdapter(['findVisibleByPid' => null]);
+
+        $adapters = [
+            ImageSizeModel::class => $imageSizeAdapter,
+            ImageSizeItemModel::class => $imageSizeItemAdapter,
+        ];
+
+        $framework = $this->mockContaoFramework($adapters);
+        $pictureFactory = $this->getPictureFactory(framework: $framework);
+
+        [$config, $attributes, $options] = $pictureFactory->createConfig(1);
+
+        $this->assertSame(100, $config->getSize()->getResizeConfig()->getWidth());
+        $this->assertSame(200, $config->getSize()->getResizeConfig()->getHeight());
+        $this->assertSame('my-size', $attributes['class']);
+        $this->assertSame('lazy', $attributes['loading']);
+        $this->assertTrue($options->getSkipIfDimensionsMatch());
+    }
+
     public function testCreatesAPictureObjectFromAnImageObjectWithAPredefinedImageSize(): void
     {
         $predefinedSizes = [

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -260,7 +260,7 @@ class PictureFactoryTest extends TestCase
         $pictureFactory->create($path, 1);
     }
 
-    public function testCreatesAPictureConfigurationFromADatabaseSize(): void
+    public function testCreatesAPictureGenerationConfigFromADatabaseSize(): void
     {
         $imageSizeProperties = [
             'width' => 100,
@@ -292,12 +292,12 @@ class PictureFactoryTest extends TestCase
         $framework = $this->mockContaoFramework($adapters);
         $pictureFactory = $this->getPictureFactory(framework: $framework);
 
-        [$config, $attributes, $options] = $pictureFactory->createConfig(1);
+        $configResult = $pictureFactory->createPictureConfiguration(1);
+        $config = $configResult->getPictureConfiguration();
+        $options = $configResult->getResizeOptions();
 
         $this->assertSame(100, $config->getSize()->getResizeConfig()->getWidth());
         $this->assertSame(200, $config->getSize()->getResizeConfig()->getHeight());
-        $this->assertSame('my-size', $attributes['class']);
-        $this->assertSame('lazy', $attributes['loading']);
         $this->assertTrue($options->getSkipIfDimensionsMatch());
     }
 


### PR DESCRIPTION
I would like to propose to make `PictureFactory::createConfig()` publicly accessible.

In one of my projects, I would like to create the `PictureConfiguration` (including image attributes and resize options) directly from configured image sizes in the database, without having to generate a full picture first.
Why this is useful:

* Enables reuse of Contao’s existing image-size resolution logic outside `create()`
* Avoids duplicating DB-to-config mapping in custom integrations

At the moment, I help myself with reflection but it isn't really nice 😊 

```php
$method = new \ReflectionMethod($this->pictureFactory, 'createConfig');
$method->setAccessible(true);
$result = $method->invoke($this->pictureFactory, $imageSize);
```