### PR TITLE
Ignore separators when checking whether to show the operations menu button or not

### DIFF
--- a/core-bundle/contao/templates/twig/backend/data_container/operations.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/operations.html.twig
@@ -11,7 +11,7 @@
             {% set html = operation.html|default(null) %}
             {% set is_link = href or (html is not null and ('<a ' in html or '<button ' in html)) %}
             {% set has_submenu = has_submenu or is_link %}
-            {% if has_primary and not operation.primary|default(false) %}
+            {% if has_primary and not operation.primary|default(false) and not operation.separator|default(false) %}
                 {% set show_button = true %}
             {% else %}
                 {{ _self.operation(operation, false, globalOperations) }}


### PR DESCRIPTION
I have a custom backend module with a parent and child table. The child table list view looks like this by default:

<img width="1752" height="450" alt="CleanShot 2026-05-21 at 08 58 44" src="https://github.com/user-attachments/assets/5edd91fc-38b5-4b8b-826b-96d0aabeedab" />

There are no list operations defined as primary. The only one that is a primary one is the sorting handler, which comes from Contao. Because of that the menu button is displayed. So far so good.

However, if I mark all my operations as primary, the operations are visible right away, but the menu button is still shown:

<img width="1760" height="452" alt="CleanShot 2026-05-21 at 09 01 03" src="https://github.com/user-attachments/assets/e699593b-0d69-4716-9b43-b12065ad77e7" />

This duplicates all buttons and introduces some confusion, because one thinks there are some extra buttons in the menu.

The reason of this hassle is the `['separator' => true]` operation. I think it should be ignored while determining whether to show menu button or not. Then it would be correct and look like this:

<img width="1758" height="310" alt="CleanShot 2026-05-21 at 09 05 20" src="https://github.com/user-attachments/assets/81b298fb-c0f5-4681-9ee5-84bba5c5078f" />

Important note: this works fine if there is no "separator" operation (e.g. parent module view). All operations are displayed right away and there is no extra menu button:

<img width="1716" height="154" alt="CleanShot 2026-05-21 at 09 03 42" src="https://github.com/user-attachments/assets/33194572-1e6a-4e9c-906d-60ab90117211" />

I am not entirely sure if it's an actual bug, but I find this behavior a bit confusing.