### PR TITLE
Do not extend the `TestCase` class of the core bundle in other bundles

### DIFF
--- a/calendar-bundle/tests/EventListener/DataContainer/EventSearchListenerTest.php
+++ b/calendar-bundle/tests/EventListener/DataContainer/EventSearchListenerTest.php
@@ -15,13 +15,13 @@ namespace Contao\CalendarBundle\Tests\EventListener\DataContainer;
 use Contao\CalendarBundle\EventListener\DataContainer\EventSearchListener;
 use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
-use Contao\CoreBundle\Tests\TestCase;
 use Contao\DataContainer;
 use Contao\Search;
+use Contao\TestCase\ContaoTestCase;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class EventSearchListenerTest extends TestCase
+class EventSearchListenerTest extends ContaoTestCase
 {
     public function testPurgesTheSearchIndexOnAliasChange(): void
     {

--- a/calendar-bundle/tests/Security/Voter/CalendarContentVoterTest.php
+++ b/calendar-bundle/tests/Security/Voter/CalendarContentVoterTest.php
@@ -19,13 +19,13 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
-use Contao\CoreBundle\Tests\TestCase;
+use Contao\TestCase\ContaoTestCase;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CalendarContentVoterTest extends TestCase
+class CalendarContentVoterTest extends ContaoTestCase
 {
     public function testSupportsAttributesAndTypes(): void
     {

--- a/comments-bundle/tests/Util/BbCodeTest.php
+++ b/comments-bundle/tests/Util/BbCodeTest.php
@@ -10,11 +10,13 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-use Contao\CommentsBundle\Util\BbCode;
-use Contao\CoreBundle\Tests\TestCase;
-use Contao\System;
+namespace Contao\CommentsBundle\Tests\Util;
 
-class BbCodeTest extends TestCase
+use Contao\CommentsBundle\Util\BbCode;
+use Contao\System;
+use Contao\TestCase\ContaoTestCase;
+
+class BbCodeTest extends ContaoTestCase
 {
     protected function tearDown(): void
     {

--- a/comments-bundle/tests/Util/NodeTest.php
+++ b/comments-bundle/tests/Util/NodeTest.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
+namespace Contao\CommentsBundle\Tests\Util;
+
 use Contao\CommentsBundle\Util\Node;
 use PHPUnit\Framework\TestCase;
 

--- a/faq-bundle/tests/EventListener/DataContainer/FaqSearchListenerTest.php
+++ b/faq-bundle/tests/EventListener/DataContainer/FaqSearchListenerTest.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 namespace Contao\FaqBundle\Tests\EventListener\DataContainer;
 
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
-use Contao\CoreBundle\Tests\TestCase;
 use Contao\DataContainer;
 use Contao\FaqBundle\EventListener\DataContainer\FaqSearchListener;
 use Contao\FaqModel;
 use Contao\Search;
+use Contao\TestCase\ContaoTestCase;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class FaqSearchListenerTest extends TestCase
+class FaqSearchListenerTest extends ContaoTestCase
 {
     public function testPurgesTheSearchIndexOnAliasChange(): void
     {

--- a/news-bundle/tests/EventListener/DataContainer/NewsSearchListenerTest.php
+++ b/news-bundle/tests/EventListener/DataContainer/NewsSearchListenerTest.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 namespace Contao\NewsBundle\Tests\EventListener\DataContainer;
 
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
-use Contao\CoreBundle\Tests\TestCase;
 use Contao\DataContainer;
 use Contao\NewsBundle\EventListener\DataContainer\NewsSearchListener;
 use Contao\NewsModel;
 use Contao\Search;
+use Contao\TestCase\ContaoTestCase;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class NewsSearchListenerTest extends TestCase
+class NewsSearchListenerTest extends ContaoTestCase
 {
     public function testPurgesTheSearchIndexOnAliasChange(): void
     {

--- a/news-bundle/tests/Security/Voter/NewsContentVoterTest.php
+++ b/news-bundle/tests/Security/Voter/NewsContentVoterTest.php
@@ -17,15 +17,15 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
-use Contao\CoreBundle\Tests\TestCase;
 use Contao\NewsBundle\Security\ContaoNewsPermissions;
 use Contao\NewsBundle\Security\Voter\NewsContentVoter;
+use Contao\TestCase\ContaoTestCase;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class NewsContentVoterTest extends TestCase
+class NewsContentVoterTest extends ContaoTestCase
 {
     public function testSupportsAttributesAndTypes(): void
     {

--- a/newsletter-bundle/tests/EventListener/NewsletterRecipientsEditButtonsListenerTest.php
+++ b/newsletter-bundle/tests/EventListener/NewsletterRecipientsEditButtonsListenerTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace Contao\NewsletterBundle\Tests\EventListener;
 
-use Contao\CoreBundle\Tests\TestCase;
 use Contao\NewsletterBundle\EventListener\NewsletterRecipientsEditButtonsListener;
+use Contao\TestCase\ContaoTestCase;
 
-class NewsletterRecipientsEditButtonsListenerTest extends TestCase
+class NewsletterRecipientsEditButtonsListenerTest extends ContaoTestCase
 {
     /**
      * @dataProvider buttonProvider


### PR DESCRIPTION
Tests in the bundles should extend `Contao\TestCase\ContaoTestCase` instead of `Contao\CoreBundle\Tests\TestCase` as the namespace `Contao\CoreBundle\Tests` does not get loaded in the other bundles.