### PR TITLE
Fix undefined array access when `getimagesize()` fails for invalid image uploads

### DIFF
--- a/core-bundle/contao/classes/FileUpload.php
+++ b/core-bundle/contao/classes/FileUpload.php
@@ -154,6 +154,14 @@ class FileUpload extends Backend
 				{
 					$arrImageSize = getimagesize($file['tmp_name']);
 
+					if (false === $arrImageSize)
+					{
+						Message::addError($GLOBALS['TL_LANG']['ERR']['general']);
+						$this->blnHasError = true;
+
+						continue;
+					}
+
 					if ($arrImageSize[0] > Config::get('imageWidth') || $arrImageSize[1] > Config::get('imageHeight'))
 					{
 						Message::addError(\sprintf($GLOBALS['TL_LANG']['ERR']['largeImage'], Config::get('imageWidth'), Config::get('imageHeight')));


### PR DESCRIPTION
`getimagesize()` returns `false` when the image dimensions cannot be read from the uploaded file. This can happen for corrupted or truncated uploads, or if the file format is not supported by `getimagesize()`.

Currently this causes a warning:

```
ErrorException
Warning: Trying to access array offset on false
```
