### PR TITLE
Expose API operations via MCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,8 +417,8 @@ jobs:
                       php -r '
                           $data = json_decode(file_get_contents(__DIR__."/composer.json"), true);
                           if ("contao/api-bundle" !== $data["name"]) {
-                              $data["repositories"][0]["type"] = "path";
-                              $data["repositories"][0]["url"] = "../api-bundle";
+                              $data["repositories"][3]["type"] = "path";
+                              $data["repositories"][3]["url"] = "../api-bundle";
                           }
                           if ("contao/core-bundle" !== $data["name"]) {
                               $data["repositories"][0]["type"] = "path";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,10 +416,6 @@ jobs:
                       cd $bundle
                       php -r '
                           $data = json_decode(file_get_contents(__DIR__."/composer.json"), true);
-                          if ("contao/api-bundle" !== $data["name"]) {
-                              $data["repositories"][3]["type"] = "path";
-                              $data["repositories"][3]["url"] = "../api-bundle";
-                          }
                           if ("contao/core-bundle" !== $data["name"]) {
                               $data["repositories"][0]["type"] = "path";
                               $data["repositories"][0]["url"] = "../core-bundle";
@@ -431,6 +427,10 @@ jobs:
                           if ("contao/test-case" !== $data["name"]) {
                               $data["repositories"][2]["type"] = "path";
                               $data["repositories"][2]["url"] = "../test-case";
+                          }
+                          if ("contao/api-bundle" !== $data["name"]) {
+                              $data["repositories"][3]["type"] = "path";
+                              $data["repositories"][3]["url"] = "../api-bundle";
                           }
                           file_put_contents(__DIR__."/composer.json", json_encode($data, JSON_UNESCAPED_SLASHES));
                       '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,10 @@ jobs:
                       cd $bundle
                       php -r '
                           $data = json_decode(file_get_contents(__DIR__."/composer.json"), true);
+                          if ("contao/api-bundle" !== $data["name"]) {
+                              $data["repositories"][0]["type"] = "path";
+                              $data["repositories"][0]["url"] = "../api-bundle";
+                          }
                           if ("contao/core-bundle" !== $data["name"]) {
                               $data["repositories"][0]["type"] = "path";
                               $data["repositories"][0]["url"] = "../core-bundle";

--- a/api-bundle/src/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactory.php
+++ b/api-bundle/src/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactory.php
@@ -16,6 +16,9 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\McpTool;
+use ApiPlatform\Metadata\McpToolCollection;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
@@ -24,6 +27,7 @@ use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use Contao\ApiBundle\ApiPlatform\OpenApi\DataContainerOpenApiFactory;
 use Contao\ApiBundle\ApiPlatform\State\DataContainerStateProcessor;
 use Contao\ApiBundle\ApiPlatform\State\DataContainerStateProvider;
+use Contao\ApiBundle\Dto\DataContainerMcpRecord;
 use Contao\ApiBundle\Dto\DataContainerRecord;
 use Contao\Controller;
 use Contao\CoreBundle\Config\ResourceFinderInterface;
@@ -102,6 +106,7 @@ final class DataContainerResourceMetadataCollectionFactory implements ResourceMe
                 ->withProcessor(DataContainerStateProcessor::class)
                 ->withRoutePrefix($routePrefix)
                 ->withDefaults(['_scope' => 'backend'])
+                ->withMcp($this->createMcpOperations($table, $shortName, $routePrefix, !($config['notDeletable'] ?? false)))
                 ->withExtraProperties([
                     'contao' => [
                         'table' => $table,
@@ -151,5 +156,84 @@ final class DataContainerResourceMetadataCollectionFactory implements ResourceMe
     private function getRoutePrefix(string $table): string
     {
         return '/'.trim($this->dataContainerApiPrefix, '/').'/'.$table;
+    }
+
+    /**
+     * @return array<string, McpTool|McpToolCollection>
+     */
+    private function createMcpOperations(string $table, string $shortName, string $routePrefix, bool $deletable): array
+    {
+        $baseName = preg_replace('/^tl_/', '', $table) ?? $table;
+
+        $operations = [
+            $baseName.'_get_collection' => new McpToolCollection(
+                name: $baseName.'_get_collection',
+                description: 'List '.$shortName.' records',
+                method: 'GET',
+                uriTemplate: $routePrefix,
+                shortName: $shortName,
+                class: DataContainerRecord::class,
+                input: ['class' => DataContainerMcpRecord::class],
+                output: ['class' => DataContainerRecord::class],
+                provider: DataContainerStateProvider::class,
+                processor: DataContainerStateProcessor::class,
+            ),
+            $baseName.'_get' => new McpTool(
+                name: $baseName.'_get',
+                description: 'Fetch a '.$shortName.' record',
+                method: 'GET',
+                uriTemplate: $routePrefix.'/{id}',
+                uriVariables: ['id' => new Link(fromClass: DataContainerMcpRecord::class)],
+                shortName: $shortName,
+                class: DataContainerRecord::class,
+                input: ['class' => DataContainerMcpRecord::class],
+                output: ['class' => DataContainerRecord::class],
+                provider: DataContainerStateProvider::class,
+                processor: DataContainerStateProcessor::class,
+            ),
+            $baseName.'_post' => new McpTool(
+                name: $baseName.'_post',
+                description: 'Create a '.$shortName.' record',
+                method: 'POST',
+                uriTemplate: $routePrefix,
+                shortName: $shortName,
+                class: DataContainerRecord::class,
+                input: ['class' => DataContainerMcpRecord::class],
+                output: ['class' => DataContainerRecord::class],
+                provider: DataContainerStateProvider::class,
+                processor: DataContainerStateProcessor::class,
+            ),
+            $baseName.'_patch' => new McpTool(
+                name: $baseName.'_patch',
+                description: 'Update a '.$shortName.' record',
+                method: 'PATCH',
+                uriTemplate: $routePrefix.'/{id}',
+                uriVariables: ['id' => new Link(fromClass: DataContainerMcpRecord::class)],
+                shortName: $shortName,
+                class: DataContainerRecord::class,
+                input: ['class' => DataContainerMcpRecord::class],
+                output: ['class' => DataContainerRecord::class],
+                provider: DataContainerStateProvider::class,
+                processor: DataContainerStateProcessor::class,
+            ),
+        ];
+
+        if ($deletable) {
+            $operations[$baseName.'_delete'] = new McpTool(
+                name: $baseName.'_delete',
+                description: 'Delete a '.$shortName.' record',
+                method: 'DELETE',
+                uriTemplate: $routePrefix.'/{id}',
+                uriVariables: ['id' => new Link(fromClass: DataContainerMcpRecord::class)],
+                shortName: $shortName,
+                class: DataContainerRecord::class,
+                input: ['class' => DataContainerMcpRecord::class],
+                output: false,
+                provider: DataContainerStateProvider::class,
+                processor: DataContainerStateProcessor::class,
+            )->withStructuredContent(false)->withStatus(204);
+        }
+
+        return $operations;
     }
 }

--- a/api-bundle/src/ApiPlatform/State/DataContainerStateProcessor.php
+++ b/api-bundle/src/ApiPlatform/State/DataContainerStateProcessor.php
@@ -13,20 +13,22 @@ declare(strict_types=1);
 namespace Contao\ApiBundle\ApiPlatform\State;
 
 use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
+use Contao\ApiBundle\Dto\DataContainerMcpRecord;
 use Contao\ApiBundle\Dto\DataContainerRecord;
 
 /**
- * @implements ProcessorInterface<DataContainerRecord|mixed, DataContainerRecord|mixed>
+ * @implements ProcessorInterface<DataContainerRecord|DataContainerMcpRecord|mixed, DataContainerRecord|mixed>
  */
 final class DataContainerStateProcessor implements ProcessorInterface
 {
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
     {
-        if (!$data instanceof DataContainerRecord) {
+        if (!$data instanceof DataContainerRecord && !$data instanceof DataContainerMcpRecord) {
             return $data;
         }
 
@@ -35,24 +37,33 @@ final class DataContainerStateProcessor implements ProcessorInterface
             return $data;
         }
 
-        if ($operation instanceof Post) {
+        if ($operation instanceof Delete || $this->hasMethod($operation, 'DELETE')) {
+            // TODO: delete the record in $table identified by $uriVariables['id'].
+            return null;
+        }
+
+        if ($data instanceof DataContainerMcpRecord) {
+            $data = DataContainerRecord::fromArray($table, $data->data, $data->id ?? $uriVariables['id'] ?? null);
+        }
+
+        if ($operation instanceof Post || $this->hasMethod($operation, 'POST')) {
             // TODO: insert a new record into $table from $data->data.
             // TODO: return the persisted record with its generated id.
             return $data;
         }
 
-        if ($operation instanceof Patch) {
+        if ($operation instanceof Patch || $this->hasMethod($operation, 'PATCH')) {
             // TODO: update the record in $table identified by $uriVariables['id'].
             // TODO: return the updated record.
             return $data;
         }
 
-        if ($operation instanceof Delete) {
-            // TODO: delete the record in $table identified by $uriVariables['id'].
-            return null;
-        }
-
         return $data;
+    }
+
+    private function hasMethod(Operation $operation, string $method): bool
+    {
+        return $operation instanceof HttpOperation && $method === $operation->getMethod();
     }
 
     private function getTable(Operation $operation): string|null

--- a/api-bundle/src/ApiPlatform/State/DataContainerStateProvider.php
+++ b/api-bundle/src/ApiPlatform/State/DataContainerStateProvider.php
@@ -12,14 +12,16 @@ declare(strict_types=1);
 
 namespace Contao\ApiBundle\ApiPlatform\State;
 
+use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Get;
-use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
+use Contao\ApiBundle\Dto\DataContainerMcpRecord;
 use Contao\ApiBundle\Dto\DataContainerRecord;
 
 /**
- * @implements ProviderInterface<DataContainerRecord>
+ * @implements ProviderInterface<DataContainerMcpRecord|DataContainerRecord>
  */
 final class DataContainerStateProvider implements ProviderInterface
 {
@@ -30,18 +32,32 @@ final class DataContainerStateProvider implements ProviderInterface
             return null;
         }
 
-        if ($operation instanceof GetCollection) {
+        if ($operation instanceof CollectionOperationInterface) {
             // TODO: load the records from $table and hydrate DataContainerRecord objects.
             return [];
         }
 
-        if ($operation instanceof Get) {
+        if ($operation instanceof Get || $this->hasMethod($operation, 'GET')) {
             // TODO: load a single record from $table using $uriVariables['id'].
             // TODO: hydrate and return a DataContainerRecord.
             return new DataContainerRecord($table, [], $uriVariables['id'] ?? null);
         }
 
-        return null;
+        $data = $context['mcp_data'] ?? null;
+
+        if (!\is_array($data)) {
+            return null;
+        }
+
+        return new DataContainerMcpRecord(
+            \is_array($data['data'] ?? null) ? $data['data'] : [],
+            \is_int($data['id'] ?? null) || \is_string($data['id'] ?? null) ? $data['id'] : null,
+        );
+    }
+
+    private function hasMethod(Operation $operation, string $method): bool
+    {
+        return $operation instanceof HttpOperation && $method === $operation->getMethod();
     }
 
     private function getTable(Operation $operation): string|null

--- a/api-bundle/src/ContaoApiBundle.php
+++ b/api-bundle/src/ContaoApiBundle.php
@@ -23,14 +23,14 @@ class ContaoApiBundle extends AbstractBundle
     {
         $definition->rootNode()
             ->children()
-            ->scalarNode('api_prefix')
-            ->defaultValue('/_api')
-            ->info('The general route prefix at which Contao shall expose the API.')
-            ->end()
-            ->scalarNode('data_container_api_prefix')
-            ->defaultValue('/backend/dc')
-            ->info('The DC specific subprefix at which Contao shall expose the API.')
-            ->end()
+                ->scalarNode('api_prefix')
+                    ->defaultValue('/_api')
+                    ->info('The general route prefix at which Contao shall expose the API.')
+                ->end()
+                ->scalarNode('data_container_api_prefix')
+                    ->defaultValue('/backend/dc')
+                    ->info('The DC specific subprefix at which Contao shall expose the API.')
+                ->end()
             ->end()
         ;
     }

--- a/api-bundle/src/Dto/DataContainerMcpRecord.php
+++ b/api-bundle/src/Dto/DataContainerMcpRecord.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ApiBundle\Dto;
+
+final class DataContainerMcpRecord
+{
+    public function __construct(
+        public array $data = [],
+        public int|string|null $id = null,
+    ) {
+    }
+}

--- a/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactoryTest.php
+++ b/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactoryTest.php
@@ -16,6 +16,8 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\McpTool;
+use ApiPlatform\Metadata\McpToolCollection;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
@@ -122,6 +124,7 @@ final class DataContainerResourceMetadataCollectionFactoryTest extends ContaoTes
         $this->assertSame(['_scope' => 'backend'], $resource->getDefaults());
         $this->assertSame($expectedTable, $resource->getExtraProperties()['contao']['table']);
         $this->assertSame(DataContainerOpenApiFactory::getSchemaPath($expectedTable), $resource->getExtraProperties()['contao']['schema_path']);
+        $this->assertMcpOperations($resource, $expectedShortName, $expectedTable, $deletable);
 
         $operations = $resource->getOperations();
         $this->assertInstanceOf(Operations::class, $operations);
@@ -138,6 +141,43 @@ final class DataContainerResourceMetadataCollectionFactoryTest extends ContaoTes
             $this->assertOperation($operations['delete'], Delete::class, $expectedShortName, $expectedRoutePrefix.'/{id}');
         } else {
             $this->assertArrayNotHasKey('delete', $operations);
+        }
+    }
+
+    private function assertMcpOperations(ApiResource $resource, string $expectedShortName, string $expectedTable, bool $deletable): void
+    {
+        $mcp = $resource->getMcp();
+        $this->assertIsArray($mcp);
+        $this->assertCount($deletable ? 5 : 4, $mcp);
+
+        $baseName = preg_replace('/^tl_/', '', $expectedTable) ?? $expectedTable;
+
+        $this->assertInstanceOf(McpToolCollection::class, $mcp[$baseName.'_get_collection']);
+        $this->assertSame($expectedShortName, $mcp[$baseName.'_get_collection']->getShortName());
+        $this->assertSame(DataContainerRecord::class, $mcp[$baseName.'_get_collection']->getClass());
+        $this->assertSame(DataContainerStateProvider::class, $mcp[$baseName.'_get_collection']->getProvider());
+        $this->assertSame(DataContainerStateProcessor::class, $mcp[$baseName.'_get_collection']->getProcessor());
+
+        foreach (['get', 'post', 'patch'] as $operationName) {
+            $operation = $mcp[$baseName.'_'.$operationName];
+
+            $this->assertInstanceOf(McpTool::class, $operation);
+            $this->assertSame($expectedShortName, $operation->getShortName());
+            $this->assertSame(DataContainerRecord::class, $operation->getClass());
+            $this->assertSame(DataContainerStateProvider::class, $operation->getProvider());
+            $this->assertSame(DataContainerStateProcessor::class, $operation->getProcessor());
+        }
+
+        if ($deletable) {
+            $delete = $mcp[$baseName.'_delete'];
+            $this->assertInstanceOf(McpTool::class, $delete);
+            $this->assertSame($expectedShortName, $delete->getShortName());
+            $this->assertSame(DataContainerRecord::class, $delete->getClass());
+            $this->assertSame(DataContainerStateProvider::class, $delete->getProvider());
+            $this->assertSame(DataContainerStateProcessor::class, $delete->getProcessor());
+            $this->assertFalse($delete->getStructuredContent());
+        } else {
+            $this->assertArrayNotHasKey($baseName.'_delete', $mcp);
         }
     }
 

--- a/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactoryTest.php
+++ b/api-bundle/tests/ApiPlatform/Metadata/DataContainerResourceMetadataCollectionFactoryTest.php
@@ -48,12 +48,14 @@ final class DataContainerResourceMetadataCollectionFactoryTest extends ContaoTes
     public function testBuildsMetadataForAllAvailableDataContainers(): void
     {
         $decorated = $this->createStub(ResourceMetadataCollectionFactoryInterface::class);
-        $controllerAdapter = $this->createAdapterMock(['loadDataContainer']);
+
         $extendedDcTableClass = (new class() extends DC_Table {
             public function __construct()
             {
             }
         })::class;
+
+        $controllerAdapter = $this->createAdapterMock(['loadDataContainer']);
         $controllerAdapter
             ->expects($this->exactly(5))
             ->method('loadDataContainer')
@@ -82,6 +84,7 @@ final class DataContainerResourceMetadataCollectionFactoryTest extends ContaoTes
                 },
             )
         ;
+
         $framework = $this->createContaoFrameworkStub([Controller::class => $controllerAdapter]);
         $resourceFinder = $this->createResourceFinder(['tl_article', 'tl_content', 'tl_log', 'tl_page', 'tl_settings']);
 
@@ -100,15 +103,17 @@ final class DataContainerResourceMetadataCollectionFactoryTest extends ContaoTes
     public function testDelegatesForNonDataContainerResources(): void
     {
         $collection = new ResourceMetadataCollection('App\\Entity\\Foo');
-        $decorated = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
         $framework = $this->createContaoFrameworkStub();
         $resourceFinder = $this->createStub(ResourceFinderInterface::class);
+
+        $decorated = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
         $decorated
             ->expects($this->once())
             ->method('create')
             ->with('App\\Entity\\Foo')
             ->willReturn($collection)
         ;
+
         $factory = new DataContainerResourceMetadataCollectionFactory($decorated, $framework, $resourceFinder, 'backend/dc');
 
         $this->assertSame($collection, $factory->create('App\\Entity\\Foo'));
@@ -131,7 +136,6 @@ final class DataContainerResourceMetadataCollectionFactoryTest extends ContaoTes
         $this->assertCount($deletable ? 5 : 4, $operations);
 
         $operations = iterator_to_array($operations);
-
         $this->assertOperation($operations['get_collection'], GetCollection::class, $expectedShortName, $expectedRoutePrefix);
         $this->assertOperation($operations['get'], Get::class, $expectedShortName, $expectedRoutePrefix.'/{id}');
         $this->assertOperation($operations['post'], Post::class, $expectedShortName, $expectedRoutePrefix);
@@ -160,7 +164,6 @@ final class DataContainerResourceMetadataCollectionFactoryTest extends ContaoTes
 
         foreach (['get', 'post', 'patch'] as $operationName) {
             $operation = $mcp[$baseName.'_'.$operationName];
-
             $this->assertInstanceOf(McpTool::class, $operation);
             $this->assertSame($expectedShortName, $operation->getShortName());
             $this->assertSame(DataContainerRecord::class, $operation->getClass());

--- a/api-bundle/tests/ApiPlatform/State/DataContainerStateProcessorTest.php
+++ b/api-bundle/tests/ApiPlatform/State/DataContainerStateProcessorTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 namespace Contao\ApiBundle\Tests\ApiPlatform\State;
 
 use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\McpTool;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use Contao\ApiBundle\ApiPlatform\State\DataContainerStateProcessor;
+use Contao\ApiBundle\Dto\DataContainerMcpRecord;
 use Contao\ApiBundle\Dto\DataContainerRecord;
 use PHPUnit\Framework\TestCase;
 
@@ -25,7 +27,7 @@ final class DataContainerStateProcessorTest extends TestCase
     {
         $processor = new DataContainerStateProcessor();
         $record = new DataContainerRecord('tl_content', ['headline' => 'Example']);
-        $operation = new Post()->withExtraProperties([
+        $operation = new McpTool(method: 'POST')->withExtraProperties([
             'contao' => [
                 'table' => 'tl_content',
             ],
@@ -40,6 +42,24 @@ final class DataContainerStateProcessorTest extends TestCase
         ]);
 
         $this->assertSame($record, $processor->process($record, $operation, ['id' => 17]));
+    }
+
+    public function testConvertsMcpWriteInputToADataContainerRecord(): void
+    {
+        $processor = new DataContainerStateProcessor();
+        $input = new DataContainerMcpRecord(['headline' => 'Example'], 17);
+        $operation = new Post()->withExtraProperties([
+            'contao' => [
+                'table' => 'tl_content',
+            ],
+        ]);
+
+        $record = $processor->process($input, $operation);
+
+        $this->assertInstanceOf(DataContainerRecord::class, $record);
+        $this->assertSame('tl_content', $record->table);
+        $this->assertSame(['headline' => 'Example'], $record->data);
+        $this->assertSame(17, $record->id);
     }
 
     public function testReturnsNullForDeleteOperations(): void

--- a/api-bundle/tests/ApiPlatform/State/DataContainerStateProcessorTest.php
+++ b/api-bundle/tests/ApiPlatform/State/DataContainerStateProcessorTest.php
@@ -27,6 +27,7 @@ final class DataContainerStateProcessorTest extends TestCase
     {
         $processor = new DataContainerStateProcessor();
         $record = new DataContainerRecord('tl_content', ['headline' => 'Example']);
+
         $operation = new McpTool(method: 'POST')->withExtraProperties([
             'contao' => [
                 'table' => 'tl_content',
@@ -48,6 +49,7 @@ final class DataContainerStateProcessorTest extends TestCase
     {
         $processor = new DataContainerStateProcessor();
         $input = new DataContainerMcpRecord(['headline' => 'Example'], 17);
+
         $operation = new Post()->withExtraProperties([
             'contao' => [
                 'table' => 'tl_content',
@@ -66,6 +68,7 @@ final class DataContainerStateProcessorTest extends TestCase
     {
         $processor = new DataContainerStateProcessor();
         $record = new DataContainerRecord('tl_content', ['headline' => 'Example']);
+
         $operation = new Delete()->withExtraProperties([
             'contao' => [
                 'table' => 'tl_content',

--- a/api-bundle/tests/ApiPlatform/State/DataContainerStateProviderTest.php
+++ b/api-bundle/tests/ApiPlatform/State/DataContainerStateProviderTest.php
@@ -14,7 +14,10 @@ namespace Contao\ApiBundle\Tests\ApiPlatform\State;
 
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\McpTool;
+use ApiPlatform\Metadata\McpToolCollection;
 use Contao\ApiBundle\ApiPlatform\State\DataContainerStateProvider;
+use Contao\ApiBundle\Dto\DataContainerMcpRecord;
 use Contao\ApiBundle\Dto\DataContainerRecord;
 use PHPUnit\Framework\TestCase;
 
@@ -37,10 +40,60 @@ final class DataContainerStateProviderTest extends TestCase
         $this->assertSame([], $record->data);
     }
 
+    public function testProvidesARecordForMcpToolItemOperations(): void
+    {
+        $provider = new DataContainerStateProvider();
+        $operation = new McpTool()->withExtraProperties([
+            'contao' => [
+                'table' => 'tl_content',
+            ],
+        ]);
+
+        $record = $provider->provide($operation, ['id' => 17]);
+
+        $this->assertInstanceOf(DataContainerRecord::class, $record);
+        $this->assertSame('tl_content', $record->table);
+        $this->assertSame(17, $record->id);
+        $this->assertSame([], $record->data);
+    }
+
     public function testProvidesAnEmptyCollectionForCollectionOperations(): void
     {
         $provider = new DataContainerStateProvider();
         $operation = new GetCollection()->withExtraProperties([
+            'contao' => [
+                'table' => 'tl_content',
+            ],
+        ]);
+
+        $this->assertSame([], $provider->provide($operation));
+    }
+
+    public function testProvidesMcpInputForWriteOperations(): void
+    {
+        $provider = new DataContainerStateProvider();
+        $operation = new McpTool(method: 'POST')->withExtraProperties([
+            'contao' => [
+                'table' => 'tl_content',
+            ],
+        ]);
+
+        $record = $provider->provide($operation, context: [
+            'mcp_data' => [
+                'data' => ['headline' => 'Example'],
+                'id' => 17,
+            ],
+        ]);
+
+        $this->assertInstanceOf(DataContainerMcpRecord::class, $record);
+        $this->assertSame(['headline' => 'Example'], $record->data);
+        $this->assertSame(17, $record->id);
+    }
+
+    public function testProvidesAnEmptyCollectionForMcpToolCollectionOperations(): void
+    {
+        $provider = new DataContainerStateProvider();
+        $operation = new McpToolCollection()->withExtraProperties([
             'contao' => [
                 'table' => 'tl_content',
             ],

--- a/api-bundle/tests/ApiPlatform/State/DataContainerStateProviderTest.php
+++ b/api-bundle/tests/ApiPlatform/State/DataContainerStateProviderTest.php
@@ -26,6 +26,7 @@ final class DataContainerStateProviderTest extends TestCase
     public function testProvidesARecordForItemOperations(): void
     {
         $provider = new DataContainerStateProvider();
+
         $operation = new Get()->withExtraProperties([
             'contao' => [
                 'table' => 'tl_content',
@@ -43,6 +44,7 @@ final class DataContainerStateProviderTest extends TestCase
     public function testProvidesARecordForMcpToolItemOperations(): void
     {
         $provider = new DataContainerStateProvider();
+
         $operation = new McpTool()->withExtraProperties([
             'contao' => [
                 'table' => 'tl_content',
@@ -60,6 +62,7 @@ final class DataContainerStateProviderTest extends TestCase
     public function testProvidesAnEmptyCollectionForCollectionOperations(): void
     {
         $provider = new DataContainerStateProvider();
+
         $operation = new GetCollection()->withExtraProperties([
             'contao' => [
                 'table' => 'tl_content',
@@ -72,6 +75,7 @@ final class DataContainerStateProviderTest extends TestCase
     public function testProvidesMcpInputForWriteOperations(): void
     {
         $provider = new DataContainerStateProvider();
+
         $operation = new McpTool(method: 'POST')->withExtraProperties([
             'contao' => [
                 'table' => 'tl_content',
@@ -93,6 +97,7 @@ final class DataContainerStateProviderTest extends TestCase
     public function testProvidesAnEmptyCollectionForMcpToolCollectionOperations(): void
     {
         $provider = new DataContainerStateProvider();
+
         $operation = new McpToolCollection()->withExtraProperties([
             'contao' => [
                 'table' => 'tl_content',

--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
         "symfony/intl": "^7.4 || ^8.0",
         "symfony/mailer": "^7.4 || ^8.0",
         "symfony/maker-bundle": "^1.1",
-        "symfony/mcp-bundle": "^0.10.0",
+        "symfony/mcp-bundle": "^0.10",
         "symfony/messenger": "^7.4 || ^8.0",
         "symfony/mime": "^7.4 || ^8.0",
         "symfony/monolog-bridge": "^7.4 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -140,6 +140,7 @@
         "symfony/intl": "^7.4 || ^8.0",
         "symfony/mailer": "^7.4 || ^8.0",
         "symfony/maker-bundle": "^1.1",
+        "symfony/mcp-bundle": "^0.10.0",
         "symfony/messenger": "^7.4 || ^8.0",
         "symfony/mime": "^7.4 || ^8.0",
         "symfony/monolog-bridge": "^7.4 || ^8.0",

--- a/ecs.php
+++ b/ecs.php
@@ -50,6 +50,7 @@ return ECSConfig::configure()
     ])
     ->withSkip([
         MethodChainingIndentationFixer::class => [
+            '*-bundle/src/*Bundle.php',
             '*/DependencyInjection/Configuration.php',
         ],
         ReferenceUsedNamesOnlySniff::class => [

--- a/mcp-bundle/composer.json
+++ b/mcp-bundle/composer.json
@@ -28,8 +28,11 @@
     ],
     "require": {
         "php": "^8.4",
+        "api-platform/mcp": "^4.3",
+        "contao/api-bundle": "self.version",
         "contao/core-bundle": "self.version",
-        "symfony/http-kernel": "^7.4 || ^8.0"
+        "symfony/http-kernel": "^7.4 || ^8.0",
+        "symfony/mcp-bundle": "^0.10.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",

--- a/mcp-bundle/composer.json
+++ b/mcp-bundle/composer.json
@@ -32,7 +32,7 @@
         "contao/api-bundle": "self.version",
         "contao/core-bundle": "self.version",
         "symfony/http-kernel": "^7.4 || ^8.0",
-        "symfony/mcp-bundle": "^0.10.0"
+        "symfony/mcp-bundle": "^0.10"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",

--- a/mcp-bundle/config/routes.yaml
+++ b/mcp-bundle/config/routes.yaml
@@ -1,0 +1,5 @@
+mcp:
+    resource: .
+    type: mcp
+    defaults:
+        _scope: backend

--- a/mcp-bundle/skeleton/config/api_platform.yaml
+++ b/mcp-bundle/skeleton/config/api_platform.yaml
@@ -1,0 +1,4 @@
+api_platform:
+    mcp:
+        enabled: true
+        format: jsonld

--- a/mcp-bundle/skeleton/config/mcp.yaml
+++ b/mcp-bundle/skeleton/config/mcp.yaml
@@ -1,0 +1,10 @@
+mcp:
+    client_transports:
+        http: true
+        stdio: false
+    http:
+        path: '%contao_mcp.path%'
+        session:
+            store: file
+            directory: '%kernel.cache_dir%/mcp'
+            ttl: 3600

--- a/mcp-bundle/src/ContaoManager/Plugin.php
+++ b/mcp-bundle/src/ContaoManager/Plugin.php
@@ -12,22 +12,45 @@ declare(strict_types=1);
 
 namespace Contao\McpBundle\ContaoManager;
 
+use Contao\ApiBundle\ContaoApiBundle;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Contao\ManagerPlugin\Config\ConfigPluginInterface;
+use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 use Contao\McpBundle\ContaoMcpBundle;
+use Symfony\AI\McpBundle\McpBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\RouteCollection;
 
 /**
  * @internal
  */
-class Plugin implements BundlePluginInterface
+class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPluginInterface
 {
     public function getBundles(ParserInterface $parser): array
     {
         return [
             BundleConfig::create(ContaoMcpBundle::class)
-                ->setLoadAfter([ContaoCoreBundle::class]),
+                ->setLoadAfter([ContaoApiBundle::class, ContaoCoreBundle::class]),
+            BundleConfig::create(McpBundle::class)
+                ->setLoadAfter([ContaoMcpBundle::class]),
         ];
+    }
+
+    public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel): RouteCollection|null
+    {
+        $path = __DIR__.'/../../config/routes.yaml';
+
+        return $resolver->resolve($path)->load($path);
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader, array $managerConfig): void
+    {
+        $loader->load(__DIR__.'/../../skeleton/config/mcp.yaml');
+        $loader->load(__DIR__.'/../../skeleton/config/api_platform.yaml');
     }
 }

--- a/mcp-bundle/src/ContaoMcpBundle.php
+++ b/mcp-bundle/src/ContaoMcpBundle.php
@@ -12,8 +12,29 @@ declare(strict_types=1);
 
 namespace Contao\McpBundle;
 
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
 class ContaoMcpBundle extends AbstractBundle
 {
+    public function configure(DefinitionConfigurator $definition): void
+    {
+        $definition->rootNode()
+            ->children()
+            ->scalarNode('path')
+            ->defaultValue('/_mcp')
+            ->info('The HTTP route at which Contao shall expose the MCP server.')
+            ->end()
+            ->end()
+        ;
+    }
+
+    public function loadExtension(array $config, ContainerConfigurator $configurator, ContainerBuilder $container): void
+    {
+        $configurator->parameters()
+            ->set('contao_mcp.path', $config['path'])
+        ;
+    }
 }

--- a/mcp-bundle/src/ContaoMcpBundle.php
+++ b/mcp-bundle/src/ContaoMcpBundle.php
@@ -25,7 +25,7 @@ class ContaoMcpBundle extends AbstractBundle
             ->children()
                 ->scalarNode('path')
                     ->defaultValue('/_mcp')
-                    ->info('The HTTP route at which Contao shall expose the MCP server.')
+                    ->info('The HTTP route at which Contao exposes the MCP server.')
                 ->end()
             ->end()
         ;

--- a/mcp-bundle/src/ContaoMcpBundle.php
+++ b/mcp-bundle/src/ContaoMcpBundle.php
@@ -23,10 +23,10 @@ class ContaoMcpBundle extends AbstractBundle
     {
         $definition->rootNode()
             ->children()
-            ->scalarNode('path')
-            ->defaultValue('/_mcp')
-            ->info('The HTTP route at which Contao shall expose the MCP server.')
-            ->end()
+                ->scalarNode('path')
+                    ->defaultValue('/_mcp')
+                    ->info('The HTTP route at which Contao shall expose the MCP server.')
+                ->end()
             ->end()
         ;
     }

--- a/mcp-bundle/tests/ContaoManager/PluginTest.php
+++ b/mcp-bundle/tests/ContaoManager/PluginTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\McpBundle\Tests\ContaoManager;
+
+use Contao\ApiBundle\ContaoApiBundle;
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Contao\McpBundle\ContaoManager\Plugin;
+use Contao\McpBundle\ContaoMcpBundle;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\McpBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Yaml\Yaml;
+
+final class PluginTest extends TestCase
+{
+    public function testRegistersTheMcpBundleInTheCorrectOrder(): void
+    {
+        $plugin = new Plugin();
+        $bundles = $plugin->getBundles($this->createStub(ParserInterface::class));
+
+        $this->assertCount(2, $bundles);
+        $this->assertSame(ContaoMcpBundle::class, $bundles[0]->getName());
+        $this->assertSame([ContaoApiBundle::class, ContaoCoreBundle::class], $bundles[0]->getLoadAfter());
+        $this->assertSame(McpBundle::class, $bundles[1]->getName());
+        $this->assertSame([ContaoMcpBundle::class], $bundles[1]->getLoadAfter());
+    }
+
+    public function testLoadsTheSkeletonConfigAndMcpRoutes(): void
+    {
+        $plugin = new Plugin();
+        $resolver = $this->createMock(LoaderResolverInterface::class);
+        $loader = $this->createMock(LoaderInterface::class);
+        $routeCollection = new RouteCollection();
+
+        $resolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with(\dirname(__DIR__, 2).'/src/ContaoManager/../../config/routes.yaml')
+            ->willReturn($loader)
+        ;
+
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->with(\dirname(__DIR__, 2).'/src/ContaoManager/../../config/routes.yaml')
+            ->willReturn($routeCollection)
+        ;
+
+        $this->assertSame($routeCollection, $plugin->getRouteCollection($resolver, $this->createStub(KernelInterface::class)));
+
+        $loader = $this->createMock(LoaderInterface::class);
+        $paths = [];
+        $loader
+            ->expects($this->exactly(2))
+            ->method('load')
+            ->willReturnCallback(
+                static function (string $path) use (&$paths): void {
+                    $paths[] = $path;
+                },
+            )
+        ;
+
+        $plugin->registerContainerConfiguration($loader, []);
+
+        $this->assertSame(
+            [
+                \dirname(__DIR__, 2).'/src/ContaoManager/../../skeleton/config/mcp.yaml',
+                \dirname(__DIR__, 2).'/src/ContaoManager/../../skeleton/config/api_platform.yaml',
+            ],
+            $paths,
+        );
+    }
+
+    public function testProtectsTheMcpRouteWithBackendScope(): void
+    {
+        $route = Yaml::parseFile(\dirname(__DIR__, 2).'/src/ContaoManager/../../config/routes.yaml')['mcp'];
+
+        $this->assertSame(['_scope' => 'backend'], $route['defaults']);
+    }
+}

--- a/mcp-bundle/tests/ContaoManager/PluginTest.php
+++ b/mcp-bundle/tests/ContaoManager/PluginTest.php
@@ -42,17 +42,9 @@ final class PluginTest extends TestCase
     public function testLoadsTheSkeletonConfigAndMcpRoutes(): void
     {
         $plugin = new Plugin();
-        $resolver = $this->createMock(LoaderResolverInterface::class);
-        $loader = $this->createMock(LoaderInterface::class);
         $routeCollection = new RouteCollection();
 
-        $resolver
-            ->expects($this->once())
-            ->method('resolve')
-            ->with(\dirname(__DIR__, 2).'/src/ContaoManager/../../config/routes.yaml')
-            ->willReturn($loader)
-        ;
-
+        $loader = $this->createMock(LoaderInterface::class);
         $loader
             ->expects($this->once())
             ->method('load')
@@ -60,10 +52,19 @@ final class PluginTest extends TestCase
             ->willReturn($routeCollection)
         ;
 
+        $resolver = $this->createMock(LoaderResolverInterface::class);
+        $resolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with(\dirname(__DIR__, 2).'/src/ContaoManager/../../config/routes.yaml')
+            ->willReturn($loader)
+        ;
+
         $this->assertSame($routeCollection, $plugin->getRouteCollection($resolver, $this->createStub(KernelInterface::class)));
 
-        $loader = $this->createMock(LoaderInterface::class);
         $paths = [];
+
+        $loader = $this->createMock(LoaderInterface::class);
         $loader
             ->expects($this->exactly(2))
             ->method('load')


### PR DESCRIPTION
Outlines how all API operations could be exposed via MCP.

Currently, the Symfony MCP bundle does not provide multiple ways to register MCP API endpoints so this is only for `scope = backend` for now but as all the components are highly experimental (none of them is stable), things will change quickly in the future probably anyway 😊 
