### PR TITLE
Only add custom form field classes to the outer container

### DIFF
--- a/core-bundle/contao/forms/FormSelect.php
+++ b/core-bundle/contao/forms/FormSelect.php
@@ -179,18 +179,13 @@ class FormSelect extends Widget
 	 */
 	public function parse($arrAttributes=null)
 	{
-		$strClass = 'select';
-
-		if ($this->multiple)
-		{
-			$strClass = 'multiselect';
-		}
-
 		// Make sure there are no multiple options in single mode
-		elseif (\is_array($this->varValue))
+		if (!$this->multiple && \is_array($this->varValue))
 		{
 			$this->varValue = $this->varValue[0] ?? null;
 		}
+
+		$strClass = '';
 
 		// Chosen
 		if ($this->chosen)

--- a/core-bundle/contao/templates/form_altcha.html.twig
+++ b/core-bundle/contao/templates/form_altcha.html.twig
@@ -9,7 +9,7 @@
 
 {% block label %}
     {% if this.label and not this.altchaFloating|default %}
-        <label for="ctrl_{{ this.id }}"{% if this.class|default %} class="{{ this.class|default }}"{% endif %}>
+        <label for="ctrl_{{ this.id }}">
             <span class="invisible">{{ this.mandatoryField }} </span>{{ this.label|insert_tag_raw }}<span class="mandatory">*</span>
         </label>
     {% endif %}

--- a/core-bundle/contao/templates/form_captcha.html.twig
+++ b/core-bundle/contao/templates/form_captcha.html.twig
@@ -2,7 +2,7 @@
 
 {% block label %}
     {% if this.label %}
-        <label for="ctrl_{{ this.id }}"{% if this.class|default %} class="{{ this.class|default }}"{% endif %}>
+        <label for="ctrl_{{ this.id }}">
             <span class="invisible">{{ this.mandatoryField }} </span>{{ this.label|insert_tag_raw }}<span class="mandatory">*</span>
         </label>
     {% endif %}
@@ -20,13 +20,12 @@
         .set('name', this.name)
         .set('id', "ctrl_#{this.id}")
         .addClass('captcha mandatory')
-        .addClass(this.class|default)
         .set('aria-describedby', "captcha_text_#{this.id}")
         .set('value', '')
         .mergeWith(input_attributes)
         .setIfExists('placeholder', input_attributes.placeholder|default|insert_tag)
     }}>
-    <span id="captcha_text_{{ this.id }}" class="captcha_text{% if this.class|default %} {{ this.class|default }}{% endif %}">{{ getQuestion.invoke()|raw }}</span>
+    <span id="captcha_text_{{ this.id }}" class="captcha_text">{{ getQuestion.invoke()|raw }}</span>
     <input type="hidden" name="{{ this.name }}_hash{{ hasErrors.invoke() ? 1 + this.sum ** 2 : '' }}" value="{{ hasErrors.invoke() ? getHash.invoke() : '' }}">
 
     {% if not hasErrors.invoke() %}

--- a/core-bundle/contao/templates/form_checkbox.html.twig
+++ b/core-bundle/contao/templates/form_checkbox.html.twig
@@ -1,7 +1,7 @@
 {% extends '@Contao/form_row.html.twig' %}
 
 {% block field %}
-    <fieldset id="ctrl_{{ this.id }}" class="checkbox_container{% if this.class|default %} {{ this.class|default }}{% endif %}"{% if this.help|default %} aria-describedby="help_ctrl_{{ this.id }}"{% endif %}>
+    <fieldset id="ctrl_{{ this.id }}" class="checkbox_container"{% if this.help|default %} aria-describedby="help_ctrl_{{ this.id }}"{% endif %}>
 
         {% if this.label %}
             <legend>

--- a/core-bundle/contao/templates/form_explanation.html.twig
+++ b/core-bundle/contao/templates/form_explanation.html.twig
@@ -1,5 +1,5 @@
 {% set wrapperAttributes = attrs()
-    .addClass([this.prefix, 'explanation', this.class|default])
+    .addClass([this.prefix, this.class|default])
     .mergeWith(wrapperAttributes|default)
 %}
 

--- a/core-bundle/contao/templates/form_password.html.twig
+++ b/core-bundle/contao/templates/form_password.html.twig
@@ -2,7 +2,7 @@
 
 {% block label %}
     {% if this.label %}
-        <label for="ctrl_{{ this.id }}"{% if this.class|default %} class="{{ this.class|default }}"{% endif %}>
+        <label for="ctrl_{{ this.id }}">
             {% if this.mandatory|default %}
                 <span class="invisible">{{ this.mandatoryField }} </span>{{ this.label|insert_tag_raw }}<span class="mandatory">*</span>
             {% else %}
@@ -24,7 +24,6 @@
         .set('name', this.name)
         .set('id', "ctrl_#{this.id}")
         .addClass('text password')
-        .addClass(this.class|default)
         .set('value', '')
         .set('autocomplete', 'new-password')
         .set('aria-describedby', "help_ctrl_#{this.id}", this.help|default)

--- a/core-bundle/contao/templates/form_radio.html.twig
+++ b/core-bundle/contao/templates/form_radio.html.twig
@@ -1,7 +1,7 @@
 {% extends '@Contao/form_row.html.twig' %}
 
 {% block field %}
-    <fieldset id="ctrl_{{ this.id }}" class="radio_container{% if this.class|default %} {{ this.class|default }}{% endif %}"{% if this.help|default %} aria-describedby="help_ctrl_{{ this.id }}"{% endif %}>
+    <fieldset id="ctrl_{{ this.id }}" class="radio_container"{% if this.help|default %} aria-describedby="help_ctrl_{{ this.id }}"{% endif %}>
 
         {% if this.label %}
             <legend>

--- a/core-bundle/contao/templates/form_range.html.twig
+++ b/core-bundle/contao/templates/form_range.html.twig
@@ -2,7 +2,7 @@
 
 {% block label %}
     {% if this.label %}
-        <label for="ctrl_{{ this.id }}"{% if this.class|default %} class="{{ this.class|default }}"{% endif %}>
+        <label for="ctrl_{{ this.id }}">
             {% if this.mandatory|default %}
                 <span class="invisible">{{ this.mandatoryField }} </span>{{ this.label|insert_tag_raw }}<span class="mandatory">*</span>
             {% else %}
@@ -22,7 +22,6 @@
         .set('name', this.name)
         .set('id', "ctrl_#{this.id}")
         .addClass('range')
-        .addClass(this.class|default)
         .set('value', this.value, this.value != '')
         .set('aria-describedby', "help_ctrl_#{this.id}", this.help|default)
         .mergeWith(getAttributes.invoke())

--- a/core-bundle/contao/templates/form_select.html.twig
+++ b/core-bundle/contao/templates/form_select.html.twig
@@ -2,7 +2,7 @@
 
 {% block label %}
     {% if this.label %}
-        <label for="ctrl_{{ this.id }}"{% if this.class|default %} class="{{ this.class|default }}"{% endif %}>
+        <label for="ctrl_{{ this.id }}">
             {% if this.mandatory|default %}
                 <span class="invisible">{{ this.mandatoryField }} </span>{{ this.label|insert_tag_raw }}<span class="mandatory">*</span>
             {% else %}
@@ -24,7 +24,7 @@
     <select{{ attrs()
         .set('name', this.name)
         .set('id', "ctrl_#{this.id}")
-        .addClass(this.class|default)
+        .addClass(this.multiple|default ? 'multiselect' : 'select')
         .set('aria-describedby', "help_ctrl_#{this.id}", this.help|default)
         .mergeWith(getAttributes.invoke())
     }}>

--- a/core-bundle/contao/templates/form_submit.html.twig
+++ b/core-bundle/contao/templates/form_submit.html.twig
@@ -7,7 +7,6 @@
             .set('src', this.src)
             .set('id', "ctrl_#{this.id}")
             .addClass('submit')
-            .addClass(this.class|default)
             .set('title', this.slabel)
             .set('alt', this.slabel)
             .mergeWith(getAttributes.invoke())
@@ -17,7 +16,6 @@
             .set('type', 'submit')
             .set('id', "ctrl_#{this.id}")
             .addClass('submit')
-            .addClass(this.class|default)
             .mergeWith(getAttributes.invoke())
         }}>{{ this.slabel }}</button>
     {% endif %}

--- a/core-bundle/contao/templates/form_text.html.twig
+++ b/core-bundle/contao/templates/form_text.html.twig
@@ -2,7 +2,7 @@
 
 {% block label %}
     {% if this.label %}
-        <label for="ctrl_{{ this.id }}"{% if this.class|default %} class="{{ this.class|default }}"{% endif %}>
+        <label for="ctrl_{{ this.id }}">
             {% if this.mandatory|default %}
                 <span class="invisible">{{ this.mandatoryField }} </span>{{ this.label|insert_tag_raw }}<span class="mandatory">*</span>
             {% else %}
@@ -25,7 +25,6 @@
         .set('id', "ctrl_#{this.id}")
         .addClass('text')
         .addClass('password', this.hideInput|default)
-        .addClass(this.class|default)
         .set('value', convertDate.invoke(this.value|default))
         .set('aria-describedby', "help_ctrl_#{this.id}", this.help|default)
         .mergeWith(input_attributes)

--- a/core-bundle/contao/templates/form_textarea.html.twig
+++ b/core-bundle/contao/templates/form_textarea.html.twig
@@ -2,7 +2,7 @@
 
 {% block label %}
     {% if this.label %}
-        <label for="ctrl_{{ this.id }}"{% if this.class|default %} class="{{ this.class|default }}"{% endif %}>
+        <label for="ctrl_{{ this.id }}">
             {% if this.mandatory|default %}
                 <span class="invisible">{{ this.mandatoryField }} </span>{{ this.label|insert_tag_raw }}<span class="mandatory">*</span>
             {% else %}
@@ -23,7 +23,6 @@
         .set('name', this.name)
         .set('id', "ctrl_#{this.id}")
         .addClass('textarea')
-        .addClass(this.class|default)
         .set('rows', this.rows)
         .set('cols', this.cols)
         .set('aria-describedby', "help_ctrl_#{this.id}", this.help|default)

--- a/core-bundle/contao/templates/form_upload.html.twig
+++ b/core-bundle/contao/templates/form_upload.html.twig
@@ -2,7 +2,7 @@
 
 {% block label %}
     {% if this.label %}
-        <label for="ctrl_{{ this.id }}"{% if this.class|default %} class="{{ this.class|default }}"{% endif %}>
+        <label for="ctrl_{{ this.id }}">
             {% if this.mandatory|default %}
                 <span class="invisible">{{ this.mandatoryField }} </span>{{ this.label|insert_tag_raw }}<span class="mandatory">*</span>
             {% else %}
@@ -22,7 +22,6 @@
         .set('name', this.name)
         .set('id', "ctrl_#{this.id}")
         .addClass('upload')
-        .addClass(this.class|default)
         .set('aria-describedby', "help_ctrl_#{this.id}", this.help|default)
         .set('multiple', true, this.multipleFiles|default)
         .mergeWith(getAttributes.invoke())


### PR DESCRIPTION
Implements #6300

```diff
@@ -1,8 +1,8 @@
 <form method="post" enctype="application/x-www-form-urlencoded">
     <div class="formbody">
-        <div class="widget widget-select select my-salutation">
-            <label for="ctrl_15" class="select my-salutation">Salutation</label>
-            <select name="salutation" id="ctrl_15" class="select my-salutation">
+        <div class="widget widget-select my-salutation">
+            <label for="ctrl_15">Salutation</label>
+            <select name="salutation" id="ctrl_15" class="select">
                 <option value="mrs">Mrs.</option>
                 <option value="mr">Mr.</option>
             </select>
@@ -10,24 +10,24 @@
         <fieldset class="my-fieldset">
             <legend>Fieldset</legend>
             <div class="widget widget-text my-name">
-                <label for="ctrl_16" class="my-name">Name</label>
-                <input type="text" name="name" id="ctrl_16" class="text my-name" value aria-describedby="help_ctrl_16">
+                <label for="ctrl_16">Name</label>
+                <input type="text" name="name" id="ctrl_16" class="text" value aria-describedby="help_ctrl_16">
                 <p class="help" id="help_ctrl_16">Gib deinen Namen ein.</p>
             </div>
             <div class="widget widget-text my-email mandatory">
-                <label for="ctrl_18" class="my-email mandatory"><span class="invisible">Mandatory field </span>E-Mail<span class="mandatory">*</span></label>
-                <input type="email" name="email" id="ctrl_18" class="text my-email mandatory" value required>
+                <label for="ctrl_18"><span class="invisible">Mandatory field </span>E-Mail<span class="mandatory">*</span></label>
+                <input type="email" name="email" id="ctrl_18" class="text" value required>
             </div>
         </fieldset>
         <div class="widget widget-textarea my-textarea mandatory">
-            <label for="ctrl_19" class="my-textarea mandatory"><span class="invisible">Mandatory field </span>Your message<span class="mandatory">*</span></label>
-            <textarea name="message" id="ctrl_19" class="textarea my-textarea mandatory" rows="4" cols="40" required></textarea>
+            <label for="ctrl_19"><span class="invisible">Mandatory field </span>Your message<span class="mandatory">*</span></label>
+            <textarea name="message" id="ctrl_19" class="textarea" rows="4" cols="40" required></textarea>
         </div>
-        <div class="widget widget-explanation explanation my-explanation">
+        <div class="widget widget-explanation my-explanation">
             <p><strong>Explanation</strong><br>This is an optional information text within the form that adds further text content here.</p>
         </div>
         <div class="widget widget-submit submit_container">
-            <button type="submit" id="ctrl_21" class="submit submit_container">Submit</button>
+            <button type="submit" id="ctrl_21" class="submit">Submit</button>
         </div>
     </div>
 </form>
```
