### PR TITLE
Simplify the search index listener

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,7 @@
         "symfony/http-client": "^6.4",
         "symfony/http-client-contracts": "^3.1",
         "symfony/http-foundation": "^6.4",
-        "symfony/http-kernel": "^6.4",
+        "symfony/http-kernel": "^6.4.39",
         "symfony/intl": "^6.4",
         "symfony/mailer": "^6.4",
         "symfony/maker-bundle": "^1.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -124,7 +124,7 @@
         "symfony/http-client": "^6.4",
         "symfony/http-client-contracts": "^3.1",
         "symfony/http-foundation": "^6.4",
-        "symfony/http-kernel": "^6.4",
+        "symfony/http-kernel": "^6.4.39",
         "symfony/intl": "^6.4",
         "symfony/mailer": "^6.4",
         "symfony/messenger": "^6.4",

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -502,8 +502,8 @@ services:
         class: Contao\CoreBundle\EventListener\SearchIndexListener
         arguments:
             - '@messenger.bus.default'
+            - '@contao.routing.scope_matcher'
             - '%fragment.path%'
-            - '%contao.backend.route_prefix%'
             - '%kernel.debug%'
 
     contao.listener.security.logout:

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Crawl\Escargot\Factory;
 use Contao\CoreBundle\Messenger\Message\SearchIndexMessage;
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Search\Document;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,8 +34,8 @@ class SearchIndexListener
 
     public function __construct(
         private readonly MessageBusInterface $messageBus,
+        private readonly ScopeMatcher $scopeMatcher,
         private readonly string $fragmentPath = '_fragment',
-        private readonly string $contaoBackendRoutePrefix = '/contao',
         private readonly bool $debugMode = false,
         private readonly int $enabledFeatures = self::FEATURE_INDEX | self::FEATURE_DELETE,
     ) {
@@ -67,13 +68,7 @@ class SearchIndexListener
             return;
         }
 
-        // Do not handle Contao backend requests
-        if (preg_match('~(?:^|/)'.preg_quote(ltrim($this->contaoBackendRoutePrefix, '/'), '~').'(?:$|/)~', $request->getPathInfo())) {
-            return;
-        }
-
-        // Do not handle profiler requests
-        if (preg_match('~(?:^|/)_wdt/~', $request->getPathInfo())) {
+        if (!$this->scopeMatcher->isFrontendMainRequest($event)) {
             return;
         }
 

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -50,14 +50,14 @@ class SearchIndexListenerTest extends TestCase
 
         $event = new TerminateEvent($this->createMock(HttpKernelInterface::class), $request, $response);
 
-        $listener = new SearchIndexListener($messenger, '_fragment', '/contao', $debug, $features);
+        $listener = new SearchIndexListener($messenger, $this->mockScopeMatcher(), '_fragment', $debug, $features);
         $listener($event);
     }
 
     public static function getRequestResponse(): iterable
     {
         yield 'Should index because the response was successful and contains ld+json information' => [
-            Request::create('/contao-likes-to-index-things'),
+            self::createFrontendRequest('/contao-likes-to-index-things'),
             new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             true,
@@ -66,7 +66,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should not index because even though the response was successful and contains ld+json information, it was disabled by the feature flag' => [
-            Request::create('/foobar'),
+            self::createFrontendRequest('/foobar'),
             new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
             SearchIndexListener::FEATURE_DELETE,
             false,
@@ -75,7 +75,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should be skipped because kernel.debug is true' => [
-            Request::create('/foobar'),
+            self::createFrontendRequest('/foobar'),
             new Response(),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -84,7 +84,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should be skipped because it is not a GET request' => [
-            Request::create('/foobar', 'POST'),
+            self::createFrontendRequest('/foobar', 'POST'),
             new Response('', Response::HTTP_INTERNAL_SERVER_ERROR),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -93,7 +93,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should be skipped because it was requested by our own crawler' => [
-            Request::create('/foobar', 'GET', [], [], [], ['HTTP_USER_AGENT' => Factory::USER_AGENT]),
+            self::createFrontendRequest('/foobar', 'GET', ['HTTP_USER_AGENT' => Factory::USER_AGENT]),
             new Response(),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -102,7 +102,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should be skipped because it was a redirect' => [
-            Request::create('/foobar'),
+            self::createFrontendRequest('/foobar'),
             new RedirectResponse('https://somewhere.else'),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -111,25 +111,16 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should be skipped because it is a fragment request' => [
-            Request::create('/_fragment/foo/bar'),
-            new Response(),
+            self::createFrontendRequest('/_fragment/foo/bar'),
+            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
             false,
             false,
         ];
 
-        yield 'Should be skipped because it is a contao backend request' => [
-            Request::create('/contao?do=article'),
-            new Response(),
-            SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
-            false,
-            false,
-            false,
-        ];
-
-        yield 'Should be skipped because it is a web profiler request' => [
-            Request::create('/_wdt/123'),
+        yield 'Should be skipped because request scope is not frontend' => [
+            self::createBackendRequest('/contao?do=article'),
             new Response(),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -138,7 +129,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should be deleted because the response was "not found" (404)' => [
-            Request::create('/foobar'),
+            self::createFrontendRequest('/foobar'),
             new Response('', 404),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -147,7 +138,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should be deleted because the response was "gone" (410)' => [
-            Request::create('/foobar'),
+            self::createFrontendRequest('/foobar'),
             new Response('', 404),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -156,7 +147,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should not be deleted because even though the response was "not found" (404), it was disabled by the feature flag' => [
-            Request::create('/foobar'),
+            self::createFrontendRequest('/foobar'),
             new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 404),
             SearchIndexListener::FEATURE_INDEX,
             false,
@@ -168,7 +159,7 @@ class SearchIndexListenerTest extends TestCase
         $response->headers->set('X-Robots-Tag', 'noindex');
 
         yield 'Should not index but should delete because the X-Robots-Tag header contains "noindex"' => [
-            Request::create('/foobar'),
+            self::createFrontendRequest('/foobar'),
             $response,
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -180,7 +171,7 @@ class SearchIndexListenerTest extends TestCase
         $response->headers->set('X-Robots-Tag', 'noindex');
 
         yield 'Should not index and delete because the X-Robots-Tag header contains "noindex" and response is unsuccessful' => [
-            Request::create('/foobar'),
+            self::createFrontendRequest('/foobar'),
             $response,
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -189,7 +180,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should not index but should delete because the meta robots tag contains "noindex"' => [
-            Request::create('/foobar'),
+            self::createFrontendRequest('/foobar'),
             new Response('<html><head><meta name="robots" content="noindex,nofollow"/></head><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 200),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -198,7 +189,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should not index and delete because the meta robots tag contains "noindex" and response is unsuccessful' => [
-            Request::create('/foobar'),
+            self::createFrontendRequest('/foobar'),
             new Response('<html><head><meta name="robots" content="noindex,nofollow"/></head><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 500),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -214,7 +205,7 @@ class SearchIndexListenerTest extends TestCase
             }
 
             yield 'Should be skipped because the response status ('.$status.') is not successful and not a "not found" or "gone" response' => [
-                Request::create('/foobar'),
+                self::createFrontendRequest('/foobar'),
                 new Response('', $status),
                 SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
                 false,
@@ -222,5 +213,21 @@ class SearchIndexListenerTest extends TestCase
                 false,
             ];
         }
+    }
+
+    private static function createFrontendRequest(string $uri, string $method = 'GET', array $server = []): Request
+    {
+        $request = Request::create($uri, $method, [], [], [], $server);
+        $request->attributes->set('_scope', 'frontend');
+
+        return $request;
+    }
+
+    private static function createBackendRequest(string $uri, string $method = 'GET', array $server = []): Request
+    {
+        $request = Request::create($uri, $method, [], [], [], $server);
+        $request->attributes->set('_scope', 'backend');
+
+        return $request;
     }
 }


### PR DESCRIPTION
With the [latest changes in Symfony](https://github.com/symfony/symfony/pull/64150) we can now safely rely on the request attributes (should've done this PR a long time ago) in the `kernel.terminate` event.

This means we don't need path matching anymore and thus can a) simplify the logic and b) cover more cases that are currently probably sent to the indexer even though they are not relevant for the Contao search index at all. Hence, I consider this to be a valid change for `5.3+` because it may reduce the number of requests analyzed for no reason.

The fragment path we still need to check explicitly because for ESI requests via real proxy, you'll have a `_scope=frontend` main request.

A note on the requirements: I did not bother to raise the minimum dependency in the `composer.json` - it will make for easier upstream merges. But feel free to add this before merging. It would be `"symfony/http-kernel": "^6.4.39"`.