### PR TITLE
Restrict web-triggered cron/worker execution to the Contao scope

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -42,7 +42,7 @@ services:
         arguments:
             - '@contao.cron'
             - '@database_connection'
-            - '%fragment.path%'
+            - '@contao.routing.scope_matcher'
             - false
 
     contao.listener.csp_report:

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -43,6 +43,7 @@ services:
             - '@contao.cron'
             - '@database_connection'
             - '@contao.routing.scope_matcher'
+            - '%fragment.path%'
             - false
 
     contao.listener.csp_report:

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -575,6 +575,7 @@ services:
         arguments:
             - '@cache.app'
             - '@console.command.messenger_consume_messages'
+            - '@contao.routing.scope_matcher'
 
     contao.model_argument_resolver:
         class: Contao\CoreBundle\HttpKernel\ModelArgumentResolver

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -251,8 +251,8 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
             if ([] === $config['messenger']['web_worker']['transports']) {
                 $container->removeDefinition('contao.messenger.web_worker');
             } else {
-                $definition->setArgument(2, $config['messenger']['web_worker']['transports']);
-                $definition->setArgument(3, $config['messenger']['web_worker']['grace_period']);
+                $definition->setArgument('$transports', $config['messenger']['web_worker']['transports']);
+                $definition->setArgument('$gracePeriod', $config['messenger']['web_worker']['grace_period']);
             }
         }
 

--- a/core-bundle/src/EventListener/CommandSchedulerListener.php
+++ b/core-bundle/src/EventListener/CommandSchedulerListener.php
@@ -48,21 +48,14 @@ class CommandSchedulerListener
 
     private function shouldRunCron(TerminateEvent $event): bool
     {
-        $request = $event->getRequest();
-        $pathInfo = $request->getPathInfo();
+        $pathInfo = $event->getRequest()->getPathInfo();
 
         // Skip the listener upon fragment URLs
         if (preg_match('~(?:^|/)'.preg_quote($this->fragmentPath, '~').'/~', $pathInfo)) {
             return false;
         }
 
-        if (
-            (
-                !$this->scopeMatcher->isContaoMainRequest($event)
-                && true !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)
-            )
-            || false === $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)
-        ) {
+        if (!$this->allowsCommandScheduler($event)) {
             return false;
         }
 
@@ -76,6 +69,21 @@ class CommandSchedulerListener
         }
 
         return true;
+    }
+
+    private function allowsCommandScheduler(TerminateEvent $event): bool
+    {
+        $request = $event->getRequest();
+
+        // The feature is enabled explicitly
+        if (true === $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)) {
+            return true;
+        }
+
+        // Automatically enable the feature for Contao requests unless it is
+        // disabled explicitly
+        return $this->scopeMatcher->isContaoMainRequest($event)
+            && false !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE);
     }
 
     /**

--- a/core-bundle/src/EventListener/CommandSchedulerListener.php
+++ b/core-bundle/src/EventListener/CommandSchedulerListener.php
@@ -57,8 +57,11 @@ class CommandSchedulerListener
         }
 
         if (
-            !$this->scopeMatcher->isContaoMainRequest($event)
-            && true !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)
+            (
+                !$this->scopeMatcher->isContaoMainRequest($event)
+                && true !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)
+            )
+            || false === $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)
         ) {
             return false;
         }

--- a/core-bundle/src/EventListener/CommandSchedulerListener.php
+++ b/core-bundle/src/EventListener/CommandSchedulerListener.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Cron\Cron;
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 /**
@@ -25,10 +25,12 @@ use Symfony\Component\HttpKernel\Event\TerminateEvent;
 #[AsEventListener]
 class CommandSchedulerListener
 {
+    final public const REQUEST_ATTRIBUTE_ENABLE = '_contao_command_scheduler';
+
     public function __construct(
         private readonly Cron $cron,
         private readonly Connection $connection,
-        private readonly string $fragmentPath = '_fragment',
+        private readonly ScopeMatcher $scopeMatcher,
         private readonly bool $autoMode = false,
     ) {
     }
@@ -38,17 +40,19 @@ class CommandSchedulerListener
      */
     public function __invoke(TerminateEvent $event): void
     {
-        if ($this->shouldRunCron($event->getRequest())) {
+        if ($this->shouldRunCron($event)) {
             $this->cron->run(Cron::SCOPE_WEB);
         }
     }
 
-    private function shouldRunCron(Request $request): bool
+    private function shouldRunCron(TerminateEvent $event): bool
     {
-        $pathInfo = $request->getPathInfo();
+        $request = $event->getRequest();
 
-        // Skip the listener upon fragment URLs
-        if (preg_match('~(?:^|/)'.preg_quote($this->fragmentPath, '~').'/~', $pathInfo)) {
+        if (
+            !$this->scopeMatcher->isFrontendMainRequest($event)
+            && true !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)
+        ) {
             return false;
         }
 

--- a/core-bundle/src/EventListener/CommandSchedulerListener.php
+++ b/core-bundle/src/EventListener/CommandSchedulerListener.php
@@ -50,7 +50,7 @@ class CommandSchedulerListener
         $request = $event->getRequest();
 
         if (
-            !$this->scopeMatcher->isFrontendMainRequest($event)
+            !$this->scopeMatcher->isContaoMainRequest($event)
             && true !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)
         ) {
             return false;

--- a/core-bundle/src/EventListener/CommandSchedulerListener.php
+++ b/core-bundle/src/EventListener/CommandSchedulerListener.php
@@ -31,6 +31,7 @@ class CommandSchedulerListener
         private readonly Cron $cron,
         private readonly Connection $connection,
         private readonly ScopeMatcher $scopeMatcher,
+        private readonly string $fragmentPath = '_fragment',
         private readonly bool $autoMode = false,
     ) {
     }
@@ -48,6 +49,12 @@ class CommandSchedulerListener
     private function shouldRunCron(TerminateEvent $event): bool
     {
         $request = $event->getRequest();
+        $pathInfo = $request->getPathInfo();
+
+        // Skip the listener upon fragment URLs
+        if (preg_match('~(?:^|/)'.preg_quote($this->fragmentPath, '~').'/~', $pathInfo)) {
+            return false;
+        }
 
         if (
             !$this->scopeMatcher->isContaoMainRequest($event)

--- a/core-bundle/src/Messenger/WebWorker.php
+++ b/core-bundle/src/Messenger/WebWorker.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Messenger;
 
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -42,6 +43,8 @@ use Symfony\Component\Messenger\Event\WorkerStartedEvent;
  */
 class WebWorker
 {
+    final public const REQUEST_ATTRIBUTE_ENABLE = '_contao_web_worker';
+
     private const MAX_DURATION = 30;
 
     private bool $webWorkerRunning = false;
@@ -49,6 +52,7 @@ class WebWorker
     public function __construct(
         private readonly CacheItemPoolInterface $cache,
         private readonly ConsumeMessagesCommand $consumeMessagesCommand,
+        private readonly ScopeMatcher $scopeMatcher,
         private readonly array $transports,
         private readonly string $gracePeriod = 'PT10M',
     ) {
@@ -61,7 +65,16 @@ class WebWorker
     #[AsEventListener(priority: -2048)]
     public function onKernelTerminate(TerminateEvent $event): void
     {
-        $stopTime = $this->calculateStopTime($event->getRequest());
+        $request = $event->getRequest();
+
+        if (
+            !$this->scopeMatcher->isFrontendMainRequest($event)
+            && true !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)
+        ) {
+            return;
+        }
+
+        $stopTime = $this->calculateStopTime($request);
 
         foreach ($this->transports as $transportName) {
             $this->processTransport($transportName, $stopTime);

--- a/core-bundle/src/Messenger/WebWorker.php
+++ b/core-bundle/src/Messenger/WebWorker.php
@@ -21,6 +21,7 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
+use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 
@@ -49,6 +50,11 @@ class WebWorker
 
     private bool $webWorkerRunning = false;
 
+    /**
+     * @var array<string, int>
+     */
+    private array $dispatchedMessagesByTransport = [];
+
     public function __construct(
         private readonly CacheItemPoolInterface $cache,
         private readonly ConsumeMessagesCommand $consumeMessagesCommand,
@@ -65,19 +71,30 @@ class WebWorker
     #[AsEventListener(priority: -2048)]
     public function onKernelTerminate(TerminateEvent $event): void
     {
-        $request = $event->getRequest();
+        if (!$this->shouldAllowQueueDraining($event)) {
+            foreach ($this->dispatchedMessagesByTransport as $transportName => $count) {
+                $this->processTransportByLimit($transportName, $count);
+            }
+        } else {
+            $stopTime = $this->calculateStopTime($event->getRequest());
 
-        if (
-            !$this->scopeMatcher->isFrontendMainRequest($event)
-            && true !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)
-        ) {
-            return;
+            foreach ($this->transports as $transportName) {
+                $this->processTransportByStopTime($transportName, $stopTime);
+            }
         }
 
-        $stopTime = $this->calculateStopTime($request);
+        $this->dispatchedMessagesByTransport = [];
+    }
 
-        foreach ($this->transports as $transportName) {
-            $this->processTransport($transportName, $stopTime);
+    #[AsEventListener]
+    public function onMessageDispatched(SendMessageToTransportsEvent $event): void
+    {
+        foreach (array_keys($event->getSenders()) as $transportName) {
+            if (!\in_array($transportName, $this->transports, true)) {
+                continue;
+            }
+
+            $this->dispatchedMessagesByTransport[$transportName] = ($this->dispatchedMessagesByTransport[$transportName] ?? 0) + 1;
         }
     }
 
@@ -128,16 +145,30 @@ class WebWorker
         return $this->cache->getItem('contao-web-worker-'.$transportName);
     }
 
-    private function processTransport(string $transportName, float $stopTime): void
+    private function processTransportByStopTime(string $transportName, float $stopTime): void
     {
-        // Real worker is running, abort
-        if ($this->getCacheItemForTransportName($transportName)->isHit()) {
-            return;
-        }
-
         $timeLimit = round($stopTime - microtime(true));
 
         if ($timeLimit < 1) {
+            return;
+        }
+
+        $this->runTransport($transportName, ['--time-limit' => $timeLimit]);
+    }
+
+    private function processTransportByLimit(string $transportName, int $limit): void
+    {
+        if ($limit < 1) {
+            return;
+        }
+
+        $this->runTransport($transportName, ['--limit' => $limit]);
+    }
+
+    private function runTransport(string $transportName, array $options): void
+    {
+        // Real worker is running, abort
+        if ($this->getCacheItemForTransportName($transportName)->isHit()) {
             return;
         }
 
@@ -145,14 +176,12 @@ class WebWorker
 
         $inputParameters = [
             'receivers' => [$transportName],
-            '--time-limit' => $timeLimit,
             '--sleep' => 0,
+            ...$options,
         ];
 
-        // This ensures that we also consider configured memory limits in order to try to
-        // not process more messages than the configured memory limit allows. Meaning
-        // this will either abort after having consumed the configured memory limit for
-        // the web process $timeLimit seconds - whichever limit is hit first.
+        // This ensures that we also consider configured memory limits in order to try
+        // not processing more messages than the configured memory limit allows.
         if (($memoryLimit = (string) \ini_get('memory_limit')) && '-1' !== $memoryLimit) {
             $inputParameters['--memory-limit'] = $memoryLimit;
         }
@@ -164,6 +193,16 @@ class WebWorker
         $this->consumeMessagesCommand->run($input, new NullOutput());
 
         $this->webWorkerRunning = false;
+    }
+
+    /**
+     * Queue draining is only allowed for Contao main requests or when explicitly enabled.
+     * Otherwise, processing is restricted to messages dispatched in this request.
+     */
+    private function shouldAllowQueueDraining(TerminateEvent $event): bool
+    {
+        return $this->scopeMatcher->isContaoMainRequest($event)
+            || true === $event->getRequest()->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE);
     }
 
     private function calculateStopTime(Request $request): float

--- a/core-bundle/src/Messenger/WebWorker.php
+++ b/core-bundle/src/Messenger/WebWorker.php
@@ -71,15 +71,15 @@ class WebWorker
     #[AsEventListener(priority: -2048)]
     public function onKernelTerminate(TerminateEvent $event): void
     {
-        if (!$this->shouldAllowQueueDraining($event)) {
-            foreach ($this->dispatchedMessagesByTransport as $transportName => $count) {
-                $this->processTransportByLimit($transportName, $count);
-            }
-        } else {
+        if ($this->allowsQueueDraining($event)) {
             $stopTime = $this->calculateStopTime($event->getRequest());
 
             foreach ($this->transports as $transportName) {
                 $this->processTransportByStopTime($transportName, $stopTime);
+            }
+        } else {
+            foreach ($this->dispatchedMessagesByTransport as $transportName => $count) {
+                $this->processTransportByLimit($transportName, $count);
             }
         }
 
@@ -199,12 +199,18 @@ class WebWorker
      * Queue draining is only allowed for Contao main requests or when explicitly enabled.
      * Otherwise, processing is restricted to messages dispatched in this request.
      */
-    private function shouldAllowQueueDraining(TerminateEvent $event): bool
+    private function allowsQueueDraining(TerminateEvent $event): bool
     {
         $request = $event->getRequest();
 
-        return ($this->scopeMatcher->isContaoMainRequest($event) && false !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE))
-            || true === $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE);
+        // The feature is enabled explicitly
+        if (true === $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE)) {
+            return true;
+        }
+
+        // Automatically enable the feature for Contao requests unless it is disabled explicitly
+        return $this->scopeMatcher->isContaoMainRequest($event)
+            && false !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE);
     }
 
     private function calculateStopTime(Request $request): float

--- a/core-bundle/src/Messenger/WebWorker.php
+++ b/core-bundle/src/Messenger/WebWorker.php
@@ -201,8 +201,10 @@ class WebWorker
      */
     private function shouldAllowQueueDraining(TerminateEvent $event): bool
     {
-        return $this->scopeMatcher->isContaoMainRequest($event)
-            || true === $event->getRequest()->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE);
+        $request = $event->getRequest();
+
+        return ($this->scopeMatcher->isContaoMainRequest($event) && false !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE))
+            || true === $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE);
     }
 
     private function calculateStopTime(Request $request): float

--- a/core-bundle/src/Messenger/WebWorker.php
+++ b/core-bundle/src/Messenger/WebWorker.php
@@ -208,7 +208,8 @@ class WebWorker
             return true;
         }
 
-        // Automatically enable the feature for Contao requests unless it is disabled explicitly
+        // Automatically enable the feature for Contao requests unless it is
+        // disabled explicitly
         return $this->scopeMatcher->isContaoMainRequest($event)
             && false !== $request->attributes->get(self::REQUEST_ATTRIBUTE_ENABLE);
     }

--- a/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
+++ b/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
@@ -59,7 +59,7 @@ class CommandSchedulerListenerTest extends TestCase
             ->with(Cron::SCOPE_WEB)
         ;
 
-        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher(), true);
+        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher(), '_fragment', true);
         $listener($this->getTerminateEvent('frontend'));
     }
 
@@ -77,7 +77,7 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('run')
         ;
 
-        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher(), true);
+        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher(), '_fragment', true);
         $listener($this->getTerminateEvent('frontend'));
     }
 
@@ -92,6 +92,22 @@ class CommandSchedulerListenerTest extends TestCase
 
         $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher());
         $listener($this->getTerminateEvent('backend'));
+    }
+
+    public function testDoesNotRunTheCommandSchedulerUponFragmentRequests(): void
+    {
+        $cron = $this->createMock(Cron::class);
+        $cron
+            ->expects($this->never())
+            ->method('run')
+        ;
+
+        $request = Request::create('/_fragment/foo/bar');
+
+        $event = new TerminateEvent($this->createMock(KernelInterface::class), $request, new Response());
+
+        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher());
+        $listener($event);
     }
 
     public function testRunsTheCommandSchedulerForNonFrontendMainRequestsIfExplicitlyEnabled(): void
@@ -109,7 +125,7 @@ class CommandSchedulerListenerTest extends TestCase
         ;
 
         $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher());
-        $listener($this->getTerminateEvent('backend', [CommandSchedulerListener::REQUEST_ATTRIBUTE_ENABLE => true]));
+        $listener($this->getTerminateEvent(null, [CommandSchedulerListener::REQUEST_ATTRIBUTE_ENABLE => true]));
     }
 
     public function testDoesNotRunTheCommandSchedulerForNonContaoMainRequestsWithoutOptIn(): void

--- a/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
+++ b/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
@@ -140,6 +140,18 @@ class CommandSchedulerListenerTest extends TestCase
         $listener($this->getTerminateEvent());
     }
 
+    public function testDoesNotRunTheCommandSchedulerForContaoMainRequestsIfExplicitlyDisabled(): void
+    {
+        $cron = $this->createMock(Cron::class);
+        $cron
+            ->expects($this->never())
+            ->method('run')
+        ;
+
+        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher());
+        $listener($this->getTerminateEvent('frontend', [CommandSchedulerListener::REQUEST_ATTRIBUTE_ENABLE => false]));
+    }
+
     public function testDoesNotRunTheCommandSchedulerIfThereIsADatabaseConnectionError(): void
     {
         $cron = $this->createMock(Cron::class);

--- a/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
+++ b/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
@@ -81,12 +81,13 @@ class CommandSchedulerListenerTest extends TestCase
         $listener($this->getTerminateEvent('frontend'));
     }
 
-    public function testDoesNotRunTheCommandSchedulerForNonFrontendMainRequests(): void
+    public function testRunsTheCommandSchedulerForBackendMainRequests(): void
     {
         $cron = $this->createMock(Cron::class);
         $cron
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('run')
+            ->with(Cron::SCOPE_WEB)
         ;
 
         $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher());
@@ -109,6 +110,18 @@ class CommandSchedulerListenerTest extends TestCase
 
         $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher());
         $listener($this->getTerminateEvent('backend', [CommandSchedulerListener::REQUEST_ATTRIBUTE_ENABLE => true]));
+    }
+
+    public function testDoesNotRunTheCommandSchedulerForNonContaoMainRequestsWithoutOptIn(): void
+    {
+        $cron = $this->createMock(Cron::class);
+        $cron
+            ->expects($this->never())
+            ->method('run')
+        ;
+
+        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher());
+        $listener($this->getTerminateEvent());
     }
 
     public function testDoesNotRunTheCommandSchedulerIfThereIsADatabaseConnectionError(): void

--- a/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
+++ b/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
@@ -40,8 +40,8 @@ class CommandSchedulerListenerTest extends TestCase
             ->with(Cron::SCOPE_WEB)
         ;
 
-        $listener = new CommandSchedulerListener($cron, $this->mockConnection());
-        $listener($this->getTerminateEvent('contao_frontend'));
+        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher());
+        $listener($this->getTerminateEvent('frontend'));
     }
 
     public function testRunsTheCommandSchedulerIfAutoModeIsEnabledAndCronDoesNotExist(): void
@@ -59,8 +59,8 @@ class CommandSchedulerListenerTest extends TestCase
             ->with(Cron::SCOPE_WEB)
         ;
 
-        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), '_fragment', true);
-        $listener($this->getTerminateEvent('contao_frontend'));
+        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher(), true);
+        $listener($this->getTerminateEvent('frontend'));
     }
 
     public function testDoesNotRunTheCommandSchedulerIfAutoModeIsEnabledAndCronExists(): void
@@ -77,11 +77,11 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('run')
         ;
 
-        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), '_fragment', true);
-        $listener($this->getTerminateEvent('contao_frontend'));
+        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher(), true);
+        $listener($this->getTerminateEvent('frontend'));
     }
 
-    public function testDoesNotRunTheCommandSchedulerUponFragmentRequests(): void
+    public function testDoesNotRunTheCommandSchedulerForNonFrontendMainRequests(): void
     {
         $cron = $this->createMock(Cron::class);
         $cron
@@ -89,16 +89,26 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('run')
         ;
 
-        $ref = new \ReflectionClass(Request::class);
-        $request = $ref->newInstance();
+        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher());
+        $listener($this->getTerminateEvent('backend'));
+    }
 
-        $pathInfo = $ref->getProperty('pathInfo');
-        $pathInfo->setValue($request, '/foo/_fragment/bar');
+    public function testRunsTheCommandSchedulerForNonFrontendMainRequestsIfExplicitlyEnabled(): void
+    {
+        $cron = $this->createMock(Cron::class);
+        $cron
+            ->expects($this->never())
+            ->method('hasMinutelyCliCron')
+        ;
 
-        $event = new TerminateEvent($this->createMock(KernelInterface::class), $request, new Response());
+        $cron
+            ->expects($this->once())
+            ->method('run')
+            ->with(Cron::SCOPE_WEB)
+        ;
 
-        $listener = new CommandSchedulerListener($cron, $this->mockConnection());
-        $listener($event);
+        $listener = new CommandSchedulerListener($cron, $this->mockConnection(), $this->mockScopeMatcher());
+        $listener($this->getTerminateEvent('backend', [CommandSchedulerListener::REQUEST_ATTRIBUTE_ENABLE => true]));
     }
 
     public function testDoesNotRunTheCommandSchedulerIfThereIsADatabaseConnectionError(): void
@@ -115,8 +125,8 @@ class CommandSchedulerListenerTest extends TestCase
             ->willThrowException($this->createMock(DriverException::class))
         ;
 
-        $listener = new CommandSchedulerListener($cron, $connection);
-        $listener($this->getTerminateEvent('contao_backend'));
+        $listener = new CommandSchedulerListener($cron, $connection, $this->mockScopeMatcher());
+        $listener($this->getTerminateEvent('frontend'));
     }
 
     private function mockConnection(): Connection&MockObject
@@ -141,12 +151,16 @@ class CommandSchedulerListenerTest extends TestCase
         return $connection;
     }
 
-    private function getTerminateEvent(string|null $route = null): TerminateEvent
+    private function getTerminateEvent(string|null $scope = null, array $attributes = []): TerminateEvent
     {
         $request = new Request();
 
-        if (null !== $route) {
-            $request->attributes->set('_route', $route);
+        if (null !== $scope) {
+            $request->attributes->set('_scope', $scope);
+        }
+
+        foreach ($attributes as $key => $value) {
+            $request->attributes->set($key, $value);
         }
 
         return new TerminateEvent($this->createMock(KernelInterface::class), $request, new Response());

--- a/core-bundle/tests/Messenger/WebWorkerTest.php
+++ b/core-bundle/tests/Messenger/WebWorkerTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\Messenger;
 
 use Contao\CoreBundle\Messenger\WebWorker;
 use Contao\CoreBundle\Tests\TestCase;
+use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
@@ -27,10 +28,13 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 class WebWorkerTest extends TestCase
 {
@@ -103,7 +107,33 @@ class WebWorkerTest extends TestCase
         $this->assertContains('Stopping worker.', $this->logger->getLogs());
     }
 
-    public function testDoesNotRunWebWorkerForNonFrontendMainRequests(): void
+    public function testWorkerAlsoRunsInBackendScope(): void
+    {
+        $cache = new ArrayAdapter(); // No real workers running
+
+        $webWorker = new WebWorker(
+            $cache,
+            $this->command,
+            $this->mockScopeMatcher(),
+            ['transport-1'],
+        );
+
+        $this->addEventsToEventDispatcher($webWorker);
+
+        $request = new Request();
+        $request->attributes->set('_scope', 'backend');
+
+        $this->eventDispatcher->dispatch(new TerminateEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            new Response(),
+        ));
+
+        // @phpstan-ignore method.notFound
+        $this->assertContains('Stopping worker.', $this->logger->getLogs());
+    }
+
+    public function testDoesNotRunWebWorkerForNonContaoMainRequestsWithoutOptInOrDispatchedMessages(): void
     {
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache
@@ -121,7 +151,6 @@ class WebWorkerTest extends TestCase
         $this->addEventsToEventDispatcher($webWorker);
 
         $request = new Request();
-        $request->attributes->set('_scope', 'backend');
 
         $this->eventDispatcher->dispatch(new TerminateEvent(
             $this->createMock(HttpKernelInterface::class),
@@ -130,7 +159,7 @@ class WebWorkerTest extends TestCase
         ));
     }
 
-    public function testRunsWebWorkerForNonFrontendMainRequestsIfExplicitlyEnabled(): void
+    public function testRunsWebWorkerForNonContaoMainRequestsIfExplicitlyEnabled(): void
     {
         $cache = new ArrayAdapter(); // No real workers running
 
@@ -144,7 +173,6 @@ class WebWorkerTest extends TestCase
         $this->addEventsToEventDispatcher($webWorker);
 
         $request = new Request();
-        $request->attributes->set('_scope', 'backend');
         $request->attributes->set(WebWorker::REQUEST_ATTRIBUTE_ENABLE, true);
 
         $this->eventDispatcher->dispatch(new TerminateEvent(
@@ -155,6 +183,74 @@ class WebWorkerTest extends TestCase
 
         // @phpstan-ignore method.notFound
         $this->assertContains('Stopping worker.', $this->logger->getLogs());
+    }
+
+    public function testRunsWebWorkerForNonContaoMainRequestsIfMessagesWereDispatched(): void
+    {
+        $cache = new ArrayAdapter(); // No real workers running
+
+        $webWorker = new WebWorker(
+            $cache,
+            $this->command,
+            $this->mockScopeMatcher(),
+            ['transport-1'],
+        );
+
+        $this->addEventsToEventDispatcher($webWorker);
+
+        $this->eventDispatcher->dispatch(new SendMessageToTransportsEvent(new Envelope(new \stdClass()), ['transport-1' => $this->createMock(SenderInterface::class)]));
+
+        $this->eventDispatcher->dispatch(new TerminateEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(),
+            new Response(),
+        ));
+
+        // @phpstan-ignore method.notFound
+        $this->assertContains('Stopping worker.', $this->logger->getLogs());
+    }
+
+    public function testLimitsFallbackConsumptionToDispatchedMessagesPerTransport(): void
+    {
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+        $cacheItem
+            ->method('isHit')
+            ->willReturn(false)
+        ;
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->method('getItem')
+            ->willReturn($cacheItem)
+        ;
+
+        $command = $this->createMock(ConsumeMessagesCommand::class);
+        $command
+            ->expects($this->once())
+            ->method('run')
+            ->with(
+                $this->callback(static fn (ArrayInput $input): bool => '2' === (string) $input->getParameterOption('--limit')),
+                $this->isInstanceOf(NullOutput::class),
+            )
+            ->willReturn(0)
+        ;
+
+        $webWorker = new WebWorker(
+            $cache,
+            $command,
+            $this->mockScopeMatcher(),
+            ['transport-1'],
+        );
+
+        $sender = $this->createMock(SenderInterface::class);
+        $webWorker->onMessageDispatched(new SendMessageToTransportsEvent(new Envelope(new \stdClass()), ['transport-1' => $sender]));
+        $webWorker->onMessageDispatched(new SendMessageToTransportsEvent(new Envelope(new \stdClass()), ['transport-1' => $sender]));
+
+        $webWorker->onKernelTerminate(new TerminateEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(),
+            new Response(),
+        ));
     }
 
     private function triggerWebWorker(): void
@@ -215,6 +311,13 @@ class WebWorkerTest extends TestCase
             WorkerRunningEvent::class,
             static function (WorkerRunningEvent $event) use ($webWorker): void {
                 $webWorker->onWorkerRunning($event);
+            },
+        );
+
+        $this->eventDispatcher->addListener(
+            SendMessageToTransportsEvent::class,
+            static function (SendMessageToTransportsEvent $event) use ($webWorker): void {
+                $webWorker->onMessageDispatched($event);
             },
         );
 

--- a/core-bundle/tests/Messenger/WebWorkerTest.php
+++ b/core-bundle/tests/Messenger/WebWorkerTest.php
@@ -75,6 +75,7 @@ class WebWorkerTest extends TestCase
         $webWorker = new WebWorker(
             $cache,
             $this->command,
+            $this->mockScopeMatcher(),
             ['transport-1'],
         );
 
@@ -89,6 +90,7 @@ class WebWorkerTest extends TestCase
         $webWorker = new WebWorker(
             $cache,
             $this->command,
+            $this->mockScopeMatcher(),
             ['transport-1'],
         );
 
@@ -101,11 +103,68 @@ class WebWorkerTest extends TestCase
         $this->assertContains('Stopping worker.', $this->logger->getLogs());
     }
 
-    private function triggerWebWorker(): void
+    public function testDoesNotRunWebWorkerForNonFrontendMainRequests(): void
     {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->never())
+            ->method('getItem')
+        ;
+
+        $webWorker = new WebWorker(
+            $cache,
+            $this->command,
+            $this->mockScopeMatcher(),
+            ['transport-1'],
+        );
+
+        $this->addEventsToEventDispatcher($webWorker);
+
+        $request = new Request();
+        $request->attributes->set('_scope', 'backend');
+
         $this->eventDispatcher->dispatch(new TerminateEvent(
             $this->createMock(HttpKernelInterface::class),
-            new Request(),
+            $request,
+            new Response(),
+        ));
+    }
+
+    public function testRunsWebWorkerForNonFrontendMainRequestsIfExplicitlyEnabled(): void
+    {
+        $cache = new ArrayAdapter(); // No real workers running
+
+        $webWorker = new WebWorker(
+            $cache,
+            $this->command,
+            $this->mockScopeMatcher(),
+            ['transport-1'],
+        );
+
+        $this->addEventsToEventDispatcher($webWorker);
+
+        $request = new Request();
+        $request->attributes->set('_scope', 'backend');
+        $request->attributes->set(WebWorker::REQUEST_ATTRIBUTE_ENABLE, true);
+
+        $this->eventDispatcher->dispatch(new TerminateEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            new Response(),
+        ));
+
+        // @phpstan-ignore method.notFound
+        $this->assertContains('Stopping worker.', $this->logger->getLogs());
+    }
+
+    private function triggerWebWorker(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_scope', 'frontend');
+
+        $this->eventDispatcher->dispatch(new TerminateEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
             new Response(),
         ));
     }

--- a/core-bundle/tests/Messenger/WebWorkerTest.php
+++ b/core-bundle/tests/Messenger/WebWorkerTest.php
@@ -185,6 +185,34 @@ class WebWorkerTest extends TestCase
         $this->assertContains('Stopping worker.', $this->logger->getLogs());
     }
 
+    public function testDoesNotRunWebWorkerForContaoMainRequestsIfExplicitlyDisabledWithoutDispatchedMessages(): void
+    {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->never())
+            ->method('getItem')
+        ;
+
+        $webWorker = new WebWorker(
+            $cache,
+            $this->command,
+            $this->mockScopeMatcher(),
+            ['transport-1'],
+        );
+
+        $this->addEventsToEventDispatcher($webWorker);
+
+        $request = new Request();
+        $request->attributes->set('_scope', 'frontend');
+        $request->attributes->set(WebWorker::REQUEST_ATTRIBUTE_ENABLE, false);
+
+        $this->eventDispatcher->dispatch(new TerminateEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            new Response(),
+        ));
+    }
+
     public function testRunsWebWorkerForNonContaoMainRequestsIfMessagesWereDispatched(): void
     {
         $cache = new ArrayAdapter(); // No real workers running


### PR DESCRIPTION
This change makes `kernel.terminate` behavior non-invasive by default: `CommandSchedulerListener` and `WebWorker` now only run in Contao frontend main requests.
For custom non-Contao routes, you can opt in explicitly via request attributes:
* `_contao_command_scheduler`
* `_contao_web_worker`

Why I think we **really, really** should do it like this and change the defaults:

* It prevents unintended side effects in mixed Symfony apps where non-Contao endpoints (APIs, Ajax, webhooks) currently trigger Contao background work. Right now, Contao interferes with my API and webhook endpoints. It pollutes my profiles and sometimes delays responses which I really don't want in those endpoints.
* It reduces surprise and improves isolation: only Contao frontend traffic triggers Contao web-process behavior by default.
* It lowers operational risk in production (latency spikes, extra DB/message-bus load) on routes unrelated to Contao rendering.



Note: I did remove the fragment path check in the `CommandScheduler` because I think we'd kinda want this? If you have no real cronjob but actual ESI requests via proxy, you'd want those to trigger the cronjobs, no?