### PR TITLE
Fix `VideoObject` JSON-LD as per Google Schema Validator requirements

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/player.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/player.html.twig
@@ -33,6 +33,12 @@
 {# Add metadata #}
 {% block metadata %}
     {% for source_file in source_files %}
-        {% do add_schema_org(source_file.schemaOrgData|default) %}
+        {% set schemaOrgData = source_file.schemaOrgData|default({}) %}
+        {% if figure.media.attributes.poster|default %}
+            {% set schemaOrgData = schemaOrgData|merge({
+                'thumbnailUrl': figure.media.attributes.poster
+            }) %}
+        {% endif %}
+        {% do add_schema_org(schemaOrgData) %}
     {% endfor %}
 {% endblock %}

--- a/core-bundle/src/Filesystem/FilesystemItem.php
+++ b/core-bundle/src/Filesystem/FilesystemItem.php
@@ -251,6 +251,7 @@ class FilesystemItem implements \Stringable
             'identifier' => $fileIdentifier,
             'contentUrl' => $this->getPath(),
             'encodingFormat' => $this->getMimeType(''),
+            'uploadDate' => 'VideoObject' === $type && $this->getLastModified() ? date('c', $this->getLastModified()) : null,
         ]);
 
         if ($this->getMetaData()) {

--- a/core-bundle/tests/Filesystem/FilesystemItemTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemTest.php
@@ -341,6 +341,7 @@ class FilesystemItemTest extends TestCase
                 'encodingFormat' => 'video/mp4',
                 'identifier' => '#/schema/file/2fcae369-c955-4b43-bcf9-d069f9d25542',
                 'name' => 'My title!',
+                'uploadDate' => '1970-01-02T10:17:30+00:00',
             ],
         ];
 


### PR DESCRIPTION
This PR adds the, as per the Google Schema Validator required, `thumbnailUrl` and `uploadDate` attributes for the VideoObject JSON-LD.
Currently the `thumbnailUrl` will still be missing if no poster is set in the content element, but IMO with this change it's way better than nothing.

Also I have not added the `description` attribute right now, as we would probably need a separate field for that. The `caption` which I initially thought could just be used is already output as the `caption` attribute in the JSON-LD, so using that doesn't really make sense IMO.

Closes #9934 