### PR TITLE
Fix an error if a hidden form field is created without a value

### DIFF
--- a/core-bundle/contao/templates/twig/form_hidden.html.twig
+++ b/core-bundle/contao/templates/twig/form_hidden.html.twig
@@ -1,1 +1,1 @@
-<input type="hidden" name="{{ this.name }}" value="{{ this.value|insert_tag }}">
+<input type="hidden" name="{{ this.name }}" value="{{ this.value|default('')|insert_tag }}">

--- a/core-bundle/contao/templates/twig/form_hidden.html.twig
+++ b/core-bundle/contao/templates/twig/form_hidden.html.twig
@@ -1,1 +1,1 @@
-<input type="hidden" name="{{ this.name }}" value="{{ this.value|default('')|insert_tag }}">
+<input type="hidden" name="{{ this.name }}" value="{{ this.value|default|insert_tag }}">


### PR DESCRIPTION
If the hidden form field has no value, we will get an error:

```
Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Contao\CoreBundle\Twig\Runtime\InsertTagRuntime::replaceInsertTags(): Argument #2 ($text) must be of type string, null given, called in /var/www/…/var/cache/prod/twig/f2/f2b5f0c92f95df4c58e2be32215922a6.php on line 48") in "@Contao/form_hidden.html.twig" at line 1." at form_hidden.html.twig line 1
```