### PR TITLE
Check `ptable` when fetching child records

### DIFF
--- a/core-bundle/contao/library/Contao/Database.php
+++ b/core-bundle/contao/library/Contao/Database.php
@@ -474,6 +474,11 @@ class Database
 			return $arrReturn;
 		}
 
+		if ($this->fieldExists('ptable', $strTable))
+		{
+			$strWhere .= " ptable = '" . $strTable . "'";
+		}
+
 		$objChildren = $this->query("SELECT id, pid FROM " . $strTable . " WHERE pid IN(" . implode(',', $arrParentIds) . ")" . ($strWhere ? " AND $strWhere" : "") . ($blnSorting ? " ORDER BY " . $this->findInSet('pid', $arrParentIds) . ", sorting" : ""));
 
 		if ($objChildren->numRows > 0)


### PR DESCRIPTION
Stumbled upon this while working on #8349 🙃 

When fetching the child records of a record we need to make sure to only retrieve the records where `pid` and `ptable` match, as otherwise this can result in queries like this.
```
SELECT id, pid FROM tl_content WHERE pid IN(1)
```

This is a problem, because then, for example, all content elements in the article with the ID 1 are returned as child records for the content element with the ID 1, which is obviously wrong and will lead to an infinite loop if the content element with the ID 1 is also in the article with the ID 1.

### Affected versions
5.3.x-dev, 5.7.x-dev, dev-main

### Steps to reproduce in the Contao Demo

1. Go to the content elements of the Home article of the Home page.
2. Create an element group.
3. Move the text element that is directly inside the Home article to the element group.
4. The page will load for a while and the request will eventually hit the memory limit.