### PR TITLE
Do not load labels in `System::getReferer()`

### DIFF
--- a/core-bundle/contao/library/Contao/System.php
+++ b/core-bundle/contao/library/Contao/System.php
@@ -327,7 +327,7 @@ abstract class System
 		{
 			if ($isBackend)
 			{
-				$trail = $container->get('contao.data_container.dca_url_analyzer')->getTrail(limit: $intLevel + 1);
+				$trail = $container->get('contao.data_container.dca_url_analyzer')->getTrail(limit: $intLevel + 1, loadLabels: false);
 
 				if ($trail[\count($trail) - $intLevel - 1]['url'] ?? null)
 				{

--- a/core-bundle/src/DataContainer/DcaUrlAnalyzer.php
+++ b/core-bundle/src/DataContainer/DcaUrlAnalyzer.php
@@ -54,14 +54,14 @@ class DcaUrlAnalyzer
     /**
      * @return list<array{url: string, label: string, treeTrail: list<array{url: string|null, label: string}>|null, treeSiblings: list<array{url: string|null, label: string, active: bool}>|null}>
      */
-    public function getTrail(Request|string|null $request = null, int $limit = PHP_INT_MAX, bool $withTreeTrail = false): array
+    public function getTrail(Request|string|null $request = null, int $limit = PHP_INT_MAX, bool $withTreeTrail = false, bool $loadLabels = true): array
     {
         return $this->dcaRequestSwitcher->runWithRequest(
             $request,
-            function () use ($limit, $withTreeTrail) {
+            function () use ($limit, $withTreeTrail, $loadLabels) {
                 [$table, $id] = $this->findTableAndId();
 
-                return $this->doGetTrail($table, $id, $limit, $withTreeTrail);
+                return $this->doGetTrail($table, $id, $limit, $withTreeTrail, $loadLabels);
             },
         );
     }
@@ -124,7 +124,7 @@ class DcaUrlAnalyzer
     /**
      * @return list<array{url: string, label: string, treeTrail: list<array{url: string|null, label: string}>|null, treeSiblings: list<array{url: string|null, label: string, active: bool}>|null}>
      */
-    private function doGetTrail(string|null $table, int|null $id, int $limit, bool $withTreeTrail): array
+    private function doGetTrail(string|null $table, int|null $id, int $limit, bool $withTreeTrail, bool $loadLabels): array
     {
         $do = $this->findGet('do');
         $trail = [];
@@ -138,7 +138,10 @@ class DcaUrlAnalyzer
         $links = [];
 
         foreach (array_reverse($trail, true) as $index => [$table, $row]) {
-            $this->framework->getAdapter(System::class)->loadLanguageFile($table);
+            if ($loadLabels) {
+                $this->framework->getAdapter(System::class)->loadLanguageFile($table);
+            }
+
             (new DcaLoader($table))->load();
 
             $query = [
@@ -198,7 +201,7 @@ class DcaUrlAnalyzer
 
             $links[] = [
                 'query' => $query,
-                'label' => $this->recordLabeler->getLabel("contao.db.$table.$row[id]", $row),
+                'label' => $loadLabels ? $this->recordLabeler->getLabel("contao.db.$table.$row[id]", $row) : '',
                 'treeTrail' => $treeTrail,
                 'treeSiblings' => $treeSiblings,
             ];
@@ -206,7 +209,7 @@ class DcaUrlAnalyzer
 
         $links[] = [
             'query' => ['do' => $do, 'table' => $table],
-            'label' => $this->translator->trans("MOD.$do.0", [], 'contao_modules'),
+            'label' => $loadLabels ? $this->translator->trans("MOD.$do.0", [], 'contao_modules') : '',
             'treeTrail' => null,
             'treeSiblings' => null,
         ];

--- a/core-bundle/tests/Functional/DcaUrlAnalyzerTest.php
+++ b/core-bundle/tests/Functional/DcaUrlAnalyzerTest.php
@@ -201,6 +201,45 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
         $this->assertSame($expected, $container->get('contao.data_container.dca_url_analyzer')->getTrail(withTreeTrail: true));
     }
 
+    public function testGetTrailWithoutLabels(): void
+    {
+        $container = self::createClient()->getContainer();
+        System::setContainer($container);
+
+        $container->get('request_stack')->push(Request::create('https://example.com/contao?do=article&act=edit&id=1'));
+
+        $container->set(
+            'security.authorization_checker',
+            new class() implements AuthorizationCheckerInterface {
+                public function isGranted(mixed $attribute, mixed $subject = null): bool
+                {
+                    return true;
+                }
+            },
+        );
+
+        $tokenManager = $this->createStub(ContaoCsrfTokenManager::class);
+        $tokenManager
+            ->method('getDefaultTokenValue')
+            ->willReturn('RT')
+        ;
+
+        $container->set(
+            'contao.csrf.token_manager',
+            $tokenManager,
+        );
+
+        $this->loadFixtureFile('default');
+
+        $this->assertSame(
+            [
+                ['label' => '', 'treeTrail' => null, 'treeSiblings' => null, 'url' => '/contao?do=article&table=tl_article'],
+                ['label' => '', 'treeTrail' => null, 'treeSiblings' => null, 'url' => '/contao?do=article&id=1&table=tl_article&act=edit'],
+            ],
+            $container->get('contao.data_container.dca_url_analyzer')->getTrail(loadLabels: false),
+        );
+    }
+
     public static function getTrail(): iterable
     {
         yield [


### PR DESCRIPTION
Gets rid of all the useless label handling when not needed 🚀 