### PR TITLE
Replace the remaining `Input` usages

### DIFF
--- a/core-bundle/src/Controller/Backend/AbstractBackendController.php
+++ b/core-bundle/src/Controller/Backend/AbstractBackendController.php
@@ -56,8 +56,8 @@ abstract class AbstractBackendController extends AbstractController
                     $this->Template->version = $GLOBALS['TL_LANG']['MSC']['version'].' '.ContaoCoreBundle::getVersion();
 
                     // Handle Ajax request
-                    if (Input::post('action') && Environment::get('isAjaxRequest')) {
-                        $this->objAjax = new Ajax(Input::post('action'));
+                    if (Input::post('action') && Environment::get('isAjaxRequest')) { // FIXME: Input
+                        $this->objAjax = new Ajax(Input::post('action')); // FIXME: Input
                         $this->objAjax->executePreActions();
                     }
 

--- a/core-bundle/src/DataContainer/ButtonsBuilder.php
+++ b/core-bundle/src/DataContainer/ButtonsBuilder.php
@@ -36,10 +36,10 @@ class ButtonsBuilder
         $arrButtons = [];
         $arrButtons['save'] = '<button type="submit" name="save" id="save" class="tl_submit" accesskey="s" data-action="contao--scroll-offset#discard">'.$GLOBALS['TL_LANG']['MSC']['save'].'</button>';
 
-        if (!Input::get('nb')) {
+        if (!Input::get('nb')) { // FIXME: Input
             $arrButtons['saveNclose'] = '<button type="submit" name="saveNclose" id="saveNclose" class="tl_submit" accesskey="c" data-action="contao--scroll-offset#discard">'.$GLOBALS['TL_LANG']['MSC']['saveNclose'].'</button>';
 
-            if (!Input::get('nc')) {
+            if (!Input::get('nc')) { // FIXME: Input
                 if (!($GLOBALS['TL_DCA'][$strTable]['config']['closed'] ?? null) && !($GLOBALS['TL_DCA'][$strTable]['config']['notCreatable'] ?? null) && $hasCreatePermission) {
                     $arrButtons['saveNcreate'] = '<button type="submit" name="saveNcreate" id="saveNcreate" class="tl_submit" accesskey="n" data-action="contao--scroll-offset#discard">'.$GLOBALS['TL_LANG']['MSC']['saveNcreate'].'</button>';
                 }

--- a/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
+++ b/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php
@@ -302,7 +302,7 @@ class DataContainerOperationsBuilder extends AbstractDataContainerOperationsBuil
         }
 
         if (isset($config['href'])) {
-            return $this->framework->getAdapter(Backend::class)->addToUrl($config['href'].'&id='.$record['id'].(Input::get('nb') ? '&nc=1' : ''), addRequestToken: !($config['prefetch'] ?? false) && null === ($config['method'] ?? null));
+            return $this->framework->getAdapter(Backend::class)->addToUrl($config['href'].'&id='.$record['id'].(Input::get('nb') ? '&nc=1' : ''), addRequestToken: !($config['prefetch'] ?? false) && null === ($config['method'] ?? null)); // FIXME: Input
         }
 
         return null;

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -288,7 +288,7 @@ class StringUtilTest extends TestCase
         System::getContainer()->set('request_stack', $stack = new RequestStack());
         $stack->push(new Request(['value' => $source]));
 
-        $inputEncoded = Input::get('value');
+        $inputEncoded = Input::get('value'); // FIXME: Input
 
         // Test input encoding round trip
         $this->assertSame($expected ?? $source, StringUtil::revertInputEncoding($inputEncoded));

--- a/core-bundle/tests/String/HtmlDecoderTest.php
+++ b/core-bundle/tests/String/HtmlDecoderTest.php
@@ -74,7 +74,7 @@ class HtmlDecoderTest extends TestCase
         System::getContainer()->set('request_stack', $stack = new RequestStack());
         $stack->push(new Request(['value' => $expected]));
 
-        $inputEncoded = Input::get('value');
+        $inputEncoded = Input::get('value'); // FIXME: Input
 
         // Test input encoding round trip
         $this->assertSame($expected, $htmlDecoder->inputEncodedToPlainText($inputEncoded, true));
@@ -113,7 +113,7 @@ class HtmlDecoderTest extends TestCase
         System::getContainer()->set('request_stack', $stack = new RequestStack());
         $stack->push(new Request([], ['value' => str_replace(['&#123;&#123;', '&#125;&#125;'], ['[{]', '[}]'], $source)]));
 
-        $inputXssStripped = str_replace(['&#123;&#123;', '&#125;&#125;'], ['{{', '}}'], Input::postHtml('value', true));
+        $inputXssStripped = str_replace(['&#123;&#123;', '&#125;&#125;'], ['{{', '}}'], Input::postHtml('value', true)); // FIXME: Input
 
         $this->assertSame($expected, $htmlDecoder->htmlToPlainText($inputXssStripped, $removeInsertTags));
     }


### PR DESCRIPTION
@ausi This is certainly not a priority, but there are a few remaining usages of the `Input` class in the new code. Do you want me to replace them or do you want to do it yourself?