### PR TITLE
Resolve insert tags in the accordion header

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/accordion.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/accordion.html.twig
@@ -16,7 +16,7 @@
                         .mergeWith(accordion_header_button_attributes|default)
                     %}
                     <button{{ accordion_header_button_attributes }}>
-                        {{- element.header -}}
+                        {{- element.header|insert_tag_raw -}}
                     </button>
                 </{{ element.header_tag }}>
             {% endblock %}


### PR DESCRIPTION
The accordion content element outputs the header via `{{- element.header -}}` without running it through the insert tag parser. As a result, any insert tags used in the header (e.g. `{{small::…}}`) are rendered verbatim instead of being replaced.

Use the `insert_tag_raw` filter on the header output so insert tags are resolved consistently, matching the behaviour of other template fields.

<img width="1139" height="371" alt="image" src="https://github.com/user-attachments/assets/28c3f055-1256-462d-bd22-bfe86955eca8" />
