### PR TITLE
Remove `<style>` and `<script>` content when converting HTML to plain text

### DIFF
--- a/core-bundle/src/String/HtmlDecoder.php
+++ b/core-bundle/src/String/HtmlDecoder.php
@@ -62,8 +62,8 @@ class HtmlDecoder
 
         // Add new lines before and after block level elements
         $val = preg_replace(
-            ['/[\r\n]+/', '/<\/?(?:br|blockquote|div|dl|figcaption|figure|footer|h\d|header|hr|li|p|pre|tr)\b/i'],
-            [' ', "\n$0"],
+            ['/[\r\n]+/', '/<\/?(?:br|blockquote|div|dl|figcaption|figure|footer|h\d|header|hr|li|p|pre|tr)\b/i', '/(<(script|style)\b[^>]*>).*?(<\/\2>)/is'],
+            [' ', "\n$0", ''],
             $val,
         );
 

--- a/core-bundle/src/String/HtmlDecoder.php
+++ b/core-bundle/src/String/HtmlDecoder.php
@@ -60,10 +60,18 @@ class HtmlDecoder
             $val = $this->insertTagParser->replaceInline($val);
         }
 
+        // Remove hidden elements according to
+        // https://html.spec.whatwg.org/multipage/rendering.html#hidden-elements
+        $val = preg_replace(
+            ['/(<(area|base|basefont|datalist|head|link|meta|noembed|noframes|param|rp|script|style|template|title)\b[^>]*>).*?(<\/\2>)/is'],
+            [''],
+            $val,
+        );
+
         // Add new lines before and after block level elements
         $val = preg_replace(
-            ['/[\r\n]+/', '/<\/?(?:br|blockquote|div|dl|figcaption|figure|footer|h\d|header|hr|li|p|pre|tr)\b/i', '/(<(script|style)\b[^>]*>).*?(<\/\2>)/is'],
-            [' ', "\n$0", ''],
+            ['/[\r\n]+/', '/<\/?(?:br|blockquote|div|dl|figcaption|figure|footer|h\d|header|hr|li|p|pre|tr)\b/i'],
+            [' ', "\n$0"],
             $val,
         );
 

--- a/core-bundle/tests/String/HtmlDecoderTest.php
+++ b/core-bundle/tests/String/HtmlDecoderTest.php
@@ -110,6 +110,8 @@ class HtmlDecoderTest extends TestCase
 
         $this->assertSame($expected, $htmlDecoder->htmlToPlainText($source, $removeInsertTags));
 
+        Config::set('allowedTags', '<script><style>'.Config::get('allowedTags'));
+
         System::getContainer()->set('request_stack', $stack = new RequestStack());
         $stack->push(new Request([], ['value' => str_replace(['&#123;&#123;', '&#125;&#125;'], ['[{]', '[}]'], $source)]));
 

--- a/core-bundle/tests/String/HtmlDecoderTest.php
+++ b/core-bundle/tests/String/HtmlDecoderTest.php
@@ -125,6 +125,8 @@ class HtmlDecoderTest extends TestCase
         yield ['foo<br>bar{{br}}baz', "foo\nbar\nbaz"];
         yield [" \t\r\nfoo \t\r\n \r\n\t bar \t\r\n", 'foo bar'];
         yield [" \t\r\n<br>foo \t<br>\r\n \r\n\t<br> bar <br>\t\r\n", "foo\nbar"];
+        yield ['<script>foo</script>', ''];
+        yield ['<style>foo</style>', ''];
 
         yield [
             '<h1>Headline</h1>Text<ul><li>List 1</li><li>List 2</li></ul><p>Inline<span>text</span> and <a>link</a></p><div><div><div>single newline',


### PR DESCRIPTION
Currently, if you have a HTML content element with CSS or JS in your news article or calendar event, the `<style>` or `<script>` content will be included in the JSON-LD schema, which is obviously wrong.
This is the case for Contao 5.3 and 5.7.

In general I think you never want that when converting HTML to plain text, so this PR changes the `htmlToPlainText` method in the `HtmlDecoder` to remove those tags including their content.

<img width="387" height="233" alt="image" src="https://github.com/user-attachments/assets/78cc2011-a707-4aa3-8e94-c9de70b557ff" />
<img width="269" height="178" alt="image" src="https://github.com/user-attachments/assets/4cb68642-e40d-4fb2-b6c1-a1775c3af3c8" />
<br><br>
Tried adding that behavior to the unit test, but it's failing currently due to the source being input encoded, so the `<script>` being replaced with `&amp;#\60;script&amp;#\62;` (\ added not to link to unrelated issues/PRs 😄 ), in the second assertion of the test. So I think it requires more changes to the test.
Not sure what's the best way to solve that, maybe someone has an idea?