### PR TITLE
Fix root redirect not working for forward pages

### DIFF
--- a/core-bundle/src/Routing/Content/PageResolver.php
+++ b/core-bundle/src/Routing/Content/PageResolver.php
@@ -30,7 +30,7 @@ class PageResolver implements ContentUrlResolverInterface
         switch ($content->type) {
             case 'root':
                 $pageAdapter = $this->framework->getAdapter(PageModel::class);
-                $forwardPage = $pageAdapter->findFirstPublishedRegularByPid($content->id);
+                $forwardPage = $pageAdapter->findFirstPublishedByPid($content->id);
 
                 return ContentUrlResult::redirect($forwardPage);
 

--- a/core-bundle/tests/Routing/Content/PageResolverTest.php
+++ b/core-bundle/tests/Routing/Content/PageResolverTest.php
@@ -64,10 +64,10 @@ class PageResolverTest extends TestCase
         $content = $this->createClassWithPropertiesStub(PageModel::class, ['id' => 42, 'type' => 'root']);
         $jumpTo = $this->createClassWithPropertiesStub(PageModel::class);
 
-        $pageAdapter = $this->createAdapterMock(['findFirstPublishedRegularByPid']);
+        $pageAdapter = $this->createAdapterMock(['findFirstPublishedByPid']);
         $pageAdapter
             ->expects($this->once())
-            ->method('findFirstPublishedRegularByPid')
+            ->method('findFirstPublishedByPid')
             ->with(42)
             ->willReturn($jumpTo)
         ;


### PR DESCRIPTION
In https://github.com/contao/contao/pull/9076, we've changed the way URLs for root pages are generated. This breaks the following use case now:

- Root page for e.g. `it`
   - `redirect` page with external redirect to `https://foobar.com`

You cannot generate that URL anymore now because it is not a `regular` page. However, generating an URL to that external page is perfectly possible 😊  