### PR TITLE
Delete `OptIn` tokens if the model does not exist anymore

### DIFF
--- a/core-bundle/src/OptIn/OptIn.php
+++ b/core-bundle/src/OptIn/OptIn.php
@@ -93,8 +93,13 @@ class OptIn implements OptInInterface
                 $related = $token->getRelatedRecords();
 
                 foreach ($related as $table => $id) {
-                    /** @var class-string<Model> $class */
-                    $class = $adapter->getClassFromTable($table);
+                    try {
+                        /** @var class-string<Model> $class */
+                        $class = $adapter->getClassFromTable($table);
+                    } catch (\RuntimeException) {
+                        // If the model class does not exist anymore, we can delete the token
+                        continue;
+                    }
 
                     /** @var Adapter<Model> $model */
                     $model = $this->framework->getAdapter($class);


### PR DESCRIPTION
Fixes #9899

Alternatively, we could remove the dependency on a registered Model class for a table and instead query the database directly (and just assume that the primary key is `id`).