### PR TITLE
Complete the contao 2FA provider on the `code_valid` event

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -507,6 +507,11 @@ services:
             - '%fragment.path%'
             - '%kernel.debug%'
 
+    contao.listener.security.complete_two_factor_provider:
+        class: Contao\CoreBundle\EventListener\Security\CompleteTwoFactorProviderListener
+        arguments:
+            - '@security.token_storage'
+
     contao.listener.security.logout:
         class: Contao\CoreBundle\EventListener\Security\LogoutListener
         arguments:

--- a/core-bundle/src/EventListener/Security/CompleteTwoFactorProviderListener.php
+++ b/core-bundle/src/EventListener/Security/CompleteTwoFactorProviderListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\Security;
+
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @internal
+ */
+#[AsEventListener('scheb_two_factor.authentication.code_valid')]
+readonly class CompleteTwoFactorProviderListener
+{
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+    ) {
+    }
+
+    public function __invoke(TwoFactorCodeEvent $event): void
+    {
+        $token = $this->tokenStorage->getToken();
+
+        if (!$token instanceof TwoFactorTokenInterface) {
+            return;
+        }
+
+        $currentProvider = $token->getCurrentTwoFactorProvider();
+
+        if (null !== $currentProvider) {
+            $token->setTwoFactorProviderComplete($currentProvider);
+        }
+    }
+}

--- a/core-bundle/src/EventListener/Security/CompleteTwoFactorProviderListener.php
+++ b/core-bundle/src/EventListener/Security/CompleteTwoFactorProviderListener.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\Security;
 
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeEvent;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -21,14 +20,14 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  * @internal
  */
 #[AsEventListener('scheb_two_factor.authentication.code_valid')]
-readonly class CompleteTwoFactorProviderListener
+class CompleteTwoFactorProviderListener
 {
     public function __construct(
-        private TokenStorageInterface $tokenStorage,
+        private readonly TokenStorageInterface $tokenStorage,
     ) {
     }
 
-    public function __invoke(TwoFactorCodeEvent $event): void
+    public function __invoke(): void
     {
         $token = $this->tokenStorage->getToken();
 


### PR DESCRIPTION
### Description

- fixes https://github.com/contao/conflicts/pull/89

https://github.com/scheb/2fa/pull/316 added a "minor" behavioral change that would break usages of `allTwoFactorProvidersAuthenticated` that we used within our Authenticator.

See comment: https://github.com/scheb/2fa/pull/316#issue-4392646122
> The TwoFactorTokenInterface::allTwoFactorProvidersAuthenticated method will likely never return true, since the previous token forgot after onSuccessfulAuthentication.

See Release notes: https://github.com/scheb/2fa/releases/tag/v7.14.0 / https://github.com/scheb/2fa/releases/tag/v8.6.0
> A minor behavioral change has been introduced: Two-factor providers have been flagged "completed" on the TwoFactorToken immediately after the code was validated. Now, the provider is only flagged, once all post-success listeners have executed.

___

In my opinion, https://github.com/scheb/2fa/pull/316 is incomplete and did not account for completed providers, there actually is a comment that it "may be added" in the future.
The simple hack on our side would be to count the providers as in the PR (feels hacky 🤷) ... I did however see that new events have been introduced when fixing https://github.com/scheb/2fa/issues/317:

```
    /**
     * When the two-factor authentication code is checked, right before the two-factor code is handed to the
     * actual providers.
     */
    public const CHECK = 'scheb_two_factor.authentication.check';

    /**
     * Right after a two-factor authentication code was checked, when the code was valid.
     */
    public const CODE_VALID = 'scheb_two_factor.authentication.code_valid';
```

Hence I'm listening to the CODE_VALID event to set our contao provider complete on our side.
(Not using the constant for the event so it's BC-compatible)

Can be merged upstream into 5.7 as well