### PR TITLE
Change "Contao 6" to "Contao 7" in the deprecation messages

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -2,12 +2,12 @@
 
 ## Service annotations
 
-All of Contao's service annotations have been deprecated in Contao 5.4 and will no longer work in Contao 6. Use the
+All of Contao's service annotations have been deprecated in Contao 5.4 and will no longer work in Contao 7. Use the
 respective PHP attributes instead, e.g. `#[AsCallback(…)]` instead of `@Callback(…)` etc.
 
 ## $GLOBALS['objPage']
 
-Both `$GLOBALS['objPage']` and `global $objPage` have been deprecated in Contao 5.4 and will no longer work in Contao 6.
+Both `$GLOBALS['objPage']` and `global $objPage` have been deprecated in Contao 5.4 and will no longer work in Contao 7.
 Use the page finder service instead:
 
 ```php
@@ -16,12 +16,12 @@ $page = System::getContainer()->get('contao.routing.page_finder')->getCurrentPag
 
 ## Base tag
 
-Relying on the `<base>` tag is deprecated in Contao 5.0 and will no longer work in Contao 6. Use absolute paths
+Relying on the `<base>` tag is deprecated in Contao 5.0 and will no longer work in Contao 7. Use absolute paths
 for links and assets instead.
 
 ## $GLOBALS['TL_LANGUAGE']
 
-Using the global `$GLOBALS['TL_LANGUAGE']` is deprecated in Contao 4.0 and will no longer work in Contao 6. Use
+Using the global `$GLOBALS['TL_LANGUAGE']` is deprecated in Contao 4.0 and will no longer work in Contao 7. Use
 the locale from the request object instead:
 
 ```php

--- a/calendar-bundle/src/Security/Voter/LegacyBackendAccessVoter.php
+++ b/calendar-bundle/src/Security/Voter/LegacyBackendAccessVoter.php
@@ -32,7 +32,7 @@ class LegacyBackendAccessVoter extends AbstractBackendAccessVoter
      */
     protected function hasAccess(array|null $subject, string $field, BackendUser $user): bool
     {
-        trigger_deprecation('contao/calendar-bundle', '5.7', 'Checking access on "contao_user.'.$field.'" is deprecated and will no longer work in Contao 6. Vote on "contao_user.cud" instead.');
+        trigger_deprecation('contao/calendar-bundle', '5.7', 'Checking access on "contao_user.'.$field.'" is deprecated and will no longer work in Contao 7. Vote on "contao_user.cud" instead.');
 
         $table = match ($field) {
             'calendarp' => 'tl_calendar',

--- a/comments-bundle/src/Security/Voter/CommentsAccessVoter.php
+++ b/comments-bundle/src/Security/Voter/CommentsAccessVoter.php
@@ -62,7 +62,7 @@ class CommentsAccessVoter implements VoterInterface, CacheableVoterInterface
             }
         }
 
-        // TODO: in Contao 6, this should default to ACCESS_ABSTAIN if no voter denied
+        // TODO: in Contao 7, this should default to ACCESS_ABSTAIN if no voter denied
         return self::ACCESS_DENIED;
     }
 }

--- a/core-bundle/assets/controllers/sortable-controller.js
+++ b/core-bundle/assets/controllers/sortable-controller.js
@@ -34,7 +34,7 @@ export default class extends Controller {
     }
 
     /**
-     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6.
+     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7.
      */
     fallbackHandleTargetConnected(el) {
         // No need to remove the class if a primaryHandleTarget exists (see #8859)

--- a/core-bundle/assets/styles/layout/list-view.pcss
+++ b/core-bundle/assets/styles/layout/list-view.pcss
@@ -477,13 +477,13 @@
     color: var(--red);
 }
 
-/** Deprecated in Contao 5.6, to be removed in Contao 6 */
+/** Deprecated in Contao 5.6, to be removed in Contao 7 */
 .cte_type.icon-protected {
     padding-left: 27px;
     background: var(--table-header) url("../../icons/protected.svg") 8px 8px no-repeat;
 }
 
-/* Deprecated in Contao 5.7, to be removed in Contao 6 */
+/* Deprecated in Contao 5.7, to be removed in Contao 7 */
 .cte_type .visibility,
 .cte_type .type {
     color: var(--gray);

--- a/core-bundle/contao/classes/Backend.php
+++ b/core-bundle/contao/classes/Backend.php
@@ -798,12 +798,12 @@ abstract class Backend extends Controller
 	 *
 	 * @return string
 	 *
-	 * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
 	 *             use the Stimulus controller instead.
 	 */
 	public static function getTogglePasswordWizard($inputName)
 	{
-		trigger_deprecation('contao/core-bundle', '5.6', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the Stimulus controller instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.6', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the Stimulus controller instead.', __METHOD__);
 
 		return ' <button type="button" class="image-button" id="pw_' . $inputName . '">' . Image::getHtml('visible.svg', $GLOBALS['TL_LANG']['MSC']['showPassword']) . '</button>
   <script>

--- a/core-bundle/contao/classes/BackendUser.php
+++ b/core-bundle/contao/classes/BackendUser.php
@@ -47,7 +47,7 @@ class BackendUser extends User
 	/**
 	 * Name of the current cookie
 	 * @var string
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	protected $strCookie = 'BE_USER_AUTH';
 
@@ -146,12 +146,12 @@ class BackendUser extends User
 	 *
 	 * @return boolean
 	 *
-	 * @deprecated Deprecated since Contao 5.2, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.2, to be removed in Contao 7;
 	 *             use the "ContaoCorePermissions::USER_CAN_ACCESS_*" permissions instead.
 	 */
 	public function hasAccess($field, $array)
 	{
-		trigger_deprecation('contao/core-bundle', '5.2', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the "ContaoCorePermissions::USER_CAN_ACCESS_*" permissions instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.2', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the "ContaoCorePermissions::USER_CAN_ACCESS_*" permissions instead.', __METHOD__);
 
 		if ($this->isAdmin)
 		{

--- a/core-bundle/contao/classes/BackendUser.php
+++ b/core-bundle/contao/classes/BackendUser.php
@@ -45,13 +45,6 @@ class BackendUser extends User
 	protected $strTable = 'tl_user';
 
 	/**
-	 * Name of the current cookie
-	 * @var string
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
-	 */
-	protected $strCookie = 'BE_USER_AUTH';
-
-	/**
 	 * File mount IDs
 	 * @var array
 	 */
@@ -71,7 +64,6 @@ class BackendUser extends User
 		parent::__construct();
 
 		$this->strIp = Environment::get('ip');
-		$this->strHash = Input::cookie($this->strCookie);
 	}
 
 	/**

--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -261,7 +261,7 @@ abstract class DataContainer extends Backend
 	/**
 	 * Active record
 	 * @var Model|object|null
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7;
 	 *             use DataContainer::getCurrentRecord() or DC_Table::getActiveRecord() instead.
 	 */
 	protected $objActiveRecord;
@@ -340,7 +340,7 @@ abstract class DataContainer extends Backend
 		switch ($strKey)
 		{
 			case 'activeRecord':
-				trigger_deprecation('contao/core-bundle', '5.0', 'Setting the active record is deprecated and will be removed in Contao 6.');
+				trigger_deprecation('contao/core-bundle', '5.0', 'Setting the active record is deprecated and will be removed in Contao 7.');
 				$this->objActiveRecord = $varValue;
 				break;
 
@@ -361,7 +361,7 @@ abstract class DataContainer extends Backend
 				break;
 
 			default:
-				trigger_deprecation('contao/core-bundle', '5.0', 'Accessing protected properties or adding dynamic ones is deprecated and will no longer work in Contao 6.');
+				trigger_deprecation('contao/core-bundle', '5.0', 'Accessing protected properties or adding dynamic ones is deprecated and will no longer work in Contao 7.');
 				$this->$strKey = $varValue;
 				break;
 		}
@@ -397,7 +397,7 @@ abstract class DataContainer extends Backend
 				return $this->strPalette;
 
 			case 'activeRecord':
-				trigger_deprecation('contao/core-bundle', '5.0', 'The active record is deprecated and will be removed in Contao 6. Use DataContainer::getCurrentRecord() or DC_Table::getActiveRecord() instead.');
+				trigger_deprecation('contao/core-bundle', '5.0', 'The active record is deprecated and will be removed in Contao 7. Use DataContainer::getCurrentRecord() or DC_Table::getActiveRecord() instead.');
 
 				return $this->objActiveRecord;
 
@@ -761,12 +761,12 @@ abstract class DataContainer extends Backend
 	 *
 	 * @return array
 	 *
-	 * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
 	 *             use the "contao.data_container.palette_builder" service instead.
 	 */
 	protected function combiner($names)
 	{
-		trigger_deprecation('contao/core-bundle', '5.6', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the "contao.data_container.palette_builder" service instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.6', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the "contao.data_container.palette_builder" service instead.', __METHOD__);
 
 		return System::getContainer()
 			->get('contao.data_container.palette_builder')
@@ -837,7 +837,7 @@ abstract class DataContainer extends Backend
 			$arrRow,
 			$this,
 			function (DataContainerOperation $config) use ($arrRow, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext) {
-				trigger_deprecation('contao/core-bundle', '5.5', 'Using a button_callback without DataContainerOperation object is deprecated and will no longer work in Contao 6.');
+				trigger_deprecation('contao/core-bundle', '5.5', 'Using a button_callback without DataContainerOperation object is deprecated and will no longer work in Contao 7.');
 
 				if (\is_array($config['button_callback'] ?? null))
 				{
@@ -866,7 +866,7 @@ abstract class DataContainer extends Backend
 	protected function generateGlobalButtons(/* DataContainerGlobalOperationsBuilder $operations */)
 	{
 		$legacyCallback = function (DataContainerOperation $config) {
-			trigger_deprecation('contao/core-bundle', '5.6', 'Using a button_callback without DataContainerOperation object is deprecated and will no longer work in Contao 6.');
+			trigger_deprecation('contao/core-bundle', '5.6', 'Using a button_callback without DataContainerOperation object is deprecated and will no longer work in Contao 7.');
 
 			if (!\is_array($config['button_callback'] ?? null) && !\is_callable($config['button_callback'] ?? null))
 			{
@@ -900,7 +900,7 @@ abstract class DataContainer extends Backend
 			return null;
 		}
 
-		trigger_deprecation('contao/core-bundle', '5.6', 'Calling DataContainer::generateGlobalButtons without a DataContainerGlobalOperationsBuilder object is deprecated and will no longer work in Contao 6.');
+		trigger_deprecation('contao/core-bundle', '5.6', 'Calling DataContainer::generateGlobalButtons without a DataContainerGlobalOperationsBuilder object is deprecated and will no longer work in Contao 7.');
 
 		$operations = System::getContainer()->get('contao.data_container.global_operations_builder')->initialize($this->strTable);
 		$operations->addGlobalButtons($this, $legacyCallback);
@@ -927,7 +927,7 @@ abstract class DataContainer extends Backend
 			$arrRow,
 			$dc,
 			static function (DataContainerOperation $config) use ($arrRow, $strPtable, $dc) {
-				trigger_deprecation('contao/core-bundle', '5.5', 'Using a button_callback without DataContainerOperation object is deprecated and will no longer work in Contao 6.');
+				trigger_deprecation('contao/core-bundle', '5.5', 'Using a button_callback without DataContainerOperation object is deprecated and will no longer work in Contao 7.');
 
 				if (\is_array($config['button_callback'] ?? null))
 				{

--- a/core-bundle/contao/classes/FrontendUser.php
+++ b/core-bundle/contao/classes/FrontendUser.php
@@ -31,13 +31,6 @@ class FrontendUser extends User
 	protected $strTable = 'tl_member';
 
 	/**
-	 * Name of the current cookie
-	 * @var string
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
-	 */
-	protected $strCookie = 'FE_USER_AUTH';
-
-	/**
 	 * Group login page
 	 * @var string
 	 */
@@ -63,7 +56,6 @@ class FrontendUser extends User
 		parent::__construct();
 
 		$this->strIp = Environment::get('ip');
-		$this->strHash = Input::cookie($this->strCookie);
 	}
 
 	/**

--- a/core-bundle/contao/classes/FrontendUser.php
+++ b/core-bundle/contao/classes/FrontendUser.php
@@ -33,7 +33,7 @@ class FrontendUser extends User
 	/**
 	 * Name of the current cookie
 	 * @var string
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	protected $strCookie = 'FE_USER_AUTH';
 

--- a/core-bundle/contao/classes/Hybrid.php
+++ b/core-bundle/contao/classes/Hybrid.php
@@ -23,7 +23,7 @@ use Contao\Model\Collection;
  * @property string $hl
  * @property string $attributes
  *
- * @deprecated extending from Hybrid is deprecated since Contao 6 and will no
+ * @deprecated extending from Hybrid is deprecated since Contao 6.0 and will no
  *             longer work in Contao 7; use a fragment controller instead
  */
 abstract class Hybrid extends Frontend
@@ -159,7 +159,7 @@ abstract class Hybrid extends Frontend
 
 		if ($this->typePrefix = $objElement->typePrefix)
 		{
-			trigger_deprecation('contao/core-bundle', '5.6', 'Passing the "typePrefix" via the model is deprecated and will no longer work in Contao 6. Pass the prefix via the constructor instead.');
+			trigger_deprecation('contao/core-bundle', '5.6', 'Passing the "typePrefix" via the model is deprecated and will no longer work in Contao 7. Pass the prefix via the constructor instead.');
 		}
 		else
 		{

--- a/core-bundle/contao/classes/Messages.php
+++ b/core-bundle/contao/classes/Messages.php
@@ -10,12 +10,12 @@
 
 namespace Contao;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6.', Messages::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7.', Messages::class);
 
 /**
  * Add system messages to the welcome screen.
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6.
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7.
  */
 class Messages extends Backend
 {

--- a/core-bundle/contao/controllers/FrontendIndex.php
+++ b/core-bundle/contao/controllers/FrontendIndex.php
@@ -29,12 +29,12 @@ class FrontendIndex extends Frontend
 	 * @throws PageNotFoundException
 	 * @throws AccessDeniedException
 	 *
-	 * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
 	 *             use the AbstractPageController instead.
 	 */
 	public function renderPage(PageModel $pageModel): Response
 	{
-		trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the AbstractPageController instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the AbstractPageController instead.', __METHOD__);
 
 		return System::getContainer()->get(RegularPageController::class)($pageModel);
 	}

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -873,11 +873,11 @@ class tl_content extends Backend
 	 *
 	 * @return string
 	 *
-	 * @deprecated Deprecated in Contao 5.7, to be removed in Contao 6.
+	 * @deprecated Deprecated in Contao 5.7, to be removed in Contao 7.
 	 */
 	public function getContentElementGroup($element)
 	{
-		trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		foreach ($GLOBALS['TL_CTE'] as $k=>$v)
 		{
@@ -982,11 +982,11 @@ class tl_content extends Backend
 	 *
 	 * @return array
 	 *
-	 * @deprecated Deprecated in Contao 5.7, to be removed in Contao 6.
+	 * @deprecated Deprecated in Contao 5.7, to be removed in Contao 7.
 	 */
 	public function addCteType($arrRow)
 	{
-		trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		$key = $arrRow['invisible'] ? 'unpublished' : 'published';
 		$type = $GLOBALS['TL_LANG']['CTE'][$arrRow['type']][0] ?? $arrRow['type'];

--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -329,7 +329,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			// Backwards compatibility
 			if (Input::get('childs') !== null)
 			{
-				trigger_deprecation('contao/core-bundle', '5.3', 'Using the "childs" query parameter is deprecated and will no longer work in Contao 6. Use the "children" parameter instead.');
+				trigger_deprecation('contao/core-bundle', '5.3', 'Using the "childs" query parameter is deprecated and will no longer work in Contao 7. Use the "children" parameter instead.');
 				$children = Input::get('childs');
 			}
 
@@ -571,7 +571,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 		}
 		elseif (null !== ($buttons = $this->generateGlobalButtons($operations)))
 		{
-			trigger_deprecation('contao/core-bundle', '5.6', 'Overriding DataContainer::generateGlobalButtons() is deprecated and will no longer work in Contao 6.');
+			trigger_deprecation('contao/core-bundle', '5.6', 'Overriding DataContainer::generateGlobalButtons() is deprecated and will no longer work in Contao 7.');
 
 			$operations->append(array('html' => $buttons), true);
 		}

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -480,7 +480,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			// Backwards compatibility
 			if (Input::get('childs') !== null)
 			{
-				trigger_deprecation('contao/core-bundle', '5.3', 'Using the "childs" query parameter is deprecated and will no longer work in Contao 6. Use the "children" parameter instead.');
+				trigger_deprecation('contao/core-bundle', '5.3', 'Using the "childs" query parameter is deprecated and will no longer work in Contao 7. Use the "children" parameter instead.');
 				$children = Input::get('childs');
 			}
 
@@ -1221,12 +1221,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 	}
 
 	/**
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use copyChildren() instead.
 	 */
 	protected function copyChilds($table, $insertID, $id, $parentId)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use "copyChildren()" instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use "copyChildren()" instead.', __METHOD__);
 		$this->copyChildren($table, $insertID, $id, $parentId);
 	}
 
@@ -1250,7 +1250,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		// Backwards compatibility
 		if (Input::get('childs') !== null)
 		{
-			trigger_deprecation('contao/core-bundle', '5.3', 'Using the "childs" query parameter is deprecated and will no longer work in Contao 6. Use the "children" parameter instead.');
+			trigger_deprecation('contao/core-bundle', '5.3', 'Using the "childs" query parameter is deprecated and will no longer work in Contao 7. Use the "children" parameter instead.');
 			$children = Input::get('childs');
 		}
 
@@ -1902,12 +1902,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 	}
 
 	/**
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use deleteChildren() instead.
 	 */
 	protected function deleteChilds($table, $id, &$delete)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use "deleteChildren()" instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use "deleteChildren()" instead.', __METHOD__);
 		$this->deleteChildren($table, $id, $delete);
 	}
 
@@ -3482,7 +3482,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 		elseif (null !== ($buttons = $this->generateGlobalButtons($operations)))
 		{
-			trigger_deprecation('contao/core-bundle', '5.6', 'Overriding DataContainer::generateGlobalButtons() is deprecated and will no longer work in Contao 6.');
+			trigger_deprecation('contao/core-bundle', '5.6', 'Overriding DataContainer::generateGlobalButtons() is deprecated and will no longer work in Contao 7.');
 
 			$operations->append(array('html' => $buttons), true);
 		}
@@ -4173,7 +4173,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 		elseif (null !== ($buttons = $this->generateGlobalButtons($operations)))
 		{
-			trigger_deprecation('contao/core-bundle', '5.6', 'Overriding DataContainer::generateGlobalButtons() is deprecated and will no longer work in Contao 6.');
+			trigger_deprecation('contao/core-bundle', '5.6', 'Overriding DataContainer::generateGlobalButtons() is deprecated and will no longer work in Contao 7.');
 
 			$operations->append(array('html' => $buttons), true);
 		}
@@ -4653,7 +4653,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		if (null !== ($buttons = $this->generateGlobalButtons($operations)))
 		{
-			trigger_deprecation('contao/core-bundle', '5.6', 'Overriding DataContainer::generateGlobalButtons() is deprecated and will no longer work in Contao 6.');
+			trigger_deprecation('contao/core-bundle', '5.6', 'Overriding DataContainer::generateGlobalButtons() is deprecated and will no longer work in Contao 7.');
 
 			$operations->append(array('html' => $buttons), true);
 		}
@@ -5593,11 +5593,11 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 	 *
 	 * @return string
 	 *
-	 * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6. Use ValueFormatter::formatGroup() instead.
+	 * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7. Use ValueFormatter::formatGroup() instead.
 	 */
 	protected function formatCurrentValue($field, $value, $mode)
 	{
-		trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use "ValueFormatter::formatGroup()" instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use "ValueFormatter::formatGroup()" instead.', __METHOD__);
 
 		$valueFormatter = System::getContainer()->get('contao.data_container.value_formatter');
 

--- a/core-bundle/contao/elements/ContentAccordion.php
+++ b/core-bundle/contao/elements/ContentAccordion.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\AccordionController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentAccordion::class, AccordionController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentAccordion::class, AccordionController::class);
 
 /**
  * Front end content element "accordion".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\AccordionController instead.
  */
 class ContentAccordion extends ContentElement

--- a/core-bundle/contao/elements/ContentAccordionStart.php
+++ b/core-bundle/contao/elements/ContentAccordionStart.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\AccordionController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentAccordionStart::class, AccordionController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentAccordionStart::class, AccordionController::class);
 
 /**
  * Front end content element "accordion" (wrapper start).
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\AccordionController instead.
  */
 class ContentAccordionStart extends ContentElement

--- a/core-bundle/contao/elements/ContentAccordionStop.php
+++ b/core-bundle/contao/elements/ContentAccordionStop.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\AccordionController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentAccordionStop::class, AccordionController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentAccordionStop::class, AccordionController::class);
 
 /**
  * Front end content element "accordion" (wrapper stop).
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\AccordionController instead.
  */
 class ContentAccordionStop extends ContentElement

--- a/core-bundle/contao/elements/ContentCode.php
+++ b/core-bundle/contao/elements/ContentCode.php
@@ -13,12 +13,12 @@ namespace Contao;
 use Contao\CoreBundle\Controller\ContentElement\CodeController;
 use Highlight\Highlighter;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentCode::class, CodeController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentCode::class, CodeController::class);
 
 /**
  * Front end content element "code".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\CodeController instead.
  */
 class ContentCode extends ContentElement

--- a/core-bundle/contao/elements/ContentDownload.php
+++ b/core-bundle/contao/elements/ContentDownload.php
@@ -15,12 +15,12 @@ use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Image\Preview\MissingPreviewProviderException;
 use Contao\CoreBundle\Image\Preview\UnableToGeneratePreviewException;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentDownload::class, DownloadsController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentDownload::class, DownloadsController::class);
 
 /**
  * Front end content element "download".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\DownloadsController instead.
  */
 class ContentDownload extends ContentElement

--- a/core-bundle/contao/elements/ContentDownloads.php
+++ b/core-bundle/contao/elements/ContentDownloads.php
@@ -14,12 +14,12 @@ use Contao\CoreBundle\Controller\ContentElement\DownloadsController;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\Model\Collection;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentDownloads::class, DownloadsController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentDownloads::class, DownloadsController::class);
 
 /**
  * Front end content element "downloads".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\DownloadsController instead.
  */
 class ContentDownloads extends ContentDownload

--- a/core-bundle/contao/elements/ContentElement.php
+++ b/core-bundle/contao/elements/ContentElement.php
@@ -104,7 +104,7 @@ use Contao\Model\Collection;
  * @property integer $origId
  * @property string  $hl
  *
- * @deprecated extending from ContentElement is deprecated since Contao 6 and will
+ * @deprecated extending from ContentElement is deprecated since Contao 7 and will
  *             no longer work in Contao 7; use a fragment controller instead
  */
 abstract class ContentElement extends Frontend

--- a/core-bundle/contao/elements/ContentElement.php
+++ b/core-bundle/contao/elements/ContentElement.php
@@ -104,7 +104,7 @@ use Contao\Model\Collection;
  * @property integer $origId
  * @property string  $hl
  *
- * @deprecated extending from ContentElement is deprecated since Contao 7 and will
+ * @deprecated extending from ContentElement is deprecated since Contao 6.0 and will
  *             no longer work in Contao 7; use a fragment controller instead
  */
 abstract class ContentElement extends Frontend

--- a/core-bundle/contao/elements/ContentGallery.php
+++ b/core-bundle/contao/elements/ContentGallery.php
@@ -15,12 +15,12 @@ use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\Model\Collection;
 use Symfony\Component\Filesystem\Path;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentGallery::class, ImagesController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentGallery::class, ImagesController::class);
 
 /**
  * Front end content element "gallery".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\ImagesController instead.
  */
 class ContentGallery extends ContentElement

--- a/core-bundle/contao/elements/ContentHeadline.php
+++ b/core-bundle/contao/elements/ContentHeadline.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\HeadlineController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentHeadline::class, HeadlineController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentHeadline::class, HeadlineController::class);
 
 /**
  * Front end content element "headline".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\HeadlineController instead.
  */
 class ContentHeadline extends ContentElement

--- a/core-bundle/contao/elements/ContentHtml.php
+++ b/core-bundle/contao/elements/ContentHtml.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\HtmlController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentHtml::class, HtmlController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentHtml::class, HtmlController::class);
 
 /**
  * Front end content element "HTML".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\HtmlController instead.
  */
 class ContentHtml extends ContentElement

--- a/core-bundle/contao/elements/ContentHyperlink.php
+++ b/core-bundle/contao/elements/ContentHyperlink.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\HyperlinkController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentHyperlink::class, HyperlinkController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentHyperlink::class, HyperlinkController::class);
 
 /**
  * Front end content element "hyperlink".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\HyperlinkController instead.
  */
 class ContentHyperlink extends ContentElement

--- a/core-bundle/contao/elements/ContentImage.php
+++ b/core-bundle/contao/elements/ContentImage.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\ImagesController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentImage::class, ImagesController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentImage::class, ImagesController::class);
 
 /**
  * Front end content element "image".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\ImagesController instead.
  */
 class ContentImage extends ContentElement

--- a/core-bundle/contao/elements/ContentList.php
+++ b/core-bundle/contao/elements/ContentList.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\ListController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentList::class, ListController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentList::class, ListController::class);
 
 /**
  * Front end content element "list".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\ListController instead.
  */
 class ContentList extends ContentElement

--- a/core-bundle/contao/elements/ContentPlayer.php
+++ b/core-bundle/contao/elements/ContentPlayer.php
@@ -14,12 +14,12 @@ use Contao\CoreBundle\Controller\ContentElement\PlayerController;
 use Contao\CoreBundle\Util\LocaleUtil;
 use Contao\Model\Collection;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentPlayer::class, PlayerController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentPlayer::class, PlayerController::class);
 
 /**
  * Content element "player".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\PlayerController instead.
  */
 class ContentPlayer extends ContentElement

--- a/core-bundle/contao/elements/ContentSliderStart.php
+++ b/core-bundle/contao/elements/ContentSliderStart.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\SwiperController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentSliderStart::class, SwiperController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentSliderStart::class, SwiperController::class);
 
 /**
  * Front end content element "slider" (wrapper start).
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\SwiperController instead.
  */
 class ContentSliderStart extends ContentElement

--- a/core-bundle/contao/elements/ContentSliderStop.php
+++ b/core-bundle/contao/elements/ContentSliderStop.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\SwiperController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentSliderStop::class, SwiperController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentSliderStop::class, SwiperController::class);
 
 /**
  * Front end content element "slider" (wrapper stop).
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\SwiperController instead.
  */
 class ContentSliderStop extends ContentElement

--- a/core-bundle/contao/elements/ContentTable.php
+++ b/core-bundle/contao/elements/ContentTable.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\TableController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentTable::class, TableController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentTable::class, TableController::class);
 
 /**
  * Front end content element "table".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\TableController instead.
  */
 class ContentTable extends ContentElement

--- a/core-bundle/contao/elements/ContentTeaser.php
+++ b/core-bundle/contao/elements/ContentTeaser.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\TeaserController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentTeaser::class, TeaserController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentTeaser::class, TeaserController::class);
 
 /**
  * Front end content element "teaser".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\TeaserController instead.
  */
 class ContentTeaser extends ContentElement

--- a/core-bundle/contao/elements/ContentText.php
+++ b/core-bundle/contao/elements/ContentText.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\TextController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentText::class, TextController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentText::class, TextController::class);
 
 /**
  * Front end content element "text".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\TextController instead.
  */
 class ContentText extends ContentElement

--- a/core-bundle/contao/elements/ContentToplink.php
+++ b/core-bundle/contao/elements/ContentToplink.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\ToplinkController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentToplink::class, ToplinkController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentToplink::class, ToplinkController::class);
 
 /**
  * Front end content element "toplink".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\ToplinkController instead.
  */
 class ContentToplink extends ContentElement

--- a/core-bundle/contao/elements/ContentVimeo.php
+++ b/core-bundle/contao/elements/ContentVimeo.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\VideoController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentVimeo::class, VideoController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentVimeo::class, VideoController::class);
 
 /**
  * Content element "Vimeo".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\VideoController instead.
  */
 class ContentVimeo extends ContentElement

--- a/core-bundle/contao/elements/ContentYouTube.php
+++ b/core-bundle/contao/elements/ContentYouTube.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\VideoController;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ContentYouTube::class, VideoController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ContentYouTube::class, VideoController::class);
 
 /**
  * Content element "YouTube".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\VideoController instead.
  */
 class ContentYouTube extends ContentElement

--- a/core-bundle/contao/library/Contao/Automator.php
+++ b/core-bundle/contao/library/Contao/Automator.php
@@ -224,12 +224,12 @@ class Automator extends System
 	/**
 	 * Purge registrations that have not been activated within 24 hours
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7;
 	 *             use MemberModel::findExpiredRegistrations() instead.
 	 */
 	public function purgeRegistrations()
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use "MemberModel::findExpiredRegistrations()" instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use "MemberModel::findExpiredRegistrations()" instead.', __METHOD__);
 
 		$objMember = MemberModel::findExpiredRegistrations();
 
@@ -249,12 +249,12 @@ class Automator extends System
 	/**
 	 * Purge opt-in tokens
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7;
 	 *             use the "contao.opt_in" service instead.
 	 */
 	public function purgeOptInTokens()
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the "contao.opt_in" service instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the "contao.opt_in" service instead.', __METHOD__);
 
 		$optIn = System::getContainer()->get('contao.opt_in');
 		$optIn->purgeTokens();

--- a/core-bundle/contao/library/Contao/Combiner.php
+++ b/core-bundle/contao/library/Contao/Combiner.php
@@ -266,11 +266,11 @@ class Combiner extends System
 	 *
 	 * @return string The debug markup
 	 *
-	 * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7.
 	 */
 	protected function getDebugMarkup($strUrl)
 	{
-		trigger_deprecation('contao/core-bundle', '5.6', 'Using "%s::%s()" is deprecated and will no longer work in Contao 6.', __CLASS__, __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.6', 'Using "%s::%s()" is deprecated and will no longer work in Contao 7.', __CLASS__, __METHOD__);
 
 		$return = $this->getFileUrls($strUrl);
 

--- a/core-bundle/contao/library/Contao/Config.php
+++ b/core-bundle/contao/library/Contao/Config.php
@@ -307,13 +307,13 @@ class Config
 	/**
 	 * Return true if the installation is complete
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 *
 	 * @return boolean True if the installation is complete
 	 */
 	public static function isComplete()
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s" is deprecated an will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s" is deprecated an will no longer work in Contao 7.', __METHOD__);
 
 		return true;
 	}

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -1130,12 +1130,12 @@ abstract class Controller extends System
 	 *
 	 * @throws AccessDeniedException
 	 *
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use the Symfony BinaryFileResponse instead.
 	 */
 	public static function sendFileToBrowser($strFile, $inline=false)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the Symfony BinaryFileResponse instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the Symfony BinaryFileResponse instead.', __METHOD__);
 
 		// Make sure there are no attempts to hack the file system
 		if (preg_match('@^\.+@', $strFile) || preg_match('@\.+/@', $strFile) || preg_match('@(://)+@', $strFile))
@@ -1210,12 +1210,12 @@ abstract class Controller extends System
 	 *
 	 * @return string The URL of the target page
 	 *
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use the contao_backend_preview route instead.
 	 */
 	protected function redirectToFrontendPage($intPage, $strArticle=null, $blnReturn=false)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the contao_backend_preview route instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the contao_backend_preview route instead.', __METHOD__);
 
 		if (($intPage = (int) $intPage) <= 0)
 		{

--- a/core-bundle/contao/library/Contao/Database.php
+++ b/core-bundle/contao/library/Contao/Database.php
@@ -87,7 +87,7 @@ class Database
 	 */
 	public function __get($strKey)
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s->%s" is deprecated and will no longer work in Contao 6.', __CLASS__, $strKey);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s->%s" is deprecated and will no longer work in Contao 7.', __CLASS__, $strKey);
 
 		return null;
 	}

--- a/core-bundle/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/contao/library/Contao/DcaLoader.php
@@ -158,7 +158,7 @@ class DcaLoader extends Controller
 
 		if (!isset($GLOBALS['TL_DCA'][$this->strTable]))
 		{
-			trigger_deprecation('contao/core-bundle', '5.0', 'Loading a non-existent DCA "%s" is deprecated and will no longer work in Contao 6.', $this->strTable);
+			trigger_deprecation('contao/core-bundle', '5.0', 'Loading a non-existent DCA "%s" is deprecated and will no longer work in Contao 7.', $this->strTable);
 		}
 	}
 

--- a/core-bundle/contao/library/Contao/Environment.php
+++ b/core-bundle/contao/library/Contao/Environment.php
@@ -314,7 +314,7 @@ class Environment
 	 */
 	protected static function script()
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use "%s::%s" instead.', __METHOD__, __CLASS__, 'scriptName');
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use "%s::%s" instead.', __METHOD__, __CLASS__, 'scriptName');
 
 		return preg_replace('/^' . preg_quote(static::get('path'), '/') . '\/?/', '', static::get('scriptName'));
 	}
@@ -326,7 +326,7 @@ class Environment
 	 */
 	protected static function request()
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use "%s::%s" instead.', __METHOD__, __CLASS__, 'requestUri');
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use "%s::%s" instead.', __METHOD__, __CLASS__, 'requestUri');
 
 		return preg_replace('/^' . preg_quote(static::get('path'), '/') . '\/?/', '', static::get('requestUri'));
 	}
@@ -407,7 +407,7 @@ class Environment
 			return $request;
 		}
 
-		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_SERVER with the "%s" class is deprecated and will no longer work in Contao 6. Make sure the request_stack has a request instead.', __CLASS__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_SERVER with the "%s" class is deprecated and will no longer work in Contao 7. Make sure the request_stack has a request instead.', __CLASS__);
 
 		return new Request(server: $_SERVER);
 	}

--- a/core-bundle/contao/library/Contao/Feed.php
+++ b/core-bundle/contao/library/Contao/Feed.php
@@ -10,7 +10,7 @@
 
 namespace Contao;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6.', Feed::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7.', Feed::class);
 
 /**
  * Creates RSS or Atom feeds
@@ -36,7 +36,7 @@ trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprec
  * @property string  $link        The feed link
  * @property integer $published   The publication date
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6.
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7.
  */
 class Feed
 {

--- a/core-bundle/contao/library/Contao/FeedItem.php
+++ b/core-bundle/contao/library/Contao/FeedItem.php
@@ -12,7 +12,7 @@ namespace Contao;
 
 use Symfony\Component\Filesystem\Path;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6.', FeedItem::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7.', FeedItem::class);
 
 /**
  * Creates items to be appended to RSS or Atom feeds
@@ -40,7 +40,7 @@ trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprec
  * @property string  $author      The item author
  * @property string  $description The item description
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6.
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7.
  */
 class FeedItem
 {

--- a/core-bundle/contao/library/Contao/Input.php
+++ b/core-bundle/contao/library/Contao/Input.php
@@ -181,7 +181,7 @@ class Input
 			return array_map(\strval(...), array_values($keys));
 		}
 
-		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_GET with the "%s" class is deprecated and will no longer work in Contao 6. Make sure the request_stack has a request instead.', __CLASS__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_GET with the "%s" class is deprecated and will no longer work in Contao 7. Make sure the request_stack has a request instead.', __CLASS__);
 
 		return array_map(\strval(...), array_keys($_GET ?? array()));
 	}
@@ -227,7 +227,7 @@ class Input
 			return $request->isMethod('POST');
 		}
 
-		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_POST with the "%s" class is deprecated and will no longer work in Contao 6. Make sure the request_stack has a request instead.', __CLASS__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_POST with the "%s" class is deprecated and will no longer work in Contao 7. Make sure the request_stack has a request instead.', __CLASS__);
 
 		return !empty($_POST);
 	}
@@ -248,7 +248,7 @@ class Input
 
 		if (!$blnDecodeEntities)
 		{
-			trigger_deprecation('contao/core-bundle', '5.0', 'Using %s() with $blnDecodeEntities set to false is deprecated and will no longer work in Contao 6.', __METHOD__);
+			trigger_deprecation('contao/core-bundle', '5.0', 'Using %s() with $blnDecodeEntities set to false is deprecated and will no longer work in Contao 7.', __METHOD__);
 		}
 
 		$varValue = static::findPost($strKey);
@@ -376,7 +376,7 @@ class Input
 
 		if (\func_num_args() > 2 && func_get_arg(2))
 		{
-			trigger_deprecation('contao/core-bundle', '5.0', 'Using %s() with the third parameter "$blnAddUnused" is deprecated and will no longer work in Contao 6.', __METHOD__);
+			trigger_deprecation('contao/core-bundle', '5.0', 'Using %s() with the third parameter "$blnAddUnused" is deprecated and will no longer work in Contao 7.', __METHOD__);
 			self::$arrUnusedRouteParameters[$strKey] = true;
 		}
 
@@ -422,11 +422,11 @@ class Input
 	 * @param string $strKey   The variable name
 	 * @param mixed  $varValue The variable value
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function setCookie($strKey, $varValue)
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		$strKey = static::cleanKeyInternal($strKey);
 
@@ -450,11 +450,11 @@ class Input
 	/**
 	 * Reset the internal cache
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function resetCache()
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 	}
 
 	/**
@@ -462,11 +462,11 @@ class Input
 	 *
 	 * @return boolean True if there are unused GET parameters
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function hasUnusedGet()
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		return \count(static::getUnusedRouteParameters()) > 0;
 	}
@@ -476,11 +476,11 @@ class Input
 	 *
 	 * @return array The unused GET parameter array
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function getUnusedGet()
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		return static::getUnusedRouteParameters();
 	}
@@ -491,11 +491,11 @@ class Input
 	 * @param string $strKey   The array key
 	 * @param mixed  $varValue The array value
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function setUnusedGet($strKey, $varValue)
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		self::$arrUnusedRouteParameters[$strKey] = true;
 	}
@@ -503,11 +503,11 @@ class Input
 	/**
 	 * Reset the unused GET parameters
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function resetUnusedGet()
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		static::setUnusedRouteParameters(array());
 	}
@@ -547,11 +547,11 @@ class Input
 	 *
 	 * @return mixed The clean name or array of names
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function cleanKey($varValue)
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		return static::cleanKeyInternal($varValue);
 	}
@@ -589,7 +589,7 @@ class Input
 
 		if ((\is_array($varValue) ? $varValue : (string) $varValue) !== $encoded)
 		{
-			trigger_deprecation('contao/core-bundle', '5.0', 'Relying on input keys being encoded in "%s::cleanKey()" is deprecated and will no longer work in Contao 6.', __CLASS__);
+			trigger_deprecation('contao/core-bundle', '5.0', 'Relying on input keys being encoded in "%s::cleanKey()" is deprecated and will no longer work in Contao 7.', __CLASS__);
 		}
 
 		return $encoded;
@@ -876,11 +876,11 @@ class Input
 	 *
 	 * @return mixed The cleaned string or array
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function xssClean($varValue, $blnStrictMode=false)
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		if (!$varValue)
 		{
@@ -995,11 +995,11 @@ class Input
 	 *
 	 * @return mixed The decoded string or array
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function decodeEntities($varValue)
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		if (!$varValue)
 		{
@@ -1031,11 +1031,11 @@ class Input
 	 *
 	 * @return mixed The string or array with the converted entities
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function preserveBasicEntities($varValue)
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		if (!$varValue)
 		{
@@ -1070,11 +1070,11 @@ class Input
 	 *
 	 * @return mixed The encoded string or array
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public static function encodeSpecialChars($varValue)
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
 
 		if (!$varValue)
 		{
@@ -1169,7 +1169,7 @@ class Input
 			return $request->query->all()[$strKey] ?? null;
 		}
 
-		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_GET with the "%s" class is deprecated and will no longer work in Contao 6. Make sure the request_stack has a request instead.', __CLASS__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_GET with the "%s" class is deprecated and will no longer work in Contao 7. Make sure the request_stack has a request instead.', __CLASS__);
 
 		return $_GET[$strKey] ?? null;
 	}
@@ -1201,7 +1201,7 @@ class Input
 			return $request->request->all()[$strKey] ?? null;
 		}
 
-		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_POST with the "%s" class is deprecated and will no longer work in Contao 6. Make sure the request_stack has a request instead.', __CLASS__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_POST with the "%s" class is deprecated and will no longer work in Contao 7. Make sure the request_stack has a request instead.', __CLASS__);
 
 		return $_POST[$strKey] ?? null;
 	}
@@ -1233,7 +1233,7 @@ class Input
 			return $request->cookies->all()[$strKey] ?? null;
 		}
 
-		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_COOKIE with the "%s" class is deprecated and will no longer work in Contao 6. Make sure the request_stack has a request instead.', __CLASS__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_COOKIE with the "%s" class is deprecated and will no longer work in Contao 7. Make sure the request_stack has a request instead.', __CLASS__);
 
 		return $_COOKIE[$strKey] ?? null;
 	}

--- a/core-bundle/contao/library/Contao/InsertTags.php
+++ b/core-bundle/contao/library/Contao/InsertTags.php
@@ -184,7 +184,7 @@ class InsertTags extends Controller
 			{
 				if (($elements[1] ?? null) == 'referer' || str_starts_with($elements[0], 'cache_'))
 				{
-					trigger_deprecation('contao/core-bundle', '5.0', 'The insert tag naming conventions {{cache_*}} and {{*::referer}} for fragments are deprecated and will no longer work in Contao 6. Use {{fragment::*}} instead.');
+					trigger_deprecation('contao/core-bundle', '5.0', 'The insert tag naming conventions {{cache_*}} and {{*::referer}} for fragments are deprecated and will no longer work in Contao 7. Use {{fragment::*}} instead.');
 
 					$attributes = array('insertTag' => '{{' . $strTag . '}}');
 
@@ -211,7 +211,7 @@ class InsertTags extends Controller
 
 			if (strtolower($elements[0]) !== $elements[0])
 			{
-				trigger_deprecation('contao/core-bundle', '5.0', 'Insert tags with uppercase letters ("%s") are deprecated and will no longer work in Contao 6. Use "%s" instead.', $elements[0], strtolower($elements[0]));
+				trigger_deprecation('contao/core-bundle', '5.0', 'Insert tags with uppercase letters ("%s") are deprecated and will no longer work in Contao 7. Use "%s" instead.', $elements[0], strtolower($elements[0]));
 			}
 
 			// Replace the tag
@@ -223,7 +223,7 @@ class InsertTags extends Controller
 					{
 						if (isset($GLOBALS['TL_HOOKS']['replaceInsertTags']) && \is_array($GLOBALS['TL_HOOKS']['replaceInsertTags']))
 						{
-							trigger_deprecation('contao/core-bundle', '5.2', 'Using the "replaceInsertTags" hook is deprecated and will no longer work in Contao 6. Use the "%s" attribute instead.', AsInsertTag::class);
+							trigger_deprecation('contao/core-bundle', '5.2', 'Using the "replaceInsertTags" hook is deprecated and will no longer work in Contao 7. Use the "%s" attribute instead.', AsInsertTag::class);
 
 							foreach ($GLOBALS['TL_HOOKS']['replaceInsertTags'] as $callback)
 							{
@@ -258,7 +258,7 @@ class InsertTags extends Controller
 					switch ($flag)
 					{
 						case 'flatten':
-							trigger_deprecation('contao/core-bundle', '5.0', 'The insert tag flag "|flatten" is deprecated and will no longer work in Contao 6. Use a proper insert tag instead.');
+							trigger_deprecation('contao/core-bundle', '5.0', 'The insert tag flag "|flatten" is deprecated and will no longer work in Contao 7. Use a proper insert tag instead.');
 
 							if (\is_array($arrCache[$strTag]))
 							{
@@ -283,7 +283,7 @@ class InsertTags extends Controller
 							// HOOK: pass unknown flags to callback functions
 							if (isset($GLOBALS['TL_HOOKS']['insertTagFlags']) && \is_array($GLOBALS['TL_HOOKS']['insertTagFlags']))
 							{
-								trigger_deprecation('contao/core-bundle', '5.2', 'Using the "insertTagFlags" hook is deprecated and will no longer work in Contao 6. Use the "%s" attribute instead.', AsInsertTagFlag::class);
+								trigger_deprecation('contao/core-bundle', '5.2', 'Using the "insertTagFlags" hook is deprecated and will no longer work in Contao 7. Use the "%s" attribute instead.', AsInsertTagFlag::class);
 
 								foreach ($GLOBALS['TL_HOOKS']['insertTagFlags'] as $callback)
 								{

--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -265,12 +265,12 @@ abstract class Model
 		{
 			if ($varValue !== ($varNewValue = static::convertToPhpValue($strKey, $varValue)))
 			{
-				trigger_deprecation('contao/core-bundle', '5.0', 'Setting "%s::$%s" to type %s is deprecated and will no longer work in Contao 6. Use type "%s" instead.', get_debug_type($this), $strKey, get_debug_type($varValue), get_debug_type($varNewValue));
+				trigger_deprecation('contao/core-bundle', '5.0', 'Setting "%s::$%s" to type %s is deprecated and will no longer work in Contao 7. Use type "%s" instead.', get_debug_type($this), $strKey, get_debug_type($varValue), get_debug_type($varNewValue));
 			}
 		}
 		catch (\TypeError)
 		{
-			trigger_deprecation('contao/core-bundle', '5.0', 'Setting "%s::$%s" to type %s is deprecated and will no longer work in Contao 6. Use the appropriate type instead.', get_debug_type($this), $strKey, get_debug_type($varValue));
+			trigger_deprecation('contao/core-bundle', '5.0', 'Setting "%s::$%s" to type %s is deprecated and will no longer work in Contao 7. Use the appropriate type instead.', get_debug_type($this), $strKey, get_debug_type($varValue));
 		}
 	}
 
@@ -1292,7 +1292,7 @@ abstract class Model
 		{
 			if (($arrOptions['return'] ?? null) == 'Array')
 			{
-				trigger_deprecation('contao/core-bundle', '5.2', 'Using "Array" as return type for model queries is deprecated and will no longer work in Contao 6. Use the "getModels()" method instead.');
+				trigger_deprecation('contao/core-bundle', '5.2', 'Using "Array" as return type for model queries is deprecated and will no longer work in Contao 7. Use the "getModels()" method instead.');
 
 				return array();
 			}
@@ -1317,7 +1317,7 @@ abstract class Model
 
 		if (($arrOptions['return'] ?? null) == 'Array')
 		{
-			trigger_deprecation('contao/core-bundle', '5.2', 'Using "Array" as return type for model queries is deprecated and will no longer work in Contao 6. Use the "getModels()" method instead.');
+			trigger_deprecation('contao/core-bundle', '5.2', 'Using "Array" as return type for model queries is deprecated and will no longer work in Contao 7. Use the "getModels()" method instead.');
 
 			return static::createCollectionFromDbResult($objResult, static::$strTable)->getModels();
 		}

--- a/core-bundle/contao/library/Contao/Pagination.php
+++ b/core-bundle/contao/library/Contao/Pagination.php
@@ -12,7 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Framework\Adapter;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "contao.pagination.factory" instead.', Pagination::class);
+trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "contao.pagination.factory" instead.', Pagination::class);
 
 /**
  * Provide methods to render a pagination menu.

--- a/core-bundle/contao/library/Contao/System.php
+++ b/core-bundle/contao/library/Contao/System.php
@@ -111,7 +111,7 @@ abstract class System
 			return null;
 		}
 
-		trigger_deprecation('contao/core-bundle', '5.2', 'Using objects that have been imported via "Contao\System::import()" is deprecated and will no longer work in Contao 6. Use "Contao\System::importStatic()" or dependency injection instead.');
+		trigger_deprecation('contao/core-bundle', '5.2', 'Using objects that have been imported via "Contao\System::import()" is deprecated and will no longer work in Contao 7. Use "Contao\System::importStatic()" or dependency injection instead.');
 
 		return $this->arrObjects[$strKey];
 	}
@@ -566,7 +566,7 @@ abstract class System
 	 */
 	public static function setCookie($strName, $varValue, $intExpires, $strPath=null, $strDomain=null, $blnSecure=null, $blnHttpOnly=false)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "Contao\System::setCookie()" is deprecated and will no longer work in Contao 6. Use Symfony\'s HttpFoundation and kernel.response events instead.');
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "Contao\System::setCookie()" is deprecated and will no longer work in Contao 7. Use Symfony\'s HttpFoundation and kernel.response events instead.');
 
 		if (!$strPath)
 		{
@@ -596,7 +596,7 @@ abstract class System
 		// HOOK: allow adding custom logic
 		if (isset($GLOBALS['TL_HOOKS']['setCookie']) && \is_array($GLOBALS['TL_HOOKS']['setCookie']))
 		{
-			trigger_deprecation('contao/core-bundle', '5.3', 'Using the "setCookie" hook is deprecated and will no longer work in Contao 6. Use the kernel.response events instead.');
+			trigger_deprecation('contao/core-bundle', '5.3', 'Using the "setCookie" hook is deprecated and will no longer work in Contao 7. Use the kernel.response events instead.');
 
 			foreach ($GLOBALS['TL_HOOKS']['setCookie'] as $callback)
 			{

--- a/core-bundle/contao/library/Contao/Template.php
+++ b/core-bundle/contao/library/Contao/Template.php
@@ -62,7 +62,7 @@ use Symfony\Component\VarDumper\VarDumper;
  * @property array        $trustedDevices
  * @property string       $currentDevice
  *
- * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7;
  *             use Twig templates instead
  */
 abstract class Template extends Controller

--- a/core-bundle/contao/library/Contao/User.php
+++ b/core-bundle/contao/library/Contao/User.php
@@ -120,7 +120,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	/**
 	 * Authentication hash
 	 * @var string
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	protected $strHash;
 
@@ -133,7 +133,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	/**
 	 * Cookie name
 	 * @var string
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	protected $strCookie;
 
@@ -302,11 +302,11 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	 *
 	 * @return boolean True if the user is a member of the group
 	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
 	 */
 	public function isMemberOf($ids)
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the "ContaoCorePermissions::MEMBER_IN_GROUPS" permission instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the "ContaoCorePermissions::MEMBER_IN_GROUPS" permission instead.', __METHOD__);
 
 		// Filter non-numeric values
 		$ids = array_filter((array) $ids, static function ($val) { return (string) (int) $val === (string) $val; });

--- a/core-bundle/contao/library/Contao/User.php
+++ b/core-bundle/contao/library/Contao/User.php
@@ -118,24 +118,10 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	protected $strIp;
 
 	/**
-	 * Authentication hash
-	 * @var string
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
-	 */
-	protected $strHash;
-
-	/**
 	 * Table
 	 * @var string
 	 */
 	protected $strTable;
-
-	/**
-	 * Cookie name
-	 * @var string
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
-	 */
-	protected $strCookie;
 
 	/**
 	 * Data

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -502,12 +502,12 @@ class PageModel extends Model
 	 *
 	 * @return PageModel|null The model or null if there is no 401 page
 	 *
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use the contao.routing.page_finder service instead.
 	 */
 	public static function find401ByPid($intPid, array $arrOptions=array())
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the "contao.routing.page_finder" service instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the "contao.routing.page_finder" service instead.', __METHOD__);
 
 		$t = static::$strTable;
 		$arrColumns = array("$t.pid=? AND $t.type='error_401'");
@@ -534,12 +534,12 @@ class PageModel extends Model
 	 *
 	 * @return PageModel|null The model or null if there is no 403 page
 	 *
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use the contao.routing.page_finder service instead.
 	 */
 	public static function find403ByPid($intPid, array $arrOptions=array())
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the "contao.routing.page_finder" service instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the "contao.routing.page_finder" service instead.', __METHOD__);
 
 		$t = static::$strTable;
 		$arrColumns = array("$t.pid=? AND $t.type='error_403'");
@@ -566,12 +566,12 @@ class PageModel extends Model
 	 *
 	 * @return PageModel|null The model or null if there is no 404 page
 	 *
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use the contao.routing.page_finder service instead.
 	 */
 	public static function find404ByPid($intPid, array $arrOptions=array())
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the "contao.routing.page_finder" service instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the "contao.routing.page_finder" service instead.', __METHOD__);
 
 		$t = static::$strTable;
 		$arrColumns = array("$t.pid=? AND $t.type='error_404'");
@@ -1142,12 +1142,12 @@ class PageModel extends Model
 	 *
 	 * @return string A URL that can be used in the front end
 	 *
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use the content URL generator instead.
 	 */
 	public function getFrontendUrl($strParams=null)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the content URL generator instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the content URL generator instead.', __METHOD__);
 
 		$this->loadDetails();
 
@@ -1191,12 +1191,12 @@ class PageModel extends Model
 	 *
 	 * @return string An absolute URL that can be used in the front end
 	 *
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use the content URL generator instead.
 	 */
 	public function getAbsoluteUrl($strParams=null)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the content URL generator instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the content URL generator instead.', __METHOD__);
 
 		$this->loadDetails();
 
@@ -1240,12 +1240,12 @@ class PageModel extends Model
 	 *
 	 * @return string The front end preview URL
 	 *
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use the content URL generator instead
 	 */
 	public function getPreviewUrl($strParams=null)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use the contao_backend_preview route instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the contao_backend_preview route instead.', __METHOD__);
 
 		$container = System::getContainer();
 

--- a/core-bundle/contao/modules/Module.php
+++ b/core-bundle/contao/modules/Module.php
@@ -84,7 +84,7 @@ use Symfony\Component\Routing\Exception\ExceptionInterface;
  * @property string  $cssID
  * @property string  $hl
  *
- * @deprecated extending from Module is deprecated since Contao 6 and will no
+ * @deprecated extending from Module is deprecated since Contao 6.0 and will no
  *             longer work in Contao 7; use a fragment controller instead
  */
 abstract class Module extends Frontend
@@ -525,7 +525,7 @@ abstract class Module extends Frontend
 	}
 
 	/**
-	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
 	 *             use a page type controller instead.
 	 */
 	public static function shouldPreload(string $type, PageModel $objPage, Request $request): bool

--- a/core-bundle/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/contao/modules/ModuleChangePassword.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\ChangePasswordController;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s" is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ModuleChangePassword::class, ChangePasswordController::class);
+trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s" is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ModuleChangePassword::class, ChangePasswordController::class);
 
 /**
  * Front end module "change password".
  *
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\ChangePasswordController instead.
  */
 class ModuleChangePassword extends Module

--- a/core-bundle/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/contao/modules/ModuleCloseAccount.php
@@ -12,12 +12,12 @@ namespace Contao;
 
 use Contao\CoreBundle\Controller\ContentElement\CloseAccountController;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s" is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ModuleCloseAccount::class, CloseAccountController::class);
+trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s" is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ModuleCloseAccount::class, CloseAccountController::class);
 
 /**
  * Front end module "close account".
  *
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\CloseAccountController instead.
  */
 class ModuleCloseAccount extends Module

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -20,12 +20,12 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\TooManyLoginAttemptsAuthenticationException;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
-trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', ModuleLogin::class, LoginController::class);
+trigger_deprecation('contao/core-bundle', '5.6', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', ModuleLogin::class, LoginController::class);
 
 /**
  * Front end module "login".
  *
- * @deprecated Deprecated since Contao 5.6, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.6, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\LoginController instead.
  */
 class ModuleLogin extends Module

--- a/core-bundle/contao/modules/ModuleRssReader.php
+++ b/core-bundle/contao/modules/ModuleRssReader.php
@@ -12,7 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
 
-trigger_deprecation('contao/core-bundle', '5.1', 'Using "%s" is deprecated and will no longer work in Contao 6. Use the feed reader module instead.', __CLASS__);
+trigger_deprecation('contao/core-bundle', '5.1', 'Using "%s" is deprecated and will no longer work in Contao 7. Use the feed reader module instead.', __CLASS__);
 
 /**
  * Front end module "rss reader".

--- a/core-bundle/contao/pages/PageError401.php
+++ b/core-bundle/contao/pages/PageError401.php
@@ -15,12 +15,12 @@ use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
 use Symfony\Component\HttpFoundation\Response;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', PageError401::class, ErrorPageController::class);
+trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', PageError401::class, ErrorPageController::class);
 
 /**
  * Provide methods to handle an error 401 page.
  *
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\Page\ErrorPageController instead.
  */
 class PageError401 extends Frontend

--- a/core-bundle/contao/pages/PageError403.php
+++ b/core-bundle/contao/pages/PageError403.php
@@ -15,12 +15,12 @@ use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', PageError403::class, ErrorPageController::class);
+trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', PageError403::class, ErrorPageController::class);
 
 /**
  * Provide methods to handle an error 403 page.
  *
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\Page\ErrorPageController instead.
  */
 class PageError403 extends Frontend

--- a/core-bundle/contao/pages/PageError404.php
+++ b/core-bundle/contao/pages/PageError404.php
@@ -15,12 +15,12 @@ use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', PageError404::class, ErrorPageController::class);
+trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', PageError404::class, ErrorPageController::class);
 
 /**
  * Provide methods to handle an error 404 page.
  *
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\Page\ErrorPageController instead.
  */
 class PageError404 extends Frontend

--- a/core-bundle/contao/pages/PageForward.php
+++ b/core-bundle/contao/pages/PageForward.php
@@ -14,12 +14,12 @@ use Contao\CoreBundle\Controller\Page\ForwardPageController;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', PageForward::class, ForwardPageController::class);
+trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', PageForward::class, ForwardPageController::class);
 
 /**
  * Provide methods to handle a forward page.
  *
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\Page\ForwardPageController instead.
  */
 class PageForward extends Frontend

--- a/core-bundle/contao/pages/PageLogout.php
+++ b/core-bundle/contao/pages/PageLogout.php
@@ -15,12 +15,12 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', PageLogout::class, LogoutPageController::class);
+trigger_deprecation('contao/core-bundle', '5.7', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', PageLogout::class, LogoutPageController::class);
 
 /**
  * Provide methods to handle a logout page.
  *
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\Page\LogoutPageController instead.
  */
 class PageLogout extends Frontend

--- a/core-bundle/contao/pages/PageRedirect.php
+++ b/core-bundle/contao/pages/PageRedirect.php
@@ -14,12 +14,12 @@ use Contao\CoreBundle\Controller\Page\RedirectPageController;
 use Contao\CoreBundle\Util\UrlUtil;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
-trigger_deprecation('contao/core-bundle', '5.3', 'Using the "%s" class is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', PageRedirect::class, RedirectPageController::class);
+trigger_deprecation('contao/core-bundle', '5.3', 'Using the "%s" class is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', PageRedirect::class, RedirectPageController::class);
 
 /**
  * Provide methods to handle a redirect page.
  *
- * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\Page\RedirectPageController instead.
  */
 class PageRedirect extends Frontend
@@ -58,7 +58,7 @@ class PageRedirect extends Frontend
 	 */
 	private function prepare($objPage)
 	{
-		// Deprecated since Contao 4.0, to be removed in Contao 6.0
+		// Deprecated since Contao 4.0, to be removed in Contao 7.0
 		$GLOBALS['TL_LANGUAGE'] = $objPage->language;
 
 		$locale = str_replace('-', '_', $objPage->language);

--- a/core-bundle/contao/pages/PageRegular.php
+++ b/core-bundle/contao/pages/PageRegular.php
@@ -65,7 +65,7 @@ class PageRegular extends Frontend
 	 */
 	private function prepare($objPage)
 	{
-		// Deprecated since Contao 4.0, to be removed in Contao 6.0
+		// Deprecated since Contao 4.0, to be removed in Contao 7.0
 		$GLOBALS['TL_LANGUAGE'] = LocaleUtil::formatAsLanguageTag($objPage->language);
 
 		$locale = LocaleUtil::formatAsLocale($objPage->language);

--- a/core-bundle/contao/widgets/KeyValueWizard.php
+++ b/core-bundle/contao/widgets/KeyValueWizard.php
@@ -10,12 +10,12 @@
 
 namespace Contao;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using "Contao\KeyValueWizard" is deprecated and will no longer work in Contao 6. Use the RowWizard instead.');
+trigger_deprecation('contao/core-bundle', '5.7', 'Using "Contao\KeyValueWizard" is deprecated and will no longer work in Contao 7. Use the RowWizard instead.');
 
 /**
  * Provide methods to handle key value pairs.
  *
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use the RowWizard instead.
  *
  * @property integer $maxlength

--- a/core-bundle/src/ContentComposition/ContentCompositionBuilder.php
+++ b/core-bundle/src/ContentComposition/ContentCompositionBuilder.php
@@ -252,7 +252,7 @@ class ContentCompositionBuilder
             [$GLOBALS['TL_ADMIN_NAME'], $GLOBALS['TL_ADMIN_EMAIL']] = StringUtil::splitFriendlyEmail(Config::get('adminEmail'));
         }
 
-        // Deprecated since Contao 4.0, to be removed in Contao 6.0
+        // Deprecated since Contao 4.0, to be removed in Contao 7.0
         $GLOBALS['TL_LANGUAGE'] = LocaleUtil::formatAsLanguageTag($page->language ?? '');
 
         // Set locale

--- a/core-bundle/src/Controller/AbstractBackendController.php
+++ b/core-bundle/src/Controller/AbstractBackendController.php
@@ -14,10 +14,10 @@ namespace Contao\CoreBundle\Controller;
 
 use Contao\CoreBundle\Controller\Backend\AbstractBackendController as BaseController;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using "Contao\CoreBundle\Controller\AbstractBackendController" is deprecated and will no longer work in Contao 6. Use "Contao\CoreBundle\Controller\Backend\AbstractBackendController" instead.');
+trigger_deprecation('contao/core-bundle', '5.7', 'Using "Contao\CoreBundle\Controller\AbstractBackendController" is deprecated and will no longer work in Contao 7. Use "Contao\CoreBundle\Controller\Backend\AbstractBackendController" instead.');
 
 /**
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\Backend\AbstractBackendController instead.
  */
 class AbstractBackendController extends BaseController

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -107,7 +107,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
      * Calling getResponse() on the returned object will internally call render() with
      * the set parameters and return the response.
      *
-     * Note: The $fallbackTemplateName argument will be removed in Contao 6; always
+     * Note: The $fallbackTemplateName argument will be removed in Contao 7; always
      * set a template via the fragment options, instead.
      */
     protected function createTemplate(Model $model, string|null $fallbackTemplateName = null): FragmentTemplate
@@ -173,7 +173,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
 
     /**
      * @internal The addHeadlineToTemplate() method is considered internal in
-     *           Contao 5 and won't be accessible anymore in Contao 6. Headline
+     *           Contao 5 and won't be accessible anymore in Contao 7. Headline
      *           data is always added to the context of modern fragment
      *           templates.
      */
@@ -188,7 +188,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
 
     /**
      * @internal The addCssAttributesToTemplate() method is considered internal
-     *           in Contao 5 and won't be accessible anymore in Contao 6.
+     *           in Contao 5 and won't be accessible anymore in Contao 7.
      *           Attributes data is always added to the context of modern
      *           fragment templates.
      */
@@ -207,7 +207,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
 
     /**
      * @internal The addPropertiesToTemplate() method is considered internal in
-     *           Contao 5 and won't be accessible anymore in Contao 6. Custom
+     *           Contao 5 and won't be accessible anymore in Contao 7. Custom
      *           properties are always added to the context of modern fragment
      *           templates.
      */
@@ -222,7 +222,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
 
     /**
      * @internal The addSectionToTemplate() method is considered internal in
-     *           Contao 5 and won't be accessible anymore in Contao 6. Section
+     *           Contao 5 and won't be accessible anymore in Contao 7. Section
      *           data is always added to the context of modern fragment
      *           templates.
      */
@@ -237,7 +237,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
      * Returns the type from the class name.
      *
      * @internal The getType() method is considered internal in Contao 5 and
-     *           won't be accessible anymore in Contao 6. Retrieve the type
+     *           won't be accessible anymore in Contao 7. Retrieve the type
      *           from the fragment options instead.
      */
     protected function getType(): string
@@ -299,7 +299,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
         $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['class'];
 
         if (!\in_array($caller, [AbstractContentElementController::class, AbstractFrontendModuleController::class], true)) {
-            trigger_deprecation('contao/core-bundle', '5.0', 'The "%s" method is considered internal and will not be accessible anymore in Contao 6.', $method);
+            trigger_deprecation('contao/core-bundle', '5.0', 'The "%s" method is considered internal and will not be accessible anymore in Contao 7.', $method);
         }
     }
 

--- a/core-bundle/src/Controller/Backend/TemplateStudioController.php
+++ b/core-bundle/src/Controller/Backend/TemplateStudioController.php
@@ -561,7 +561,7 @@ class TemplateStudioController extends AbstractBackendController
     {
         $suppressedPrefixes = ['backend', 'frontend_preview', 'web_debug_toolbar'];
 
-        // TODO: In Contao 6, do not add theme paths in the ContaoFilesystemLoader to
+        // TODO: In Contao 7, do not add theme paths in the ContaoFilesystemLoader to
         // begin with and remove this logic to suppress them (see #7027).
         foreach (array_keys($this->getAvailableThemes()) as $slug) {
             $suppressedPrefixes[] = $this->themeNamespace->getPath((string) $slug);

--- a/core-bundle/src/Controller/BackendCsvImportController.php
+++ b/core-bundle/src/Controller/BackendCsvImportController.php
@@ -14,10 +14,10 @@ namespace Contao\CoreBundle\Controller;
 
 use Contao\CoreBundle\Controller\Backend\CsvImportController as BaseController;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using "Contao\CoreBundle\Controller\BackendCsvImportController" is deprecated and will no longer work in Contao 6. Use "Contao\CoreBundle\Controller\Backend\CsvImportController" instead.');
+trigger_deprecation('contao/core-bundle', '5.7', 'Using "Contao\CoreBundle\Controller\BackendCsvImportController" is deprecated and will no longer work in Contao 7. Use "Contao\CoreBundle\Controller\Backend\CsvImportController" instead.');
 
 /**
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\Backend\CsvImportController instead.
  */
 class BackendCsvImportController extends BaseController

--- a/core-bundle/src/Controller/ContentElement/DownloadsController.php
+++ b/core-bundle/src/Controller/ContentElement/DownloadsController.php
@@ -53,7 +53,7 @@ class DownloadsController extends AbstractDownloadContentElementController
         // Explicitly define title/text metadata for a single file
         if ('download' === $model->type && $model->overwriteLink && $downloads) {
             if ($model->titleText) {
-                trigger_deprecation('contao/core-bundle', '5.3', 'Setting a download title attribute is deprecated and will no longer work in Contao 6.');
+                trigger_deprecation('contao/core-bundle', '5.3', 'Setting a download title attribute is deprecated and will no longer work in Contao 7.');
             }
 
             $downloads[0]['title'] = $model->titleText;

--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -32,12 +32,12 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s" is deprecated and will no longer work in Contao 6. Use the "%s" class instead.', TwoFactorController::class, TwoFactorControllerContentElement::class);
+trigger_deprecation('contao/core-bundle', '5.7', 'Using "%s" is deprecated and will no longer work in Contao 7. Use the "%s" class instead.', TwoFactorController::class, TwoFactorControllerContentElement::class);
 
 /**
  * @internal
  *
- * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
  *             use Contao\CoreBundle\Controller\ContentElement\TwoFactorController instead.
  */
 #[AsFrontendModule(category: 'user', template: 'mod_two_factor')]

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -137,7 +137,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
                 }
 
                 if (!empty($attributes['shouldPreload'])) {
-                    trigger_deprecation('contao/core-bundle', '5.3', 'Using the fragment attribute "shouldPreload" is deprecated and will no longer work in Contao 6. Use a page type controller instead.');
+                    trigger_deprecation('contao/core-bundle', '5.3', 'Using the fragment attribute "shouldPreload" is deprecated and will no longer work in Contao 7. Use a page type controller instead.');
 
                     $compositor->addMethodCall('addPreload', [$identifier]);
                 }

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -61,7 +61,7 @@ class Configuration implements ConfigurationInterface
                             static function (array $options): array {
                                 foreach (array_keys($options) as $option) {
                                     if ($newKey = Config::getNewKey($option)) {
-                                        trigger_deprecation('contao/core-bundle', '5.0', 'Setting "contao.localconfig.%s" is deprecated and will no longer work in Contao 6. Use "%s" instead.', $option, $newKey);
+                                        trigger_deprecation('contao/core-bundle', '5.0', 'Setting "contao.localconfig.%s" is deprecated and will no longer work in Contao 7. Use "%s" instead.', $option, $newKey);
                                     }
                                 }
 

--- a/core-bundle/src/File/ModelMetadataTrait.php
+++ b/core-bundle/src/File/ModelMetadataTrait.php
@@ -14,10 +14,10 @@ namespace Contao\CoreBundle\File;
 
 use Contao\Model\MetadataTrait;
 
-trigger_deprecation('contao/core-bundle', '5.3', 'Using "Contao\CoreBundle\File\ModelMetadataTrait" is deprecated and will no longer work in Contao 6. Use "Contao\Model\MetadataTrait" instead.');
+trigger_deprecation('contao/core-bundle', '5.3', 'Using "Contao\CoreBundle\File\ModelMetadataTrait" is deprecated and will no longer work in Contao 7. Use "Contao\Model\MetadataTrait" instead.');
 
 /**
- * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+ * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
  *             use Contao\Model\MetadataTrait instead.
  *
  * @phpstan-ignore trait.unused

--- a/core-bundle/src/Filesystem/ExtraMetadata.php
+++ b/core-bundle/src/Filesystem/ExtraMetadata.php
@@ -27,7 +27,7 @@ class ExtraMetadata implements \ArrayAccess
         $localizedMetadata = $extraMetadata['metadata'] ?? null;
 
         if ($localizedMetadata instanceof MetadataBag) {
-            trigger_deprecation('contao/core-bundle', '5.5', 'Using the key "metadata" to set localized metadata is deprecated and will no longer work in Contao 6. Use the key "localized" instead.');
+            trigger_deprecation('contao/core-bundle', '5.5', 'Using the key "metadata" to set localized metadata is deprecated and will no longer work in Contao 7. Use the key "localized" instead.');
 
             $this->extraMetadata['localized'] = $localizedMetadata;
             unset($this->extraMetadata['metadata']);
@@ -121,7 +121,7 @@ class ExtraMetadata implements \ArrayAccess
     private function handleDeprecatedMetadataKey(string &$key): void
     {
         if ('metadata' === $key) {
-            trigger_deprecation('contao/core-bundle', '5.5', 'Using the key "metadata" to get localized metadata is deprecated and will no longer work in Contao 6. Use the key "localized" instead.');
+            trigger_deprecation('contao/core-bundle', '5.5', 'Using the key "metadata" to get localized metadata is deprecated and will no longer work in Contao 7. Use the key "localized" instead.');
 
             $key = 'localized';
         }

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -200,7 +200,7 @@ class ContaoFramework implements ResetInterface
             $language = LocaleUtil::formatAsLanguageTag($this->request->getLocale());
         }
 
-        // Deprecated since Contao 4.0, to be removed in Contao 6.0
+        // Deprecated since Contao 4.0, to be removed in Contao 7.0
         $GLOBALS['TL_LANGUAGE'] = $language;
     }
 

--- a/core-bundle/src/Image/ImageFactory.php
+++ b/core-bundle/src/Image/ImageFactory.php
@@ -277,7 +277,7 @@ class ImageFactory implements ImageFactoryInterface
             return [$config, null, null];
         }
 
-        trigger_deprecation('contao/core-bundle', '5.0', 'Using the legacy resize mode "%s" is deprecated and will no longer work in Contao 6.', $size[2]);
+        trigger_deprecation('contao/core-bundle', '5.0', 'Using the legacy resize mode "%s" is deprecated and will no longer work in Contao 7.', $size[2]);
 
         $config->setMode(ResizeConfiguration::MODE_CROP);
 

--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -101,7 +101,7 @@ class PictureFactory implements PictureFactoryInterface
             && !isset($this->predefinedSizes[$size[2]])
             && 1 === substr_count($size[2], '_')
         ) {
-            trigger_deprecation('contao/core-bundle', '5.0', 'Using the legacy resize mode "%s" is deprecated and will no longer work in Contao 6.', $size[2]);
+            trigger_deprecation('contao/core-bundle', '5.0', 'Using the legacy resize mode "%s" is deprecated and will no longer work in Contao 7.', $size[2]);
 
             $image->setImportantPart($this->imageFactory->getImportantPartFromLegacyMode($image, $size[2]));
             $size[2] = ResizeConfiguration::MODE_CROP;

--- a/core-bundle/src/InsertTag/InsertTagParser.php
+++ b/core-bundle/src/InsertTag/InsertTagParser.php
@@ -103,7 +103,7 @@ class InsertTagParser implements ResetInterface
     public function addSubscription(InsertTagSubscription $subscription): void
     {
         if ($subscription->asFragment) {
-            trigger_deprecation('contao/core-bundle', '5.3', 'Using "asFragment: true" in the #[AsInsertTag] attribute is no longer effective and will fail in Contao 6. Render the desired ESI tag directly or use the fragment insert tag instead.');
+            trigger_deprecation('contao/core-bundle', '5.3', 'Using "asFragment: true" in the #[AsInsertTag] attribute is no longer effective and will fail in Contao 7. Render the desired ESI tag directly or use the fragment insert tag instead.');
         }
 
         if (1 !== preg_match($this->allowedTagsRegex, $subscription->name)) {
@@ -189,12 +189,12 @@ class InsertTagParser implements ResetInterface
     }
 
     /**
-     * @deprecated Deprecated since Contao 5.1, to be removed in Contao 6;
+     * @deprecated Deprecated since Contao 5.1, to be removed in Contao 7;
      *             use renderTag() instead.
      */
     public function render(string $input): string
     {
-        trigger_deprecation('contao/core-bundle', '5.1', 'Using "%s()" is deprecated and will no longer work in Contao 6. Use "%s::renderTag()" instead.', __METHOD__, self::class);
+        trigger_deprecation('contao/core-bundle', '5.1', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use "%s::renderTag()" instead.', __METHOD__, self::class);
 
         return $this->renderTag($input)->getValue();
     }
@@ -207,7 +207,7 @@ class InsertTagParser implements ResetInterface
             try {
                 $tag = $this->parseTag($input);
             } catch (\InvalidArgumentException $exception) {
-                trigger_deprecation('contao/core-bundle', '5.0', $exception->getMessage().'. This will no longer work in Contao 6.');
+                trigger_deprecation('contao/core-bundle', '5.0', $exception->getMessage().'. This will no longer work in Contao 7.');
                 $tag = null;
             }
         }
@@ -289,13 +289,13 @@ class InsertTagParser implements ResetInterface
         }
 
         if (strtolower($name) !== $name) {
-            trigger_deprecation('contao/core-bundle', '5.0', 'Insert tags with uppercase letters ("%s") are deprecated and will no longer work in Contao 6.', $name);
+            trigger_deprecation('contao/core-bundle', '5.0', 'Insert tags with uppercase letters ("%s") are deprecated and will no longer work in Contao 7.', $name);
             $name = strtolower($name);
         }
 
         foreach ($flags as $flag) {
             if (strtolower($flag) !== $flag) {
-                trigger_deprecation('contao/core-bundle', '5.0', 'Insert tag flags with uppercase letters ("%s") are deprecated and will no longer work in Contao 6.', $flag);
+                trigger_deprecation('contao/core-bundle', '5.0', 'Insert tag flags with uppercase letters ("%s") are deprecated and will no longer work in Contao 7.', $flag);
             }
         }
 
@@ -721,7 +721,7 @@ class InsertTagParser implements ResetInterface
             return $result;
         }
 
-        trigger_deprecation('contao/core-bundle', '5.2', 'Using the "insertTagFlags" hook is deprecated and will no longer work in Contao 6. Use the "%s" attribute instead.', AsInsertTagFlag::class);
+        trigger_deprecation('contao/core-bundle', '5.2', 'Using the "insertTagFlags" hook is deprecated and will no longer work in Contao 7. Use the "%s" attribute instead.', AsInsertTagFlag::class);
 
         // Set up as variables as they may be used by reference in the hooks
         $flagName = $flag->getName();

--- a/core-bundle/src/InsertTag/Resolver/TranslationInsertTag.php
+++ b/core-bundle/src/InsertTag/Resolver/TranslationInsertTag.php
@@ -29,7 +29,7 @@ class TranslationInsertTag implements InsertTagResolverNestedResolvedInterface
         $parameters = \array_slice($insertTag->getParameters()->all(), 2);
 
         if (1 === \count($parameters) && str_contains($parameters[0], ':')) {
-            trigger_deprecation('contao/core-bundle', '5.3', 'Using single colons to pass parameters to the "trans" insert tag is deprecated and will no longer work in Contao 6. Use double colons instead.');
+            trigger_deprecation('contao/core-bundle', '5.3', 'Using single colons to pass parameters to the "trans" insert tag is deprecated and will no longer work in Contao 7. Use double colons instead.');
             $parameters = explode(':', $parameters[0]);
         }
 

--- a/core-bundle/src/Migration/MigrationCollection.php
+++ b/core-bundle/src/Migration/MigrationCollection.php
@@ -62,7 +62,7 @@ class MigrationCollection
     public function run(array|null $pendingNames = null): iterable
     {
         if (null === $pendingNames) {
-            trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" with "pendingNames: null" is deprecated and will no longer work in Contao 6.', __METHOD__);
+            trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" with "pendingNames: null" is deprecated and will no longer work in Contao 7.', __METHOD__);
         }
 
         foreach ($this->getPending() as $migration) {

--- a/core-bundle/src/Routing/PageUrlGenerator.php
+++ b/core-bundle/src/Routing/PageUrlGenerator.php
@@ -55,7 +55,7 @@ class PageUrlGenerator extends SymfonyUrlGenerator
             && \array_key_exists(RouteObjectInterface::CONTENT_OBJECT, $parameters)
             && $parameters[RouteObjectInterface::CONTENT_OBJECT] instanceof PageModel
         ) {
-            trigger_deprecation('contao/core-bundle', '4.13', 'Using "RouteObjectInterface::OBJECT_BASED_ROUTE_NAME" to generate page URLs is deprecated and will no longer work in Contao 6. Use "PageRoute::PAGE_BASED_ROUTE_NAME" instead.');
+            trigger_deprecation('contao/core-bundle', '4.13', 'Using "RouteObjectInterface::OBJECT_BASED_ROUTE_NAME" to generate page URLs is deprecated and will no longer work in Contao 7. Use "PageRoute::PAGE_BASED_ROUTE_NAME" instead.');
             $route = $this->pageRegistry->getRoute($parameters[RouteObjectInterface::CONTENT_OBJECT]);
             unset($parameters[RouteObjectInterface::CONTENT_OBJECT]);
         } elseif (
@@ -63,7 +63,7 @@ class PageUrlGenerator extends SymfonyUrlGenerator
             && \array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters)
             && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof PageRoute
         ) {
-            trigger_deprecation('contao/core-bundle', '4.13', 'Using "RouteObjectInterface::OBJECT_BASED_ROUTE_NAME" to generate page URLs is deprecated and will no longer work in Contao 6. Use "PageRoute::PAGE_BASED_ROUTE_NAME" instead.');
+            trigger_deprecation('contao/core-bundle', '4.13', 'Using "RouteObjectInterface::OBJECT_BASED_ROUTE_NAME" to generate page URLs is deprecated and will no longer work in Contao 7. Use "PageRoute::PAGE_BASED_ROUTE_NAME" instead.');
             $route = $parameters[RouteObjectInterface::ROUTE_OBJECT];
             unset($parameters[RouteObjectInterface::ROUTE_OBJECT]);
         } else {

--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -72,17 +72,6 @@ class Document
 
     public function __unserialize(array $data): void
     {
-        // Backwards compatibility: For documents serialized before introducing
-        // compression (to be removed in Contao 7)
-        if (!isset($data['compressed'])) {
-            $this->uri = $data['uri'];
-            $this->statusCode = $data['statusCode'];
-            $this->headers = $data['headers'];
-            $this->body = $data['body'];
-
-            return;
-        }
-
         $uncompressed = unserialize(gzuncompress($data['compressed']), ['allowed_classes' => false]);
 
         $this->uri = new Uri($uncompressed['uri']);

--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -73,7 +73,7 @@ class Document
     public function __unserialize(array $data): void
     {
         // Backwards compatibility: For documents serialized before introducing
-        // compression (to be removed in Contao 6)
+        // compression (to be removed in Contao 7)
         if (!isset($data['compressed'])) {
             $this->uri = $data['uri'];
             $this->statusCode = $data['statusCode'];

--- a/core-bundle/src/Security/ContaoCorePermissions.php
+++ b/core-bundle/src/Security/ContaoCorePermissions.php
@@ -192,7 +192,7 @@ final class ContaoCorePermissions
     public const USER_CAN_ACCESS_IMAGE_SIZE = 'contao_user.imageSizes';
 
     /**
-     * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+     * @deprecated Deprecated since Contao 5.3, to be removed in Contao 7;
      *             use USER_CAN_EDIT_FORM instead
      */
     public const USER_CAN_ACCESS_FORM = 'contao_user.forms';

--- a/core-bundle/src/Security/Voter/LegacyBackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/LegacyBackendAccessVoter.php
@@ -31,7 +31,7 @@ class LegacyBackendAccessVoter extends AbstractBackendAccessVoter
      */
     protected function hasAccess(array|null $subject, string $field, BackendUser $user): bool
     {
-        trigger_deprecation('contao/core-bundle', '5.7', 'Checking access on "contao_user.formp" is deprecated and will no longer work in Contao 6. Vote on "contao_user.cud" instead.');
+        trigger_deprecation('contao/core-bundle', '5.7', 'Checking access on "contao_user.formp" is deprecated and will no longer work in Contao 7. Vote on "contao_user.cud" instead.');
 
         if (null === $subject) {
             return \count(preg_grep('/^tl_form::/', $user->cud)) > 0;

--- a/core-bundle/src/Translation/LegacyLocaleSwitcher.php
+++ b/core-bundle/src/Translation/LegacyLocaleSwitcher.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  *
  * @internal
  *
- * @deprecated Deprecated since Contao 4.0, to be removed in Contao 6.
+ * @deprecated Deprecated since Contao 4.0, to be removed in Contao 7.
  */
 class LegacyLocaleSwitcher implements LocaleAwareInterface
 {

--- a/core-bundle/src/Twig/Extension/DeprecationsNodeVisitor.php
+++ b/core-bundle/src/Twig/Extension/DeprecationsNodeVisitor.php
@@ -63,7 +63,7 @@ final class DeprecationsNodeVisitor implements NodeVisitorInterface
         $suggestedTransformation = \sprintf('"{{ \'{{%1$s}}\' }}" -> "{{ insert_tag(\'%1$s\') }}".', $matches[1]);
 
         $message = 'You should not rely on insert tags being replaced in the rendered HTML. '
-            .'This behavior will gradually be phased out in Contao 5 and will no longer work in Contao 6. '
+            .'This behavior will gradually be phased out in Contao 5 and will no longer work in Contao 7. '
             .'Explicitly replace insert tags with the "insert_tag" function instead: '.$suggestedTransformation;
 
         return $this->addDeprecation($node, $message);

--- a/core-bundle/src/Twig/Loader/ThemeNamespace.php
+++ b/core-bundle/src/Twig/Loader/ThemeNamespace.php
@@ -42,7 +42,7 @@ class ThemeNamespace
         $path = Path::normalize($relativePath);
 
         if (str_contains($path, '..')) {
-            trigger_deprecation('contao/core-bundle', '5.5', 'Using paths outside of the template directory is deprecated and will no longer work in Contao 6. Use the VFS to mount them in the user templates storage instead.');
+            trigger_deprecation('contao/core-bundle', '5.5', 'Using paths outside of the template directory is deprecated and will no longer work in Contao 7. Use the VFS to mount them in the user templates storage instead.');
         }
 
         $invalidCharacters = [];

--- a/core-bundle/src/Twig/Runtime/FigureRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRuntime.php
@@ -41,11 +41,11 @@ final class FigureRuntime implements RuntimeExtensionInterface
      * @param int|string|array|PictureConfiguration|null          $size          A picture size configuration or reference
      * @param array<string, mixed>                                $configuration Configuration for the FigureBuilder
      *
-     * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+     * @deprecated Deprecated since Contao 5.0, to be removed in Contao 7.
      */
     public function renderFigure(FilesModel|FilesystemItem|ImageInterface|int|string $from, PictureConfiguration|array|int|string|null $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): string|null
     {
-        trigger_deprecation('contao/core-bundle', '5.0', 'Using the "contao_figure" Twig function is deprecated and will no longer work in Contao 6. Use the "figure" Twig function instead.');
+        trigger_deprecation('contao/core-bundle', '5.0', 'Using the "contao_figure" Twig function is deprecated and will no longer work in Contao 7. Use the "figure" Twig function instead.');
 
         return $this->figureRenderer->render($from, $size, $configuration, $template);
     }

--- a/core-bundle/tests/Search/DocumentTest.php
+++ b/core-bundle/tests/Search/DocumentTest.php
@@ -45,15 +45,6 @@ class DocumentTest extends TestCase
         $this->assertSame(200, $document->getStatusCode());
         $this->assertArrayHasKey('content-type', $document->getHeaders());
         $this->assertSame($html, $document->getBody());
-
-        // Test BC
-        $legacy = base64_decode('TzozMzoiQ29udGFvXENvcmVCdW5kbGVcU2VhcmNoXERvY3VtZW50Ijo0OntzOjM6InVyaSI7TzoxNToiTnlob2xtXFBzcjdcVXJpIjo3OntzOjIzOiIATnlob2xtXFBzcjdcVXJpAHNjaGVtZSI7czo1OiJodHRwcyI7czoyNToiAE55aG9sbVxQc3I3XFVyaQB1c2VySW5mbyI7czowOiIiO3M6MjE6IgBOeWhvbG1cUHNyN1xVcmkAaG9zdCI7czoxMToiZXhhbXBsZS5jb20iO3M6MjE6IgBOeWhvbG1cUHNyN1xVcmkAcG9ydCI7TjtzOjIxOiIATnlob2xtXFBzcjdcVXJpAHBhdGgiO3M6NDoiL2ZvbyI7czoyMjoiAE55aG9sbVxQc3I3XFVyaQBxdWVyeSI7czo3OiJiYXI9YmF6IjtzOjI1OiIATnlob2xtXFBzcjdcVXJpAGZyYWdtZW50IjtzOjA6IiI7fXM6MTA6InN0YXR1c0NvZGUiO2k6MjAwO3M6NzoiaGVhZGVycyI7YTozOntzOjEyOiJjb250ZW50LXR5cGUiO2E6MTp7aTowO3M6OToidGV4dC9odG1sIjt9czoxMzoiY2FjaGUtY29udHJvbCI7YToxOntpOjA7czoxNzoibm8tY2FjaGUsIHByaXZhdGUiO31zOjQ6ImRhdGUiO2E6MTp7aTowO3M6Mjk6IlRodSwgMjYgSnVuIDIwMjUgMTM6MzI6MTMgR01UIjt9fXM6NDoiYm9keSI7czo2OiI8aHRtbD4iO30', true);
-        $document = unserialize($legacy);
-
-        $this->assertSame('https://example.com/foo?bar=baz', (string) $document->getUri());
-        $this->assertSame(200, $document->getStatusCode());
-        $this->assertArrayHasKey('content-type', $document->getHeaders());
-        $this->assertSame('<html>', $document->getBody());
     }
 
     #[DataProvider('searchableContentProvider')]

--- a/core-bundle/tests/Twig/Loader/ThemeTest.php
+++ b/core-bundle/tests/Twig/Loader/ThemeTest.php
@@ -42,7 +42,7 @@ class ThemeTest extends TestCase
     {
         $themeNamespace = new ThemeNamespace();
 
-        $this->expectUserDeprecationMessageMatches('/Using paths outside of the template directory is deprecated and will no longer work in Contao 6\./');
+        $this->expectUserDeprecationMessageMatches('/Using paths outside of the template directory is deprecated and will no longer work in Contao 7\./');
 
         $this->assertSame($expectedSlug, $themeNamespace->generateSlug($path));
     }

--- a/test-case/src/ContaoTestCase.php
+++ b/test-case/src/ContaoTestCase.php
@@ -132,12 +132,12 @@ abstract class ContaoTestCase extends TestCase
      *
      * @return ContaoFramework&Stub
      *
-     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
      *             use createContaoFrameworkMock() or createContaoFrameworkStub() instead.
      */
     protected function mockContaoFramework(array $adapters = [], array $instances = []): ContaoFramework
     {
-        trigger_deprecation('contao/test-case', '5.7', 'Using "ContaoTestCase::mockContaoFramework()" is deprecated and will no longer work in Contao 6. Use "ContaoTestCase::createContaoFrameworkMock()" or "ContaoTestCase::createContaoFrameworkStub()" instead.');
+        trigger_deprecation('contao/test-case', '5.7', 'Using "ContaoTestCase::mockContaoFramework()" is deprecated and will no longer work in Contao 7. Use "ContaoTestCase::createContaoFrameworkMock()" or "ContaoTestCase::createContaoFrameworkStub()" instead.');
 
         return $this->createContaoFrameworkMock($adapters, $instances);
     }
@@ -175,12 +175,12 @@ abstract class ContaoTestCase extends TestCase
      *
      * @return Adapter&MockObject
      *
-     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
      *             use createAdapterMock() or createAdapterStub() instead.
      */
     protected function mockAdapter(array $methods): Adapter
     {
-        trigger_deprecation('contao/test-case', '5.7', 'Using "ContaoTestCase::mockAdapter()" is deprecated and will no longer work in Contao 6. Use "ContaoTestCase::createAdapterMock()" or "ContaoTestCase::createAdapterStub()" instead.');
+        trigger_deprecation('contao/test-case', '5.7', 'Using "ContaoTestCase::mockAdapter()" is deprecated and will no longer work in Contao 7. Use "ContaoTestCase::createAdapterMock()" or "ContaoTestCase::createAdapterStub()" instead.');
 
         return $this->createAdapterMock($methods);
     }
@@ -206,12 +206,12 @@ abstract class ContaoTestCase extends TestCase
      *
      * @return Adapter&MockObject
      *
-     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
      *             use createConfiguredAdapterMock() or createConfiguredAdapterStub() instead.
      */
     protected function mockConfiguredAdapter(array $configuration): Adapter
     {
-        trigger_deprecation('contao/test-case', '5.7', 'Using "ContaoTestCase::mockConfiguredAdapter()" is deprecated and will no longer work in Contao 6. Use "ContaoTestCase::createConfiguredAdapterMock()" or "ContaoTestCase::createConfiguredAdapterStub()" instead.');
+        trigger_deprecation('contao/test-case', '5.7', 'Using "ContaoTestCase::mockConfiguredAdapter()" is deprecated and will no longer work in Contao 7. Use "ContaoTestCase::createConfiguredAdapterMock()" or "ContaoTestCase::createConfiguredAdapterStub()" instead.');
 
         return $this->createConfiguredAdapterMock($configuration);
     }
@@ -259,12 +259,12 @@ abstract class ContaoTestCase extends TestCase
      *
      * @return T&MockObject
      *
-     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
      *             use createClassWithPropertiesMock() or createClassWithPropertiesStub() instead.
      */
     protected function mockClassWithProperties(string $class, array $properties = [], array $except = []): MockObject|Stub
     {
-        trigger_deprecation('contao/test-case', '5.7', 'Using "ContaoTestCase::mockClassWithProperties()" is deprecated and will no longer work in Contao 6. Use "ContaoTestCase::createClassWithPropertiesMock()" or "ContaoTestCase::createClassWithPropertiesStub()" instead.');
+        trigger_deprecation('contao/test-case', '5.7', 'Using "ContaoTestCase::mockClassWithProperties()" is deprecated and will no longer work in Contao 7. Use "ContaoTestCase::createClassWithPropertiesMock()" or "ContaoTestCase::createClassWithPropertiesStub()" instead.');
 
         $classMethods = get_class_methods($class);
 
@@ -308,12 +308,12 @@ abstract class ContaoTestCase extends TestCase
     /**
      * Mocks a token storage with a Contao user.
      *
-     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 6;
+     * @deprecated Deprecated since Contao 5.7, to be removed in Contao 7;
      *             use createTokenStorageStub() instead.
      */
     protected function mockTokenStorage(string $class): TokenStorageInterface&Stub
     {
-        trigger_deprecation('contao/test-case', '5.7', 'Using "ContaoTestCase::mockTokenStorage()" is deprecated and will no longer work in Contao 6. Use "ContaoTestCase::createTokenStorageStub()" instead.');
+        trigger_deprecation('contao/test-case', '5.7', 'Using "ContaoTestCase::mockTokenStorage()" is deprecated and will no longer work in Contao 7. Use "ContaoTestCase::createTokenStorageStub()" instead.');
 
         return $this->createTokenStorageStub($class);
     }


### PR DESCRIPTION
@contao/developers Please review this thoroughly and comment if there’s anything you still want to see removed in Contao 6. The next opportunity won’t be until Contao 7.