### PR TITLE
Don't call `$this->framework->getAdapter()` in `foreach` loops

### DIFF
--- a/core-bundle/src/Controller/ContentElement/ChangePasswordController.php
+++ b/core-bundle/src/Controller/ContentElement/ChangePasswordController.php
@@ -116,9 +116,11 @@ class ChangePasswordController extends AbstractContentElementController
         $this->framework->getAdapter(Controller::class)->loadDataContainer('tl_member');
 
         if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] ?? null)) {
+            $systemAdapter = $this->framework->getAdapter(System::class);
+
             foreach ($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] as $callback) {
                 if (\is_array($callback)) {
-                    $this->framework->getAdapter(System::class)->importStatic($callback[0])->{$callback[1]}();
+                    $systemAdapter->importStatic($callback[0])->{$callback[1]}();
                 } elseif (\is_callable($callback)) {
                     $callback();
                 }

--- a/core-bundle/src/DataContainer/DcaUrlAnalyzer.php
+++ b/core-bundle/src/DataContainer/DcaUrlAnalyzer.php
@@ -136,10 +136,11 @@ class DcaUrlAnalyzer
         }
 
         $links = [];
+        $systemAdapter = $this->framework->getAdapter(System::class);
 
         foreach (array_reverse($trail, true) as $index => [$table, $row]) {
             if ($loadLabels) {
-                $this->framework->getAdapter(System::class)->loadLanguageFile($table);
+                $systemAdapter->loadLanguageFile($table);
             }
 
             (new DcaLoader($table))->load();


### PR DESCRIPTION
Since this will not make a noticeable difference because of the internal cache of the `getAdapter()` method, I consider this a CS change.