### PR TITLE
Fix non-DBAFS images not appearing in the search results

### DIFF
--- a/core-bundle/contao/modules/ModuleSearch.php
+++ b/core-bundle/contao/modules/ModuleSearch.php
@@ -287,7 +287,7 @@ class ModuleSearch extends Module
 
 		foreach ($meta as $v)
 		{
-			if (!isset($v['https://schema.org/primaryImageOfPage']['contentUrl']) && !isset($v['https://schema.org/primaryImageOfPage']['@id']))
+			if (!isset($v['https://schema.org/primaryImageOfPage']['contentUrl']))
 			{
 				continue;
 			}

--- a/core-bundle/contao/modules/ModuleSearch.php
+++ b/core-bundle/contao/modules/ModuleSearch.php
@@ -287,7 +287,7 @@ class ModuleSearch extends Module
 
 		foreach ($meta as $v)
 		{
-			if (!isset($v['https://schema.org/primaryImageOfPage']['contentUrl'], $v['https://schema.org/primaryImageOfPage']['@id']))
+			if (!isset($v['https://schema.org/primaryImageOfPage']['contentUrl']) && !isset($v['https://schema.org/primaryImageOfPage']['@id']))
 			{
 				continue;
 			}


### PR DESCRIPTION
This fixes an issue introduced here: https://github.com/contao/contao/pull/9121

Basically, the logic requires either `@id` or `contentUrl` to be present. This check however expected both properties to be present.

Contao 5.7 is affected, too.