### PR TITLE
Fix an issue with adding multiple `ptable` conditions to `$strWhere`

### DIFF
--- a/core-bundle/contao/library/Contao/Database.php
+++ b/core-bundle/contao/library/Contao/Database.php
@@ -474,12 +474,7 @@ class Database
 			return $arrReturn;
 		}
 
-		if ($this->fieldExists('ptable', $strTable))
-		{
-			$strWhere .= " ptable = '" . $strTable . "'";
-		}
-
-		$objChildren = $this->query("SELECT id, pid FROM " . $strTable . " WHERE pid IN(" . implode(',', $arrParentIds) . ")" . ($strWhere ? " AND $strWhere" : "") . ($blnSorting ? " ORDER BY " . $this->findInSet('pid', $arrParentIds) . ", sorting" : ""));
+		$objChildren = $this->query("SELECT id, pid FROM " . $strTable . " WHERE pid IN(" . implode(',', $arrParentIds) . ")" . ($this->fieldExists('ptable', $strTable) ? " AND ptable = '" . $strTable . "'" : "") . ($strWhere ? " AND $strWhere" : "") . ($blnSorting ? " ORDER BY " . $this->findInSet('pid', $arrParentIds) . ", sorting" : ""));
 
 		if ($objChildren->numRows > 0)
 		{


### PR DESCRIPTION
I have unfortunately just found an issue with my fix in #9878...
As the children are fetched recursively the condition might get added multiple times to the query, leading to invalid SQL.
This PR now moves the ptable condition out of `$strWhere`.

```
Doctrine\DBAL\Exception\SyntaxErrorException:
An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'ptable = 'tl_content'' at line 1

  at vendor/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php:78
  at Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter->convert(object(Exception), object(Query))
     (vendor/doctrine/dbal/src/Connection.php:1460)
  at Doctrine\DBAL\Connection->handleDriverException(object(Exception), object(Query))
     (vendor/doctrine/dbal/src/Connection.php:1396)
  at Doctrine\DBAL\Connection->convertExceptionDuringQuery(object(Exception), 'SELECT id, pid FROM tl_content WHERE pid IN(1,400) AND  ptable = \'tl_content\' ptable = \'tl_content\'', array(), array())
     (vendor/doctrine/dbal/src/Connection.php:809)
  at Doctrine\DBAL\Connection->executeQuery('SELECT id, pid FROM tl_content WHERE pid IN(1,400) AND  ptable = \'tl_content\' ptable = \'tl_content\'', array(), array())
     (vendor/contao/contao/core-bundle/contao/library/Contao/Database/Statement.php:268)
  at Contao\Database\Statement->query('SELECT id, pid FROM tl_content WHERE pid IN(1,400) AND  ptable = \'tl_content\' ptable = \'tl_content\'')
     (vendor/contao/contao/core-bundle/contao/library/Contao/Database.php:154)
  at Contao\Database->query('SELECT id, pid FROM tl_content WHERE pid IN(1,400) AND  ptable = \'tl_content\' ptable = \'tl_content\'')
     (vendor/contao/contao/core-bundle/contao/library/Contao/Database.php:482)
  at Contao\Database->getChildRecords(array(1, 400), 'tl_content', false, array(), ' ptable = \'tl_content\' ptable = \'tl_content\'')
     (vendor/contao/contao/core-bundle/contao/library/Contao/Database.php:508)
  at Contao\Database->getChildRecords(array(404), 'tl_content')
     (vendor/contao/contao/core-bundle/contao/drivers/DC_Table.php:922)
  at Contao\DC_Table->cut()
     (vendor/contao/contao/core-bundle/contao/classes/Backend.php:422)
  at Contao\Backend->getBackendModule('article', null)
     (vendor/contao/contao/core-bundle/contao/controllers/BackendMain.php:143)
  at Contao\BackendMain->run()
     (vendor/contao/contao/core-bundle/src/Controller/Backend/BackendController.php:45)
  at Contao\CoreBundle\Controller\Backend\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:42)
  at require('.../public/index.php')
     (/Users/lukasbableck/.composer/vendor/laravel/valet/server.php:110)                
```