### PR TITLE
Do not add attributes twice in `Image::getHtml()`

### DIFF
--- a/core-bundle/contao/library/Contao/Image.php
+++ b/core-bundle/contao/library/Contao/Image.php
@@ -178,6 +178,15 @@ class Image
 			unset($attributesObject['height']);
 		}
 
+		if (isset($attributesObject['alt']))
+		{
+			$alt = $attributesObject['alt'];
+
+			// Unset the alt attribute, otherwise it would be added twice
+			// (once in {alt} and once in {attributes})
+			unset($attributesObject['alt']);
+		}
+
 		$search = array('{width}', '{height}', '{alt}', '{attributes}');
 		$replace = array($defaultSize['width'], $defaultSize['height'], StringUtil::specialchars($alt), $attributes ? ' ' . $attributes : '');
 

--- a/core-bundle/contao/library/Contao/Image.php
+++ b/core-bundle/contao/library/Contao/Image.php
@@ -163,27 +163,18 @@ class Image
 		if (isset($attributesObject['width']))
 		{
 			$defaultSize['width'] = $attributesObject['width'];
-
-			// Unset the width attribute, otherwise it would be added twice
-			// (once in {width} and once in {attributes})
 			unset($attributesObject['width']);
 		}
 
 		if (isset($attributesObject['height']))
 		{
 			$defaultSize['height'] = $attributesObject['height'];
-
-			// Unset the height attribute, otherwise it would be added twice
-			// (once in {height} and once in {attributes})
 			unset($attributesObject['height']);
 		}
 
 		if (isset($attributesObject['alt']))
 		{
 			$alt = $attributesObject['alt'];
-
-			// Unset the alt attribute, otherwise it would be added twice
-			// (once in {alt} and once in {attributes})
 			unset($attributesObject['alt']);
 		}
 
@@ -246,7 +237,7 @@ class Image
 		{
 			$darkVariant = substr($src, 0, -4) . '--dark.svg';
 
-			$sources = (null !== ($darkIcon = ($icons[$darkVariant] ?? null))) ? array($darkIcon['path'], $icon['path']) : $icon['path'];
+			$sources = null !== ($darkIcon = ($icons[$darkVariant] ?? null)) ? array($darkIcon['path'], $icon['path']) : $icon['path'];
 
 			return self::$htmlTemplateCache[$cacheKey] = array(
 				$getImageMarkup($sources),

--- a/core-bundle/contao/library/Contao/Image.php
+++ b/core-bundle/contao/library/Contao/Image.php
@@ -160,8 +160,26 @@ class Image
 
 		$attributesObject = $attributes instanceof HtmlAttributes ? $attributes : new HtmlAttributes($attributes);
 
+		if (isset($attributesObject['width']))
+		{
+			$defaultSize['width'] = $attributesObject['width'];
+
+			// Unset the width attribute, otherwise it would be added twice
+			// (once in {width} and once in {attributes})
+			unset($attributesObject['width']);
+		}
+
+		if (isset($attributesObject['height']))
+		{
+			$defaultSize['height'] = $attributesObject['height'];
+
+			// Unset the height attribute, otherwise it would be added twice
+			// (once in {height} and once in {attributes})
+			unset($attributesObject['height']);
+		}
+
 		$search = array('{width}', '{height}', '{alt}', '{attributes}');
-		$replace = array($attributesObject['width'] ?? $defaultSize['width'], $attributesObject['height'] ??  $defaultSize['height'], StringUtil::specialchars($alt), $attributes ? ' ' . $attributes : '');
+		$replace = array($defaultSize['width'], $defaultSize['height'], StringUtil::specialchars($alt), $attributes ? ' ' . $attributes : '');
 
 		if (str_contains($template, '{darkAttributes}'))
 		{


### PR DESCRIPTION
`Image::getHtml()` uses an internal cache that stores the template as follows:

```html
<img src="/system/themes/flexible/icons/close" width="{width}" height="{height}" alt="{alt}"{darkAttributes}>
```

Now if width and height attributes are given, e.g. in the `_message.html.twig` template

```twig
{{ backend_icon('close', attributes: attrs().set('width', 12).set('height', 12)) }}
```

the attributes will be added twice, once in `{width}` and `{height}` and once in `{darkAttributes}`:

```html
<img src="/system/themes/flexible/icons/close.svg" width="12" height="12" alt="" width="12" height="12">
```
