### PR TITLE
Reset `IpUtils` after teardown in the unit tests

### DIFF
--- a/core-bundle/tests/HttpClient/NoPrivateNetworkExceptRootPagesHttpClientTest.php
+++ b/core-bundle/tests/HttpClient/NoPrivateNetworkExceptRootPagesHttpClientTest.php
@@ -22,12 +22,15 @@ use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class NoPrivateNetworkExceptRootPagesHttpClientTest extends TestCase
 {
     protected function tearDown(): void
     {
+        $this->resetStaticProperties([IpUtils::class]);
+
         parent::tearDown();
     }
 


### PR DESCRIPTION
### Description

This should fix the failing reverse order test as seen in https://github.com/contao/contao/actions/runs/29276649933/job/86907308914?pr=10014

Basically doing the same as done here https://github.com/contao/contao/pull/4618, unsure if it's the right fix. 
