### PR TITLE
Also check for scalar values when formatting options

### DIFF
--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -274,7 +274,8 @@ class ValueFormatter implements ResetInterface
         }
 
         if (
-            \is_array($GLOBALS['TL_DCA'][$table]['fields'][$field]['options'] ?? null)
+            \is_scalar($value)
+            && \is_array($GLOBALS['TL_DCA'][$table]['fields'][$field]['options'] ?? null)
             && (
                 ($GLOBALS['TL_DCA'][$table]['fields'][$field]['eval']['isAssociative'] ?? null)
                 || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$table]['fields'][$field]['options'] ?? null)
@@ -287,7 +288,7 @@ class ValueFormatter implements ResetInterface
             }
         }
 
-        if ($callbackOptions = $this->fetchOptionsCallback($table, $field, $dc)) {
+        if (\is_scalar($value) && ($callbackOptions = $this->fetchOptionsCallback($table, $field, $dc))) {
             $label = $this->findOptionLabel($callbackOptions, $value);
 
             if (null !== $label) {


### PR DESCRIPTION
Fixes #9794

We already check `is_scalar` when formatting for `reference` or `foreignKey`, but currently not for `options` and `options_callback`.