### PR TITLE
Allow version 4 of `spatie/schema-org`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
         "scrivo/highlight.php": "^9.18",
         "scssphp/scssphp": "^1.7",
         "simplepie/simplepie": "^1.3",
-        "spatie/schema-org": "^3.4",
+        "spatie/schema-org": "^3.4 || ^4.0",
         "spomky-labs/otphp": "^11.3",
         "symfony-cmf/routing": "^3.0",
         "symfony-cmf/routing-bundle": "^3.0",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -100,7 +100,7 @@
         "scrivo/highlight.php": "^9.18",
         "scssphp/scssphp": "^1.7",
         "simplepie/simplepie": "^1.3",
-        "spatie/schema-org": "^3.4",
+        "spatie/schema-org": "^3.4 || ^4.0",
         "spomky-labs/otphp": "^11.3",
         "symfony-cmf/routing": "^3.0",
         "symfony-cmf/routing-bundle": "^3.0",


### PR DESCRIPTION
This will allow to install the security fix that has only been released in version 4 yet (see https://github.com/spatie/schema-org/issues/243).