### PR TITLE
Fix job attachments not updating

### DIFF
--- a/core-bundle/contao/templates/twig/backend/jobs/attachments.html.twig
+++ b/core-bundle/contao/templates/twig/backend/jobs/attachments.html.twig
@@ -13,5 +13,5 @@
         {% endfor %}
     </ul>
 {% else %}
-    <span>-</span>
+    <span{{ attachment_attributes }}>-</span>
 {% endif %}

--- a/core-bundle/contao/templates/twig/backend/jobs/update_running_jobs.stream.html.twig
+++ b/core-bundle/contao/templates/twig/backend/jobs/update_running_jobs.stream.html.twig
@@ -24,13 +24,13 @@
 
 {# Update the status columns #}
 {% for job in jobs %}
-    <turbo-stream action="update" targets="[data-job-progress='{{ job.uuid }}']">
+    <turbo-stream action="replace" targets="[data-job-progress='{{ job.uuid }}']">
         <template>
             {{ include('@Contao/backend/jobs/progress.html.twig') }}
         </template>
     </turbo-stream>
 
-    <turbo-stream action="update" targets="[data-job-status='{{ job.uuid }}']">
+    <turbo-stream action="replace" targets="[data-job-status='{{ job.uuid }}']">
         <template>
             {{ include('@Contao/backend/jobs/status.html.twig') }}
         </template>

--- a/core-bundle/contao/templates/twig/backend/jobs/update_running_jobs.stream.html.twig
+++ b/core-bundle/contao/templates/twig/backend/jobs/update_running_jobs.stream.html.twig
@@ -36,7 +36,7 @@
         </template>
     </turbo-stream>
 
-    <turbo-stream action="update" targets="[data-job-attachments='{{ job.uuid }}']">
+    <turbo-stream action="replace" targets="[data-job-attachments='{{ job.uuid }}']">
         <template>
             {{ include('@Contao/backend/jobs/attachments.html.twig', {attachments: attachments[job.uuid]}) }}
         </template>


### PR DESCRIPTION
Fixes #9907

This fixes two things:

In #9718 the `data-job-attachments` attribute was removed from the `<span>`, thus the Turbo Stream could not actually update that element anymore.

The Turbo Stream Action was set to `update` - but this is wrong in this case. When using `update` the _content_ of the target is updated with the content of the stream. But in this case the content of the stream _includes_ the target. This caused duplicate HTML in the DOM, e.g.:

```html
<label class="jobs-progress" data-job-progress="423e96b5-250c-483d-82eb-99bcfcc52eb7">
    <label class="jobs-progress" data-job-progress="423e96b5-250c-483d-82eb-99bcfcc52eb7">
        <progress class="jobs-progress-bar" value="0" max="100"></progress>
        <span class="jobs-progress-label">0.00%</span>
    </label>
</label>
```

The same also applies to all the other Turbo Streams so I have fixed this in this PR too.