### PR TITLE
Show the translated slot names instead of `{% slot … %}`

### DIFF
--- a/core-bundle/contao/widgets/ModuleWizard.php
+++ b/core-bundle/contao/widgets/ModuleWizard.php
@@ -111,7 +111,7 @@ class ModuleWizard extends Widget
 
 			foreach ($slots as $slot)
 			{
-				$cols[$slot] = "{% slot $slot %}";
+				$cols[$slot] = $GLOBALS['TL_LANG']['COLS'][$slot] ?? $slot;
 			}
 		}
 		else

--- a/core-bundle/src/EventListener/DataContainer/ArticleColumnListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ArticleColumnListener.php
@@ -97,21 +97,13 @@ class ArticleColumnListener
     private function getSlots(string $template): array
     {
         try {
-            $slots = $this->inspector
+            return $this->inspector
                 ->inspectTemplate("@Contao/$template.html.twig")
                 ->getSlots()
             ;
         } catch (InspectionException) {
-            $slots = [];
+            return [];
         }
-
-        $options = [];
-
-        foreach ($slots as $slot) {
-            $options[$slot] = "{% slot $slot %}";
-        }
-
-        return $options;
     }
 
     private function getLayoutSections(LayoutModel $layoutModel): array

--- a/core-bundle/tests/EventListener/DataContainer/ArticleColumnListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ArticleColumnListenerTest.php
@@ -80,13 +80,7 @@ class ArticleColumnListenerTest extends TestCase
 
         $options = $articleColumnListener($dc);
 
-        $this->assertSame(
-            [
-                'foo' => '{% slot foo %}',
-                'bar' => '{% slot bar %}',
-            ],
-            $options,
-        );
+        $this->assertSame(['foo', 'bar'], $options);
     }
 
     public function testReturnsSectionsFromDefaultLayout(): void
@@ -154,13 +148,7 @@ class ArticleColumnListenerTest extends TestCase
 
         $options = $articleColumnListener($dc);
 
-        $this->assertSame(
-            [
-                'foo' => '{% slot foo %}',
-                'bar' => '{% slot bar %}',
-            ],
-            $options,
-        );
+        $this->assertSame(['foo', 'bar'], $options);
     }
 
     public function testReturnsSlotsFromModernLayout(): void


### PR DESCRIPTION
Fixes #9761