### PR TITLE
Encode labels in the "show" modal

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -739,12 +739,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 			$this->strField = $i;
 			$row[$i] = $valueFormatter->format($this->strTable, $i, $row[$i], $this);
-
-			if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['inputType'] ?? null) == 'textarea' && (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['allowHtml'] ?? null) || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['preserveTags'] ?? null)))
-			{
-				$row[$i] = StringUtil::specialchars($row[$i]);
-			}
-
 			$label = null;
 
 			// Label

--- a/core-bundle/contao/templates/backend/data_container/table/show.html.twig
+++ b/core-bundle/contao/templates/backend/data_container/table/show.html.twig
@@ -13,7 +13,7 @@
             <tbody>
                 {% for label, value in entries %}
                     <tr>
-                        <td class="tl_label">{{ label|raw }}</td>
+                        <td class="tl_label">{{ label|e|replace({'&lt;small&gt;': '<small>', '&lt;/small&gt;': '</small>'})|raw }}</td>
                         <td>{{ value }}</td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
We only allowed HTML in the label part of the `onshow_callback` because they have a format of `%s <small>%s</small>`. This PR makes sure we encode anything else.