### PR TITLE
Remove a `phpstan-ignore` directive

### DIFF
--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -150,7 +150,7 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             }
         } elseif (null === $langA && null !== $langB) {
             return 1;
-        } elseif (null !== $langA && null === $langB) { // @phpstan-ignore notIdentical.alwaysTrue
+        } elseif (null !== $langA && null === $langB) {
             return -1;
         } elseif ($langA < $langB) {
             return -1;


### PR DESCRIPTION
Removes a `phpstan-ignore` directive which is evidently not needed anymore.