### PR TITLE
Register a general DC resource for APIP

### DIFF
--- a/api-bundle/config/routes.yaml
+++ b/api-bundle/config/routes.yaml
@@ -1,4 +1,4 @@
 api_platform:
     resource: .
     type: api_platform
-    prefix: /_api
+    prefix: '%contao_api.api_prefix%'

--- a/api-bundle/skeleton/config/services.yaml
+++ b/api-bundle/skeleton/config/services.yaml
@@ -1,0 +1,15 @@
+services:
+    # Merge Contao resources into API Platform's discovered resource names so the
+    # entrypoint, docs and metadata pipeline can see DataContainerRecord.
+    Contao\ApiBundle\ApiPlatform\Metadata\DataContainerResourceNameCollectionFactory:
+        decorates: api_platform.metadata.resource.name_collection_factory
+        arguments:
+            $decorated: '@Contao\ApiBundle\ApiPlatform\Metadata\DataContainerResourceNameCollectionFactory.inner'
+
+    # Provide Contao-specific metadata for the hardcoded DataContainerRecord resource.
+    Contao\ApiBundle\ApiPlatform\Metadata\DataContainerResourceMetadataCollectionFactory:
+        decorates: api_platform.metadata.resource.metadata_collection_factory
+        arguments:
+            $decorated: '@Contao\ApiBundle\ApiPlatform\Metadata\DataContainerResourceMetadataCollectionFactory.inner'
+            $apiPrefix: '%contao_api.api_prefix%'
+            $dataContainerApiPrefix: '%contao_api.data_container_api_prefix%'

--- a/api-bundle/src/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactory.php
+++ b/api-bundle/src/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactory.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ApiBundle\ApiPlatform\Metadata;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use Contao\ApiBundle\Dto\DataContainerRecord;
+
+final class DataContainerResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    public function __construct(
+        private readonly ResourceMetadataCollectionFactoryInterface $decorated,
+        private readonly string $apiPrefix,
+        private readonly string $dataContainerApiPrefix,
+    ) {
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        if (DataContainerRecord::class !== $resourceClass) {
+            return $this->decorated->create($resourceClass);
+        }
+
+        $apiResource = (new ApiResource())
+            ->withClass(DataContainerRecord::class)
+            ->withShortName('Content')
+            ->withRoutePrefix($this->getRoutePrefix('tl_content'))
+            ->withExtraProperties([
+                'contao' => [
+                    'table' => 'tl_content',
+                ],
+            ])
+            ->withOperations(new Operations([
+                'get_collection' => (new GetCollection())
+                    ->withClass(DataContainerRecord::class)
+                    ->withShortName('Content')
+                    ->withUriTemplate($this->getRoutePrefix('tl_content')),
+                'get' => (new Get())
+                    ->withClass(DataContainerRecord::class)
+                    ->withShortName('Content')
+                    ->withUriTemplate($this->getRoutePrefix('tl_content').'/{id}'),
+                'post' => (new Post())
+                    ->withClass(DataContainerRecord::class)
+                    ->withShortName('Content')
+                    ->withUriTemplate($this->getRoutePrefix('tl_content')),
+                'patch' => (new Patch())
+                    ->withClass(DataContainerRecord::class)
+                    ->withShortName('Content')
+                    ->withUriTemplate($this->getRoutePrefix('tl_content').'/{id}'),
+                'delete' => (new Delete())
+                    ->withClass(DataContainerRecord::class)
+                    ->withShortName('Content')
+                    ->withUriTemplate($this->getRoutePrefix('tl_content').'/{id}'),
+            ]))
+        ;
+
+        return new ResourceMetadataCollection($resourceClass, [$apiResource]);
+    }
+
+    private function getRoutePrefix(string $table): string
+    {
+        return '/'.trim($this->apiPrefix, '/').'/'.trim($this->dataContainerApiPrefix, '/').'/'.$table;
+    }
+}

--- a/api-bundle/src/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactory.php
+++ b/api-bundle/src/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactory.php
@@ -38,7 +38,7 @@ final class DataContainerResourceMetadataCollectionFactory implements ResourceMe
             return $this->decorated->create($resourceClass);
         }
 
-        $apiResource = (new ApiResource())
+        $apiResource = new ApiResource()
             ->withClass(DataContainerRecord::class)
             ->withShortName('Content')
             ->withRoutePrefix($this->getRoutePrefix('tl_content'))
@@ -48,23 +48,23 @@ final class DataContainerResourceMetadataCollectionFactory implements ResourceMe
                 ],
             ])
             ->withOperations(new Operations([
-                'get_collection' => (new GetCollection())
+                'get_collection' => new GetCollection()
                     ->withClass(DataContainerRecord::class)
                     ->withShortName('Content')
                     ->withUriTemplate($this->getRoutePrefix('tl_content')),
-                'get' => (new Get())
+                'get' => new Get()
                     ->withClass(DataContainerRecord::class)
                     ->withShortName('Content')
                     ->withUriTemplate($this->getRoutePrefix('tl_content').'/{id}'),
-                'post' => (new Post())
+                'post' => new Post()
                     ->withClass(DataContainerRecord::class)
                     ->withShortName('Content')
                     ->withUriTemplate($this->getRoutePrefix('tl_content')),
-                'patch' => (new Patch())
+                'patch' => new Patch()
                     ->withClass(DataContainerRecord::class)
                     ->withShortName('Content')
                     ->withUriTemplate($this->getRoutePrefix('tl_content').'/{id}'),
-                'delete' => (new Delete())
+                'delete' => new Delete()
                     ->withClass(DataContainerRecord::class)
                     ->withShortName('Content')
                     ->withUriTemplate($this->getRoutePrefix('tl_content').'/{id}'),

--- a/api-bundle/src/ApiPlatform/Metadata/DataContainerResourceNameCollectionFactory.php
+++ b/api-bundle/src/ApiPlatform/Metadata/DataContainerResourceNameCollectionFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ApiBundle\ApiPlatform\Metadata;
+
+use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceNameCollection;
+use Contao\ApiBundle\Dto\DataContainerRecord;
+
+final class DataContainerResourceNameCollectionFactory implements ResourceNameCollectionFactoryInterface
+{
+    public function __construct(
+        private readonly ResourceNameCollectionFactoryInterface $decorated,
+    ) {
+    }
+
+    public function create(): ResourceNameCollection
+    {
+        return new ResourceNameCollection([
+            ...iterator_to_array($this->decorated->create()),
+            DataContainerRecord::class,
+        ]);
+    }
+}

--- a/api-bundle/src/ApiPlatform/Metadata/DataContainerResourceNameCollectionFactory.php
+++ b/api-bundle/src/ApiPlatform/Metadata/DataContainerResourceNameCollectionFactory.php
@@ -18,9 +18,8 @@ use Contao\ApiBundle\Dto\DataContainerRecord;
 
 final class DataContainerResourceNameCollectionFactory implements ResourceNameCollectionFactoryInterface
 {
-    public function __construct(
-        private readonly ResourceNameCollectionFactoryInterface $decorated,
-    ) {
+    public function __construct(private readonly ResourceNameCollectionFactoryInterface $decorated)
+    {
     }
 
     public function create(): ResourceNameCollection

--- a/api-bundle/src/ContaoApiBundle.php
+++ b/api-bundle/src/ContaoApiBundle.php
@@ -12,8 +12,34 @@ declare(strict_types=1);
 
 namespace Contao\ApiBundle;
 
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
 class ContaoApiBundle extends AbstractBundle
 {
+    public function configure(DefinitionConfigurator $definition): void
+    {
+        $definition->rootNode()
+            ->children()
+            ->scalarNode('api_prefix')
+            ->defaultValue('/_api')
+            ->info('The general route prefix at which Contao shall expose the API.')
+            ->end()
+            ->scalarNode('data_container_api_prefix')
+            ->defaultValue('/backend/dc')
+            ->info('The DC specific subprefix at which Contao shall expose the API.')
+            ->end()
+            ->end()
+        ;
+    }
+
+    public function loadExtension(array $config, ContainerConfigurator $configurator, ContainerBuilder $container): void
+    {
+        $configurator->parameters()
+            ->set('contao_api.api_prefix', $config['api_prefix'])
+            ->set('contao_api.data_container_api_prefix', $config['data_container_api_prefix'])
+        ;
+    }
 }

--- a/api-bundle/src/Dto/DataContainerRecord.php
+++ b/api-bundle/src/Dto/DataContainerRecord.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ApiBundle\Dto;
+
+final class DataContainerRecord
+{
+    /**
+     * The identifier is nullable because the same transport object is used for
+     * collection payloads and create operations before a record has been persisted.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function __construct(
+        public readonly string $table,
+        public array $data = [],
+        public readonly int|string|null $id = null,
+    ) {
+    }
+}

--- a/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactoryTest.php
+++ b/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactoryTest.php
@@ -21,8 +21,8 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
-use Contao\ApiBundle\Dto\DataContainerRecord;
 use Contao\ApiBundle\ApiPlatform\Metadata\DataContainerResourceMetadataCollectionFactory;
+use Contao\ApiBundle\Dto\DataContainerRecord;
 use PHPUnit\Framework\TestCase;
 
 final class DataContainerResourceMetadataCollectionFactoryTest extends TestCase

--- a/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactoryTest.php
+++ b/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ApiBundle\Tests\ApiPlatform\Metadata;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use Contao\ApiBundle\Dto\DataContainerRecord;
+use Contao\ApiBundle\ApiPlatform\Metadata\DataContainerResourceMetadataCollectionFactory;
+use PHPUnit\Framework\TestCase;
+
+final class DataContainerResourceMetadataCollectionFactoryTest extends TestCase
+{
+    public function testBuildsMetadataForTheHardcodedContentResource(): void
+    {
+        $decorated = $this->createStub(ResourceMetadataCollectionFactoryInterface::class);
+
+        $factory = new DataContainerResourceMetadataCollectionFactory($decorated, '/_api', 'backend/dc');
+        $collection = $factory->create(DataContainerRecord::class);
+
+        $this->assertCount(1, $collection);
+
+        $resource = $collection[0];
+        $this->assertInstanceOf(ApiResource::class, $resource);
+        $this->assertSame(DataContainerRecord::class, $resource->getClass());
+        $this->assertSame('Content', $resource->getShortName());
+        $this->assertSame('/_api/backend/dc/tl_content', $resource->getRoutePrefix());
+        $this->assertSame('tl_content', $resource->getExtraProperties()['contao']['table']);
+
+        $operations = $resource->getOperations();
+        $this->assertInstanceOf(Operations::class, $operations);
+        $this->assertCount(5, $operations);
+
+        $operations = iterator_to_array($operations);
+
+        $this->assertOperation($operations['get_collection'], GetCollection::class, '/_api/backend/dc/tl_content');
+        $this->assertOperation($operations['get'], Get::class, '/_api/backend/dc/tl_content/{id}');
+        $this->assertOperation($operations['post'], Post::class, '/_api/backend/dc/tl_content');
+        $this->assertOperation($operations['patch'], Patch::class, '/_api/backend/dc/tl_content/{id}');
+        $this->assertOperation($operations['delete'], Delete::class, '/_api/backend/dc/tl_content/{id}');
+    }
+
+    public function testDelegatesForNonDataContainerResources(): void
+    {
+        $collection = new ResourceMetadataCollection('App\\Entity\\Foo');
+        $decorated = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $decorated
+            ->expects($this->once())
+            ->method('create')
+            ->with('App\\Entity\\Foo')
+            ->willReturn($collection)
+        ;
+
+        $factory = new DataContainerResourceMetadataCollectionFactory($decorated, '/_api', 'backend/dc');
+
+        $this->assertSame($collection, $factory->create('App\\Entity\\Foo'));
+    }
+
+    private function assertOperation(object $operation, string $expectedClass, string $expectedUriTemplate): void
+    {
+        $this->assertInstanceOf($expectedClass, $operation);
+        $this->assertSame(DataContainerRecord::class, $operation->getClass());
+        $this->assertSame('Content', $operation->getShortName());
+        $this->assertSame($expectedUriTemplate, $operation->getUriTemplate());
+    }
+}

--- a/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceNameCollectionFactoryTest.php
+++ b/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceNameCollectionFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ApiBundle\Tests\ApiPlatform\Metadata;
+
+use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceNameCollection;
+use Contao\ApiBundle\Dto\DataContainerRecord;
+use Contao\ApiBundle\ApiPlatform\Metadata\DataContainerResourceNameCollectionFactory;
+use PHPUnit\Framework\TestCase;
+
+final class DataContainerResourceNameCollectionFactoryTest extends TestCase
+{
+    public function testAppendsTheDataContainerRecordResourceName(): void
+    {
+        $decorated = $this->createMock(ResourceNameCollectionFactoryInterface::class);
+        $decorated
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn(new ResourceNameCollection(['App\\Entity\\Foo']))
+        ;
+
+        $factory = new DataContainerResourceNameCollectionFactory($decorated);
+        $resourceNames = iterator_to_array($factory->create());
+
+        $this->assertSame(
+            [
+                'App\\Entity\\Foo',
+                DataContainerRecord::class,
+            ],
+            $resourceNames,
+        );
+    }
+}

--- a/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceNameCollectionFactoryTest.php
+++ b/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceNameCollectionFactoryTest.php
@@ -14,8 +14,8 @@ namespace Contao\ApiBundle\Tests\ApiPlatform\Metadata;
 
 use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceNameCollection;
-use Contao\ApiBundle\Dto\DataContainerRecord;
 use Contao\ApiBundle\ApiPlatform\Metadata\DataContainerResourceNameCollectionFactory;
+use Contao\ApiBundle\Dto\DataContainerRecord;
 use PHPUnit\Framework\TestCase;
 
 final class DataContainerResourceNameCollectionFactoryTest extends TestCase


### PR DESCRIPTION
Next API step: Register a general `DataContainerRecord` for APIP and register via dedicated factories that are supposed to be decorated for exactly this use case.

The goal will be to "fake" the same resource for APIP internally so that we can eventually handle all DC tables the same.

Up next: Reading all tables from our DC loader, a special serializer that handles from<->to and eventually validation.