### PR TITLE
Raise the minimum version of `symfony/twig-bridge`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,7 @@
         "symfony/string": "^6.4",
         "symfony/translation": "^6.4",
         "symfony/translation-contracts": "^3.0",
-        "symfony/twig-bridge": "^6.4",
+        "symfony/twig-bridge": "^6.4.16",
         "symfony/twig-bundle": "^6.4",
         "symfony/uid": "^6.4",
         "symfony/var-dumper": "^6.4",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -145,7 +145,7 @@
         "symfony/string": "^6.4",
         "symfony/translation": "^6.4",
         "symfony/translation-contracts": "^3.0",
-        "symfony/twig-bridge": "^6.4",
+        "symfony/twig-bridge": "^6.4.16",
         "symfony/twig-bundle": "^6.4",
         "symfony/uid": "^6.4",
         "symfony/var-dumper": "^6.4",


### PR DESCRIPTION
This fixes the `prefer-lowest` action (https://github.com/twigphp/Twig/issues/4497, https://github.com/symfony/symfony/pull/58964).

> [!NOTE]
> No change needed in `5.7.x-dev` as the fix is already present in `symfony/twig-bridge` `7.4.0`.