### PR TITLE
Add the `SORT_INITIAL_LETTER_BOTH` flags to the value formatter

### DIFF
--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -119,9 +119,11 @@ class ValueFormatter implements ResetInterface
 
         $length = match ($mode) {
             DataContainer::SORT_INITIAL_LETTER_ASC,
-            DataContainer::SORT_INITIAL_LETTER_DESC => 1,
+            DataContainer::SORT_INITIAL_LETTER_DESC,
+            DataContainer::SORT_INITIAL_LETTER_BOTH => 1,
             DataContainer::SORT_INITIAL_LETTERS_ASC,
-            DataContainer::SORT_INITIAL_LETTERS_DESC => max((int) ($GLOBALS['TL_DCA'][$table]['fields'][$field]['length'] ?? 2), 1),
+            DataContainer::SORT_INITIAL_LETTERS_DESC,
+            DataContainer::SORT_INITIAL_LETTERS_BOTH => max((int) ($GLOBALS['TL_DCA'][$table]['fields'][$field]['length'] ?? 2), 1),
             default => null,
         };
 


### PR DESCRIPTION
add SORT_INITIAL_LETTER(S)_BOTH flag to formatGroup function to provide the same Grouping as *_ASC and *_DESC sorting flag.
