### PR TITLE
Keep the ampersands in the `addToUrl()` methods

### DIFF
--- a/core-bundle/contao/classes/Backend.php
+++ b/core-bundle/contao/classes/Backend.php
@@ -158,7 +158,7 @@ abstract class Backend extends Controller
 
 		if ($addRequestToken)
 		{
-			$strRequest .= ($strRequest ? '&' : '') . 'rt=' . System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
+			$strRequest .= ($strRequest ? '&amp;' : '') . 'rt=' . System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
 		}
 
 		return parent::addToUrl($strRequest, $blnAddRef, $arrUnset);

--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -1877,7 +1877,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 
 			// Return the select menu
 			$return .= '
-<form action="' . StringUtil::ampersand(Environment::get('requestUri')) . '&fields=1" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post" data-turbo="false">
+<form action="' . StringUtil::ampersand(Environment::get('requestUri') . '&fields=1') .' id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post" data-turbo="false">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="' . $this->strTable . '_all">
 <input type="hidden" name="REQUEST_TOKEN" value="' . htmlspecialchars(System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5) . '">
@@ -2165,7 +2165,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 
 			// Return the select menu
 			$return .= '
-<form action="' . StringUtil::ampersand(Environment::get('requestUri')) . '&fields=1" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post" data-turbo="false">
+<form action="' . StringUtil::ampersand(Environment::get('requestUri') . '&fields=1') . '" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post" data-turbo="false">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="' . $this->strTable . '_all">
 <input type="hidden" name="REQUEST_TOKEN" value="' . htmlspecialchars(System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5) . '">

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -1025,7 +1025,7 @@ abstract class Controller extends System
 		// Merge the request string to be added
 		if ($strRequest)
 		{
-			parse_str(str_replace('&', '&', $strRequest), $newPairs);
+			parse_str(str_replace('&amp;', '&', $strRequest), $newPairs);
 			$pairs = array_merge($pairs, $newPairs);
 		}
 
@@ -1033,7 +1033,7 @@ abstract class Controller extends System
 
 		if (!empty($pairs))
 		{
-			$uri = '?' . http_build_query($pairs, '', '&', PHP_QUERY_RFC3986);
+			$uri = '?' . http_build_query($pairs, '', '&amp;', PHP_QUERY_RFC3986);
 		}
 
 		return $request->getBaseUrl() . $request->getPathInfo() . $uri;
@@ -1055,7 +1055,7 @@ abstract class Controller extends System
 	 */
 	public static function redirect($strLocation, $intStatus=303): never
 	{
-		$strLocation = str_replace('&', '&', $strLocation);
+		$strLocation = str_replace('&amp;', '&', $strLocation);
 
 		// Make the location an absolute URL
 		if (!preg_match('@^https?://@i', $strLocation))


### PR DESCRIPTION
This is a follow-up PR to #9568, where all `&amp;` have been replaced by `&`. However, at least for the `addToUrl()` methods, this change is too extensive as many of the generated URIs are used directly in the backend and thus aren‘t encoded again through Twig.