### PR TITLE
Use the correct sitemap namespace identifier

### DIFF
--- a/calendar-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/calendar-bundle/tests/EventListener/SitemapListenerTest.php
@@ -152,7 +152,7 @@ class SitemapListenerTest extends ContaoTestCase
     private function createSitemapEvent(array $rootPages): SitemapEvent
     {
         $sitemap = new \DOMDocument('1.0', 'UTF-8');
-        $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
+        $urlSet = $sitemap->createElementNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
         $sitemap->appendChild($urlSet);
 
         return new SitemapEvent($sitemap, new Request(), $rootPages);

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -63,7 +63,7 @@ class SitemapController extends AbstractController
         $sitemap = new \DOMDocument('1.0', 'UTF-8');
         $sitemap->formatOutput = true;
 
-        $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
+        $urlSet = $sitemap->createElementNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
 
         foreach ($urls as $url) {
             $loc = $sitemap->createElementNS($urlSet->namespaceURI, 'loc');

--- a/core-bundle/src/Event/SitemapEvent.php
+++ b/core-bundle/src/Event/SitemapEvent.php
@@ -32,7 +32,7 @@ class SitemapEvent extends Event
     public function addUrlToDefaultUrlSet(string $url): self
     {
         $sitemap = $this->getDocument();
-        $urlSet = $sitemap->getElementsByTagNameNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset')->item(0);
+        $urlSet = $sitemap->getElementsByTagNameNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset')->item(0);
 
         if (!$urlSet) {
             return $this;

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -785,7 +785,7 @@ class SitemapControllerTest extends TestCase
     private function getExpectedSitemapContent(array $urls): string
     {
         $result = '<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">';
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
 
         foreach ($urls as $url) {
             $result .= "

--- a/core-bundle/tests/Event/SitemapEventTest.php
+++ b/core-bundle/tests/Event/SitemapEventTest.php
@@ -21,13 +21,13 @@ class SitemapEventTest extends TestCase
     public function testAddingUrlsToExistingUrlSet(): void
     {
         $sitemap = new \DOMDocument('1.0', 'UTF-8');
-        $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
+        $urlSet = $sitemap->createElementNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
         $sitemap->appendChild($urlSet);
 
         $event = new SitemapEvent($sitemap, new Request(), []);
         $event->addUrlToDefaultUrlSet('https://contao.org');
 
-        $this->assertStringContainsString('<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://contao.org</loc></url></urlset>', (string) $event->getDocument()->saveXML());
+        $this->assertStringContainsString('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://contao.org</loc></url></urlset>', (string) $event->getDocument()->saveXML());
     }
 
     public function testAddingUrlsToExistingUrlSetDoesNotFailIfThereIsNoUrlSet(): void
@@ -38,18 +38,18 @@ class SitemapEventTest extends TestCase
         $event = new SitemapEvent($sitemap, new Request(), []);
         $event->addUrlToDefaultUrlSet('https://contao.org');
 
-        $this->assertStringNotContainsString('<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://contao.org</loc></url></urlset>', (string) $event->getDocument()->saveXML());
+        $this->assertStringNotContainsString('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://contao.org</loc></url></urlset>', (string) $event->getDocument()->saveXML());
     }
 
     public function testEncodesTheUrl(): void
     {
         $sitemap = new \DOMDocument('1.0', 'UTF-8');
-        $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
+        $urlSet = $sitemap->createElementNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
         $sitemap->appendChild($urlSet);
 
         $event = new SitemapEvent($sitemap, new Request(), []);
         $event->addUrlToDefaultUrlSet('https://contao.org?foo=bar&bar=baz');
 
-        $this->assertStringContainsString('<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://contao.org?foo=bar&amp;bar=baz</loc></url></urlset>', (string) $event->getDocument()->saveXML());
+        $this->assertStringContainsString('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://contao.org?foo=bar&amp;bar=baz</loc></url></urlset>', (string) $event->getDocument()->saveXML());
     }
 }

--- a/faq-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/faq-bundle/tests/EventListener/SitemapListenerTest.php
@@ -118,7 +118,7 @@ class SitemapListenerTest extends ContaoTestCase
     private function createSitemapEvent(array $rootPages): SitemapEvent
     {
         $sitemap = new \DOMDocument('1.0', 'UTF-8');
-        $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
+        $urlSet = $sitemap->createElementNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
         $sitemap->appendChild($urlSet);
 
         return new SitemapEvent($sitemap, new Request(), $rootPages);

--- a/news-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/news-bundle/tests/EventListener/SitemapListenerTest.php
@@ -150,7 +150,7 @@ class SitemapListenerTest extends ContaoTestCase
     private function createSitemapEvent(array $rootPages): SitemapEvent
     {
         $sitemap = new \DOMDocument('1.0', 'UTF-8');
-        $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
+        $urlSet = $sitemap->createElementNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
         $sitemap->appendChild($urlSet);
 
         return new SitemapEvent($sitemap, new Request(), $rootPages);

--- a/newsletter-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/newsletter-bundle/tests/EventListener/SitemapListenerTest.php
@@ -113,7 +113,7 @@ class SitemapListenerTest extends ContaoTestCase
     private function createSitemapEvent(array $rootPages): SitemapEvent
     {
         $sitemap = new \DOMDocument('1.0', 'UTF-8');
-        $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
+        $urlSet = $sitemap->createElementNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
         $sitemap->appendChild($urlSet);
 
         return new SitemapEvent($sitemap, new Request(), $rootPages);


### PR DESCRIPTION
The XML namespace identifier must always match the spec, which is `http://...`, not `https://...`.
This can cause the Google search console to reject a sitemap.

See also:
https://support.google.com/webmasters/thread/357720871/sitemap-error-incorrect-namespace-in-google-search-console
https://community.contao.org/de/showthread.php?89331-Sitemap-xml-Google-Search-Console-gt-quot-konnte-nicht-abgerufen-werden-quot
https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap?hl=de#xml
https://www.sitemaps.org/de/protocol.html
https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd