### PR TITLE
Use sane defaults when rendering elements

### DIFF
--- a/core-bundle/src/Controller/ContentElement/AbstractDownloadContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractDownloadContentElementController.php
@@ -64,7 +64,7 @@ abstract class AbstractDownloadContentElementController extends AbstractContentE
             fn (FilesystemItem $filesystemItem): array => [
                 'href' => $this->generateDownloadUrl($filesystemItem, $model, $request),
                 'file' => $filesystemItem,
-                'show_file_previews' => $model->showPreview,
+                'show_file_previews' => (bool) $model->showPreview,
                 'file_previews' => $this->getPreviewsForContentModel($filesystemItem, $model),
             ],
             iterator_to_array($filesystemItems),
@@ -119,7 +119,7 @@ abstract class AbstractDownloadContentElementController extends AbstractContentE
     protected function generateDownloadUrl(FilesystemItem $filesystemItem, ContentModel $model, Request $request): string
     {
         $path = $filesystemItem->getPath();
-        $inline = $model->inline;
+        $inline = (bool) $model->inline;
 
         if ($publicUri = $this->getVirtualFilesystem()->generatePublicUri($path, new ContentDispositionOption($inline))) {
             return (string) $publicUri;
@@ -146,7 +146,7 @@ abstract class AbstractDownloadContentElementController extends AbstractContentE
         $figureBuilder = $this->container->get('contao.image.studio')
             ->createFigureBuilder()
             ->setSize($size = $model->size)
-            ->enableLightbox($fullsize = $model->fullsize)
+            ->enableLightbox($fullsize = (bool) $model->fullsize)
             ->disableMetadata()
             ->setLightboxGroupIdentifier(\sprintf('dl_%s_%s', $model->id, md5($filesystemItem->getPath())))
         ;

--- a/core-bundle/src/Controller/ContentElement/DownloadsController.php
+++ b/core-bundle/src/Controller/ContentElement/DownloadsController.php
@@ -41,7 +41,7 @@ class DownloadsController extends AbstractDownloadContentElementController
         $filesystemItems = $this->getFilesystemItems($request, $model);
 
         // Sort elements; relay to client-side logic if list should be randomized
-        if ($sortMode = SortMode::tryFrom($model->sortBy)) {
+        if ($model->sortBy && $sortMode = SortMode::tryFrom($model->sortBy)) {
             $filesystemItems = $filesystemItems->sort($sortMode);
         }
 

--- a/core-bundle/src/Controller/ContentElement/ImagesController.php
+++ b/core-bundle/src/Controller/ContentElement/ImagesController.php
@@ -51,7 +51,7 @@ class ImagesController extends AbstractContentElementController
         ;
 
         // Sort elements; relay to client-side logic if list should be randomized
-        if ($sortMode = SortMode::tryFrom($model->sortBy)) {
+        if ($model->sortBy && $sortMode = SortMode::tryFrom($model->sortBy)) {
             $filesystemItems = $filesystemItems->sort($sortMode);
         }
 
@@ -71,7 +71,7 @@ class ImagesController extends AbstractContentElementController
             ->createFigureBuilder()
             ->setSize($model->size)
             ->setLightboxGroupIdentifier('lb'.$model->id)
-            ->enableLightbox($model->fullsize)
+            ->enableLightbox((bool) $model->fullsize)
         ;
 
         if ('image' === $model->type) {


### PR DESCRIPTION
When creating a download(s) element in Twig, it currently fails on several "unnecessary" missing options. With these default options, I can simply render this:

```
{{ content_element('downloads', {
     multiSRC: my_variable
}) }}
```