### PR TITLE
Convert binary UUIDs in user insert tag

### DIFF
--- a/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
+++ b/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
@@ -251,6 +251,8 @@ class LegacyInsertTag implements InsertTagResolverNestedResolvedInterface
                         $result = $opts[$value] ?? $value;
                     } elseif (\is_array($rfrc)) {
                         $result = isset($rfrc[$value]) ? (\is_array($rfrc[$value]) ? $rfrc[$value][0] : $rfrc[$value]) : $value;
+                    } elseif (Validator::isBinaryUuid($value)) {
+                        $result = StringUtil::binToUuid($value);
                     } else {
                         $result = $value;
                     }


### PR DESCRIPTION
The following insert tag combination currently does not work:

```
{{file::{{user::homeDir}}}}
```

This is because the binary UUID fetched from the database is getting verwordagelt by

https://github.com/contao/contao/blob/99e4d5fb12119a43ea40f054b7a9490b4a5a17f0/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php#L259

This PR fixes that by converting the value to a string UUID beforehand.