### PR TITLE
Prevent PHP object injection in `Document::__unserialize()`

### DIFF
--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -83,7 +83,7 @@ class Document
             return;
         }
 
-        $uncompressed = unserialize(gzuncompress($data['compressed']));
+        $uncompressed = unserialize(gzuncompress($data['compressed']), ['allowed_classes' => false]);
 
         $this->uri = new Uri($uncompressed['uri']);
         $this->statusCode = $uncompressed['statusCode'];


### PR DESCRIPTION
## Summary

`Document::__unserialize()` in `core-bundle/src/Search/Document.php` calls `unserialize()` on gzip-compressed data from the search index without specifying `allowed_classes`.

### The data structure

The inner serialized value always stores a plain array with scalar values:
```php
serialize([
    'uri'        => (string) $this->uri,   // string
    'statusCode' => $this->statusCode,      // int
    'headers'    => $this->headers,         // array of strings
    'body'       => $this->body,            // string
])
```

No PHP objects are legitimately stored in this structure, so `allowed_classes => false` is a safe, zero-breaking-change hardening.

### Risk

If an attacker can influence the contents of the Contao search index (e.g., via a cache poisoning attack against the search index backend), they can trigger PHP Object Injection through the bare `unserialize()` call during a search query.

### Fix

```php
// Before
$uncompressed = unserialize(gzuncompress($data['compressed']));

// After  
$uncompressed = unserialize(gzuncompress($data['compressed']), ['allowed_classes' => false]);
```

This is a minimal, surgical fix — no functional change, just defence-in-depth.