### PR TITLE
Pass a `DataContainer` object instead of `null` in the `FallbackRecordLabelListener`

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -179,6 +179,7 @@ services:
     contao.listener.data_container.fallback_record_label:
         class: Contao\CoreBundle\EventListener\DataContainer\FallbackRecordLabelListener
         arguments:
+            - '@contao.framework'
             - '@translator'
             - '@contao.data_container.value_formatter'
 

--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -14,6 +14,8 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 
 use Contao\CoreBundle\DataContainer\ValueFormatter;
 use Contao\CoreBundle\Event\DataContainerRecordLabelEvent;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\DataContainer;
 use Contao\DcaLoader;
 use Contao\StringUtil;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -27,6 +29,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class FallbackRecordLabelListener
 {
     public function __construct(
+        private readonly ContaoFramework $framework,
         private readonly TranslatorInterface&TranslatorBagInterface $translator,
         private readonly ValueFormatter $valueFormatter,
     ) {
@@ -49,7 +52,15 @@ class FallbackRecordLabelListener
         $defaultSearchField = $GLOBALS['TL_DCA'][$table]['list']['sorting']['defaultSearchField'] ?? null;
 
         if ($defaultSearchField && ($label = $event->getData()[$defaultSearchField] ?? null)) {
-            $event->setLabel(trim(StringUtil::decodeEntities(strip_tags($this->valueFormatter->format($table, $defaultSearchField, $label, null)))));
+            $dataContainer = $this->framework->getAdapter(DataContainer::class);
+
+            $dc = (new \ReflectionClass($dataContainer->getDriverForTable($table)))->newInstanceWithoutConstructor();
+            $dc->strTable = $table;
+            $dc->id = $id;
+
+            $value = $this->valueFormatter->format($table, $defaultSearchField, $label, $dc);
+
+            $event->setLabel(trim(StringUtil::decodeEntities(strip_tags($value))));
         } else {
             $messageDomain = "contao_$table";
 

--- a/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
@@ -16,9 +16,11 @@ use Contao\Config;
 use Contao\CoreBundle\DataContainer\ValueFormatter;
 use Contao\CoreBundle\Event\DataContainerRecordLabelEvent;
 use Contao\CoreBundle\EventListener\DataContainer\FallbackRecordLabelListener;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Tests\Fixtures\TranslatorStub;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\DataContainer;
+use Contao\DC_Table;
 use Contao\DcaLoader;
 use Contao\System;
 use Symfony\Component\Translation\MessageCatalogueInterface;
@@ -36,7 +38,12 @@ class FallbackRecordLabelListenerTest extends TestCase
 
     public function testIgnoresOtherIdentifiers(): void
     {
-        $listener = new FallbackRecordLabelListener($this->createStub(TranslatorStub::class), $this->createStub(ValueFormatter::class));
+        $listener = new FallbackRecordLabelListener(
+            $this->createStub(ContaoFramework::class),
+            $this->createStub(TranslatorStub::class),
+            $this->createStub(ValueFormatter::class),
+        );
+
         $listener($event = new DataContainerRecordLabelEvent('contao.something.tl_foo.123', ['id' => 123]));
 
         $this->assertNull($event->getLabel());
@@ -67,7 +74,12 @@ class FallbackRecordLabelListenerTest extends TestCase
             ->willReturn('Edit 123')
         ;
 
-        $listener = new FallbackRecordLabelListener($translator, $this->createStub(ValueFormatter::class));
+        $listener = new FallbackRecordLabelListener(
+            $this->createStub(ContaoFramework::class),
+            $translator,
+            $this->createStub(ValueFormatter::class),
+        );
+
         $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123]));
 
         $this->assertSame('Edit 123', $event->getLabel());
@@ -86,11 +98,24 @@ class FallbackRecordLabelListenerTest extends TestCase
         $formatter
             ->expects($this->once())
             ->method('format')
-            ->with('tl_foo', 'fieldA', 'A <span>(B &amp; B)</span>', null)
+            ->with('tl_foo', 'fieldA', 'A <span>(B &amp; B)</span>')
             ->willReturn('A (B & B)')
         ;
 
-        $listener = new FallbackRecordLabelListener($translator, $formatter);
+        $dataContainer = $this->createAdapterMock(['getDriverForTable']);
+        $dataContainer
+            ->expects($this->once())
+            ->method('getDriverForTable')
+            ->willReturn(DC_Table::class)
+        ;
+
+        $framework = $this->createStub(ContaoFramework::class);
+        $framework
+            ->method('getAdapter')
+            ->willReturn($dataContainer)
+        ;
+
+        $listener = new FallbackRecordLabelListener($framework, $translator, $formatter);
         $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123, 'fieldA' => 'A <span>(B &amp; B)</span>']));
 
         $this->assertSame('A (B & B)', $event->getLabel());
@@ -111,11 +136,24 @@ class FallbackRecordLabelListenerTest extends TestCase
         $formatter
             ->expects($this->once())
             ->method('format')
-            ->with('tl_foo', 'fieldA', '1772131097', null)
+            ->with('tl_foo', 'fieldA', '1772131097')
             ->willReturn('2026-02-26')
         ;
 
-        $listener = new FallbackRecordLabelListener($translator, $formatter);
+        $dataContainer = $this->createAdapterMock(['getDriverForTable']);
+        $dataContainer
+            ->expects($this->once())
+            ->method('getDriverForTable')
+            ->willReturn(DC_Table::class)
+        ;
+
+        $framework = $this->createStub(ContaoFramework::class);
+        $framework
+            ->method('getAdapter')
+            ->willReturn($dataContainer)
+        ;
+
+        $listener = new FallbackRecordLabelListener($framework, $translator, $formatter);
         $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123, 'fieldA' => '1772131097']));
 
         $this->assertSame('2026-02-26', $event->getLabel());


### PR DESCRIPTION
This is a follow-up pull request on #9593, which ensures that the value formatter receives a `DataContainer` object instead of `null`. This restores compatibility with e.g. the `options_callback`, which was previously only triggered in a data container and thus never passed `null` as value for `$dc`.