### PR TITLE
Support insert tags as twig functions

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1437,6 +1437,7 @@ services:
             - '@contao.twig.filesystem_loader'
             - '@contao.twig.global.variable'
             - '@contao.twig.inspector_node_visitor'
+            - '@contao.insert_tag.parser'
 
     contao.twig.fail_tolerant_filesystem_loader:
         class: Contao\CoreBundle\Twig\Loader\FailTolerantFilesystemLoader

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Twig\Extension;
 
 use Contao\CoreBundle\DataContainer\DataContainerOperationsBuilder;
 use Contao\CoreBundle\InsertTag\ChunkedText;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\CoreBundle\Twig\ContaoTwigUtil;
 use Contao\CoreBundle\Twig\Defer\DeferTokenParser;
@@ -62,6 +63,7 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
         private readonly ContaoFilesystemLoader $filesystemLoader,
         private readonly ContaoVariable $contaoVariable,
         private readonly InspectorNodeVisitor $inspectorNodeVisitor,
+        private readonly InsertTagParser $insertTagParser,
     ) {
         // Mark classes as safe for HTML that already escape their output themselves
         $escaperRuntime = $this->environment->getRuntime(EscaperRuntime::class);
@@ -69,6 +71,18 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
         $escaperRuntime->addSafeClass(HtmlAttributes::class, ['html', 'contao_html']);
         $escaperRuntime->addSafeClass(HighlightResult::class, ['html', 'contao_html']);
         $escaperRuntime->addSafeClass(DataContainerOperationsBuilder::class, ['html', 'contao_html']);
+
+        $this->environment->registerUndefinedFunctionCallback(function (string $name) {
+            if ($this->insertTagParser->hasInsertTag($name)) {
+                return new TwigFunction($name, function() use($name) {
+                    $args = implode('::', func_get_args());
+
+                    return $this->insertTagParser->renderTag($name.($args ? '::'.$args : ''))->getValue();
+                });
+            }
+
+            return false;
+        });
     }
 
     public function getGlobals(): array


### PR DESCRIPTION
Just stumbled upon `registerUndefinedFunctionCallback` and though _Cool, this could support insert tags in Twig_ 😎 

Not sure this makes sense and the registration is at the correct place. But with this you can now use any Contao insert tag as a Twig function, e.g. `{{ link_url(1) }}` instead of `{{ insert_tag('link_url::1') }}`.

Existing functions would obviously conflict with this, so if you have the `WeblinkBundle` installed, then `{{ link(...) }}` would already exist and not use the insert tag. We could solve that through (mandatory or optional) prefix like `{{ contao_link(...) }}` or `{{ inserttag_link(...) }}`.

WDYT @contao/developers ?