### PR TITLE
Enable cache invalidation in `dev`

### DIFF
--- a/manager-bundle/skeleton/config/config_dev.yaml
+++ b/manager-bundle/skeleton/config/config_dev.yaml
@@ -48,8 +48,3 @@ monolog:
         deprecation:
             type: 'null'
             channels: [deprecation]
-
-# FOS HttpCache configuration
-fos_http_cache:
-    invalidation:
-        enabled: false


### PR DESCRIPTION
Fixes #4193

As discussed in the Contao call, these lines were only a workaround for another issue, which got fixed soon after. However, we never removed these lines.

With our current kernel setup for the Contao Managed Edition, the dev environment just points to the prod http cache and thus is able to invalidate it.

https://github.com/contao/contao/blob/5a7f9ff936765e7ec4d1b04c1fdb75efd3d3ef54/manager-bundle/src/HttpKernel/ContaoKernel.php#L190-L208