### PR TITLE
Remove the obsolete `Input::setGet()` from the event list

### DIFF
--- a/calendar-bundle/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/contao/modules/ModuleEventlist.php
@@ -93,8 +93,6 @@ class ModuleEventlist extends Events
 	{
 		global $objPage;
 
-		$blnClearInput = false;
-
 		$intYear = (int) Input::get('year');
 		$intMonth = (int) Input::get('month');
 		$intDay = (int) Input::get('day');
@@ -128,8 +126,6 @@ class ModuleEventlist extends Events
 					$intDay = date('Ymd');
 					break;
 			}
-
-			$blnClearInput = true;
 		}
 
 		$blnDynamicFormat = !$this->cal_ignoreDynamic && \in_array($this->cal_format, array('cal_day', 'cal_month', 'cal_year'));
@@ -461,14 +457,6 @@ class ModuleEventlist extends Events
 		$this->Template->headline = $this->headline;
 		$this->Template->events = $strEvents;
 		$this->Template->eventCount = $eventCount;
-
-		// Clear the $_GET array (see #2445)
-		if ($blnClearInput)
-		{
-			Input::setGet('year', null);
-			Input::setGet('month', null);
-			Input::setGet('day', null);
-		}
 	}
 
 	public static function shouldPreload(string $type, PageModel $objPage, Request $request): bool


### PR DESCRIPTION
This code did not do anything anymore, seems like it was forgotten in 7d524958b7b4eaaf15b3ad316165de94e4045225