### PR TITLE
Handle empty user when indexing protected pages

### DIFF
--- a/core-bundle/contao/classes/Crawl.php
+++ b/core-bundle/contao/classes/Crawl.php
@@ -68,7 +68,7 @@ class Crawl extends Backend implements MaintenanceModuleInterface
 			$headers = array();
 			$objAuthenticator = System::getContainer()->get('contao.security.frontend_preview_authenticator');
 
-			if ($indexProtected)
+			if ($indexProtected && $user)
 			{
 				if (!$objAuthenticator->authenticateFrontendUser($user, false))
 				{


### PR DESCRIPTION
Follow-up to https://github.com/contao/contao/pull/9195, which leads to an error if you do not select a member at all.