### PR TITLE
Autolink URLs in comments and make them plain text

### DIFF
--- a/comments-bundle/config/services.yaml
+++ b/comments-bundle/config/services.yaml
@@ -13,6 +13,12 @@ services:
         arguments:
             - '%kernel.bundles%'
 
+    contao_comments.migration.decode_html_comments:
+        class: Contao\CommentsBundle\Migration\DecodeHtmlCommentsMigration
+        arguments:
+            - '@database_connection'
+            - '@contao.string.html_decoder'
+
     contao_comments.security.calendar_comments_voter:
         class: Contao\CommentsBundle\Security\Voter\CalendarCommentsVoter
         arguments:

--- a/comments-bundle/contao/classes/Comments.php
+++ b/comments-bundle/contao/classes/Comments.php
@@ -301,13 +301,10 @@ class Comments extends Frontend
 			}
 
 			// Do not parse any tags in the comment
-			$strComment = StringUtil::specialchars(trim($arrWidgets['comment']->value));
+			$strComment = trim($arrWidgets['comment']->value);
 
 			// Remove multiple line feeds
 			$strComment = preg_replace('@\n\n+@', "\n\n", $strComment);
-
-			// Prevent cross-site request forgeries
-			$strComment = preg_replace('/(href|src|on[a-z]+)="[^"]*(contao\/main\.php|typolight\/main\.php|javascript|vbscri?pt|script|alert|document|cookie|window)[^"]*"+/i', '$1="#"', $strComment);
 
 			$intMember = 0;
 
@@ -328,7 +325,7 @@ class Comments extends Frontend
 				'email'     => $arrWidgets['email']->value,
 				'website'   => $strWebsite,
 				'member'    => $intMember,
-				'comment'   => $this->convertLineFeeds($strComment),
+				'comment'   => $strComment,
 				'ip'        => Environment::get('ip'),
 				'date'      => $time,
 				'published' => ($objConfig->moderate ? '' : 1)
@@ -358,10 +355,6 @@ class Comments extends Frontend
 			$objEmail->from = $GLOBALS['TL_ADMIN_EMAIL'] ?? null;
 			$objEmail->fromName = $GLOBALS['TL_ADMIN_NAME'] ?? null;
 			$objEmail->subject = \sprintf($GLOBALS['TL_LANG']['MSC']['com_subject'], Idna::decode(Environment::get('host')));
-
-			// Convert the comment to plain text
-			$strComment = strip_tags($strComment);
-			$strComment = StringUtil::decodeEntities($strComment);
 
 			// Add the comment details
 			$objEmail->text = \sprintf(
@@ -400,34 +393,6 @@ class Comments extends Frontend
 
 			$this->reload();
 		}
-	}
-
-	/**
-	 * Convert line feeds to <br /> tags
-	 *
-	 * @param string $strComment
-	 *
-	 * @return string
-	 */
-	public function convertLineFeeds($strComment)
-	{
-		$strComment = preg_replace('/\r?\n/', '<br>', $strComment);
-
-		// Use paragraphs to generate new lines
-		if (strncmp('<p>', $strComment, 3) !== 0)
-		{
-			$strComment = '<p>' . $strComment . '</p>';
-		}
-
-		$arrReplace = array
-		(
-			'@<br>\s?<br>\s?@' => "</p>\n<p>", // Convert two linebreaks into a new paragraph
-			'@\s?<br></p>@'    => '</p>',      // Remove BR tags before closing P tags
-			'@<p><div@'        => '<div',      // Do not nest DIVs inside paragraphs
-			'@</div></p>@'     => '</div>'     // Do not nest DIVs inside paragraphs
-		);
-
-		return preg_replace(array_keys($arrReplace), array_values($arrReplace), $strComment);
 	}
 
 	/**

--- a/comments-bundle/contao/dca/tl_comments.php
+++ b/comments-bundle/contao/dca/tl_comments.php
@@ -153,7 +153,7 @@ $GLOBALS['TL_DCA']['tl_comments'] = array
 		(
 			'search'                  => true,
 			'inputType'               => 'textarea',
-			'eval'                    => array('mandatory'=>true, 'rte'=>'tinyMCE'),
+			'eval'                    => array('mandatory'=>true),
 			'sql'                     => array('type'=>'text', 'length'=>AbstractMySQLPlatform::LENGTH_LIMIT_TEXT, 'notnull'=>false)
 		),
 		'addReply' => array
@@ -289,7 +289,7 @@ class tl_comments extends Backend
 
 				if ($objParent->numRows)
 				{
-					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'article', 'table'=>'tl_content', 'id'=>$objParent->id))) . '"' . $onClick . '>' . $objParent->title . '</a>';
+					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'article', 'table'=>'tl_content', 'id'=>$objParent->id))) . '"' . $onClick . '>' . StringUtil::specialchars($objParent->title) . '</a>';
 				}
 				break;
 
@@ -300,7 +300,7 @@ class tl_comments extends Backend
 
 				if ($objParent->numRows)
 				{
-					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'page', 'act'=>'edit', 'id'=>$objParent->id))) . '"' . $onClick . '>' . $objParent->title . '</a>';
+					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'page', 'act'=>'edit', 'id'=>$objParent->id))) . '"' . $onClick . '>' . StringUtil::specialchars($objParent->title) . '</a>';
 				}
 				break;
 
@@ -311,7 +311,7 @@ class tl_comments extends Backend
 
 				if ($objParent->numRows)
 				{
-					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'news', 'table'=>'tl_news', 'act'=>'edit', 'id'=>$objParent->id))) . '"' . $onClick . '>' . $objParent->headline . '</a>';
+					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'news', 'table'=>'tl_news', 'act'=>'edit', 'id'=>$objParent->id))) . '"' . $onClick . '>' . StringUtil::specialchars($objParent->headline) . '</a>';
 				}
 				break;
 
@@ -322,7 +322,7 @@ class tl_comments extends Backend
 
 				if ($objParent->numRows)
 				{
-					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'faq', 'table'=>'tl_faq', 'act'=>'edit', 'id'=>$objParent->id))) . '"' . $onClick . '>' . $objParent->question . '</a>';
+					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'faq', 'table'=>'tl_faq', 'act'=>'edit', 'id'=>$objParent->id))) . '"' . $onClick . '>' . StringUtil::specialchars($objParent->question) . '</a>';
 				}
 				break;
 
@@ -333,7 +333,7 @@ class tl_comments extends Backend
 
 				if ($objParent->numRows)
 				{
-					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'calendar', 'table'=>'tl_calendar_events', 'act'=>'edit', 'id'=>$objParent->id))) . '"' . $onClick . '>' . $objParent->title . '</a>';
+					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'calendar', 'table'=>'tl_calendar_events', 'act'=>'edit', 'id'=>$objParent->id))) . '"' . $onClick . '>' . StringUtil::specialchars($objParent->title) . '</a>';
 				}
 				break;
 
@@ -358,7 +358,7 @@ class tl_comments extends Backend
 		return RecordLabel::fromHtml('
 <div class="cte_type ' . $key . '"><a href="mailto:' . StringUtil::specialchars(Idna::decodeEmail($arrRow['email'])) . '" title="' . StringUtil::specialchars(Idna::decodeEmail($arrRow['email'])) . '">' . StringUtil::specialchars($arrRow['name']) . '</a>' . ($arrRow['website'] ? ' (<a href="' . StringUtil::specialchars($arrRow['website']) . '" title="' . StringUtil::specialchars($arrRow['website']) . '" target="_blank" rel="noreferrer noopener">' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['com_website']) . '</a>)' : '') . ' – ' . StringUtil::specialchars(Date::parse(Config::get('datimFormat'), $arrRow['date'])) . ' – IP ' . StringUtil::specialchars($arrRow['ip']) . '<br>' . $title . '</div>
 <div class="cte_preview">
-' . $arrRow['comment'] . '
+' . nl2br(StringUtil::specialchars($arrRow['comment'])) . '
 </div>' . "\n    ");
 	}
 

--- a/comments-bundle/contao/templates/com_default.html.twig
+++ b/comments-bundle/contao/templates/com_default.html.twig
@@ -2,7 +2,7 @@
     <p class="info">{{ by }} {% if website %}<a href="{{ website }}" target="_blank" rel="nofollow noreferrer noopener">{{ name }}</a>{% else %}{{ name }}{% endif %} | <time datetime="{{ datetime }}" class="date">{{ date }}</time></p>
 
     <div class="comment">
-        {{ comment|sanitize_html }}
+        {{ comment|autolink_url|nl2br }}
     </div>
 
     {% if addReply %}

--- a/comments-bundle/src/Migration/DecodeHtmlCommentsMigration.php
+++ b/comments-bundle/src/Migration/DecodeHtmlCommentsMigration.php
@@ -37,7 +37,7 @@ class DecodeHtmlCommentsMigration extends AbstractMigration
             return false;
         }
 
-        $count = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM tl_comments WHERE comment != \'\'');
+        $count = (int) $this->connection->fetchOne("SELECT COUNT(*) FROM tl_comments WHERE comment != ''");
 
         return $count > 0;
     }
@@ -45,7 +45,7 @@ class DecodeHtmlCommentsMigration extends AbstractMigration
     public function run(): MigrationResult
     {
         $ids = [];
-        $comments = $this->connection->fetchAllKeyValue('SELECT id, comment FROM tl_comments WHERE comment != \'\'');
+        $comments = $this->connection->fetchAllKeyValue("SELECT id, comment FROM tl_comments WHERE comment != ''");
 
         foreach ($comments as $id => $comment) {
             $commentDecoded = $this->htmlDecoder->htmlToPlainText($comment, true);

--- a/comments-bundle/src/Migration/DecodeHtmlCommentsMigration.php
+++ b/comments-bundle/src/Migration/DecodeHtmlCommentsMigration.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CommentsBundle\Migration;
+
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Contao\CoreBundle\String\HtmlDecoder;
+use Doctrine\DBAL\Connection;
+
+class DecodeHtmlCommentsMigration extends AbstractMigration
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly HtmlDecoder $htmlDecoder,
+    ) {
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        if (
+            !$schemaManager->tablesExist(['tl_module', 'tl_comments'])
+            || !\array_key_exists('com_bbcode', $schemaManager->listTableColumns('tl_module'))
+            || !\array_key_exists('comment', $schemaManager->listTableColumns('tl_comments'))
+        ) {
+            return false;
+        }
+
+        $count = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM tl_comments WHERE comment != \'\'');
+
+        return $count > 0;
+    }
+
+    public function run(): MigrationResult
+    {
+        $ids = [];
+        $comments = $this->connection->fetchAllKeyValue('SELECT id, comment FROM tl_comments WHERE comment != \'\'');
+
+        foreach ($comments as $id => $comment) {
+            $commentDecoded = $this->htmlDecoder->htmlToPlainText($comment, true);
+
+            if ($comment === $commentDecoded) {
+                continue;
+            }
+
+            $ids[] = $id;
+
+            $this->connection->update('tl_comments', ['comment' => $commentDecoded], ['id' => (int) $id]);
+        }
+
+        $this->connection->executeStatement('ALTER TABLE tl_module DROP COLUMN com_bbcode');
+
+        return $this->createResult(true, "{$this->getName()} executed successfully: ".implode(', ', $ids));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -176,6 +176,7 @@
         "twig/string-extra": "^3.0",
         "twig/twig": "^3.21",
         "ua-parser/uap-php": "^3.9",
+        "vstelmakh/url-highlight": "^3.2",
         "web-auth/webauthn-lib": "^5.0",
         "web-auth/webauthn-symfony-bundle": "^5.0",
         "webignition/robots-txt-file": "^3.0",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -159,6 +159,7 @@
         "twig/string-extra": "^3.0",
         "twig/twig": "^3.21",
         "ua-parser/uap-php": "^3.9",
+        "vstelmakh/url-highlight": "^3.2",
         "web-auth/webauthn-lib": "^5.0",
         "web-auth/webauthn-symfony-bundle": "^5.0",
         "webignition/robots-txt-file": "^3.0",

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1405,6 +1405,11 @@ services:
             - '@contao.framework'
             - '@contao.resource_finder'
 
+    contao.twig.autolink_runtime:
+        class: Contao\CoreBundle\Twig\Runtime\AutolinkRuntime
+        arguments:
+            - '@contao.url_highlight'
+
     contao.twig.backend_helper_runtime:
         class: Contao\CoreBundle\Twig\Runtime\BackendHelperRuntime
         arguments:
@@ -1579,6 +1584,19 @@ services:
         class: Contao\CoreBundle\Twig\Runtime\UrlRuntime
         arguments:
             - '@request_stack'
+
+    contao.url_highlight:
+        class: VStelmakh\UrlHighlight\UrlHighlight
+        arguments:
+            - ~
+            - '@contao.url_highlight.html_highlighter'
+            - !service { class: VStelmakh\UrlHighlight\Encoder\HtmlSpecialcharsEncoder }
+
+    contao.url_highlight.html_highlighter:
+        class: VStelmakh\UrlHighlight\Highlighter\HtmlHighlighter
+        arguments:
+            - 'https'
+            - { target: _blank, rel: noreferrer noopener }
 
     contao.webauthn.user_entity_guesser:
         class: Webauthn\Bundle\Security\Guesser\CurrentUserEntityGuesser

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1595,7 +1595,7 @@ services:
     contao.url_highlight.html_highlighter:
         class: VStelmakh\UrlHighlight\Highlighter\HtmlHighlighter
         arguments:
-            - 'https'
+            - https
             - { target: _blank, rel: noreferrer noopener }
 
     contao.webauthn.user_entity_guesser:

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -25,6 +25,7 @@ use Contao\CoreBundle\Twig\Inspector\InspectorNodeVisitor;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
 use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
+use Contao\CoreBundle\Twig\Runtime\AutolinkRuntime;
 use Contao\CoreBundle\Twig\Runtime\BackendHelperRuntime;
 use Contao\CoreBundle\Twig\Runtime\ContentUrlRuntime;
 use Contao\CoreBundle\Twig\Runtime\CspRuntime;
@@ -306,6 +307,11 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
             new TwigFilter(
                 'deserialize',
                 static fn (mixed $value): array => StringUtil::deserialize($value, true),
+            ),
+            new TwigFilter(
+                'autolink_url',
+                [AutolinkRuntime::class, 'linkUrls'],
+                ['pre_escape' => 'html', 'is_safe' => ['html']],
             ),
         ];
     }

--- a/core-bundle/src/Twig/Runtime/AutolinkRuntime.php
+++ b/core-bundle/src/Twig/Runtime/AutolinkRuntime.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Runtime;
+
+use Twig\Extension\RuntimeExtensionInterface;
+use VStelmakh\UrlHighlight\UrlHighlight;
+
+final class AutolinkRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @internal
+     */
+    public function __construct(private readonly UrlHighlight $urlHighlight)
+    {
+    }
+
+    public function linkUrls(string $text): string
+    {
+        return $this->urlHighlight->highlightUrls($text);
+    }
+}

--- a/core-bundle/tests/Functional/ServiceArgumentsTest.php
+++ b/core-bundle/tests/Functional/ServiceArgumentsTest.php
@@ -103,6 +103,10 @@ class ServiceArgumentsTest extends FunctionalTestCase
                         $this->assertContains(\Closure::class, $typeNames, \sprintf('Argument %s of %s should be \Closure but found %s.', $i, $serviceId, implode('|', $typeNames)));
                         break;
 
+                    case 'service':
+                        $this->assertTrue(is_a($argument->getValue()['class'], implode('|', $typeNames), true), \sprintf('Argument %s of %s should be %s but found %s.', $i, $serviceId, implode('|', $typeNames), $argument->getValue()['class']));
+                        break;
+
                     case 'tagged_iterator':
                         if (\in_array('iterable', $typeNames, true)) {
                             $this->assertContains('iterable', $typeNames, \sprintf('Argument %s of %s should be an iterable but found %s.', $i, $serviceId, implode('|', $typeNames)));

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -147,6 +147,7 @@ class ContaoExtensionTest extends TestCase
             'input_encoded_to_plain_text',
             'html_to_plain_text',
             'deserialize',
+            'autolink_url',
         ];
 
         $this->assertCount(\count($expectedFilters), $filters);


### PR DESCRIPTION
See https://github.com/contao/contao/issues/9636#issuecomment-4926353243

Todo
- [x] Migration to convert HTML comments to plain text