### PR TITLE
Fix a foreign key issue in the `ValueFormatter`

### DIFF
--- a/core-bundle/src/DataContainer/ValueFormatter.php
+++ b/core-bundle/src/DataContainer/ValueFormatter.php
@@ -305,7 +305,12 @@ class ValueFormatter implements ResetInterface
             $this->framework->getAdapter(Controller::class)->loadDataContainer($ptable);
             $showField = $GLOBALS['TL_DCA'][$ptable]['list']['label']['fields'][0] ?? 'id';
 
-            $GLOBALS['TL_DCA'][$table]['fields'][$field]['foreignKey'] = $ptable.'.'.$showField;
+            // showField already has foreignKey format, no table needed
+            if (str_contains($showField, '.')) {
+                $GLOBALS['TL_DCA'][$table]['fields'][$field]['foreignKey'] = $showField;
+            } else {
+                $GLOBALS['TL_DCA'][$table]['fields'][$field]['foreignKey'] = $ptable.'.'.$showField;
+            }
         }
 
         if (isset($GLOBALS['TL_DCA'][$table]['fields'][$field]['foreignKey']) && \is_scalar($value)) {


### PR DESCRIPTION
The dynamic generation of the `foreignKey` definition for a `pid` field breaks if the first field defined in the parent table's `list.label.fields` configuration already contains a foreignKey format.

For example (edited):
in DCA,
```
$GLOBALS['TL_DCA']['tl_order_log'] = [
...
    'config' => [
    ...
    ,   'ptable'                    => 'tl_order'
...
```

```
$GLOBALS['TL_DCA']['tl_order'] = [
    'config' => [
    ...
    ,   'ctable'                    => ['tl_order_log']
    ...
,   'list' => [
   ...
    ,   'label' => [
            'fields'                => ['id:tl_order.LPAD(id,5,"0")', 'type', 'status']
        ,   'showColumns'           => true
        ]
...
```
In our real case it was a bit different, but this is the main problem.
Error occurred during `act=show` of `tl_order_log` (info popup).