### PR TITLE
Reset `IpUtils` after teardown in the unit tests

### DIFF
--- a/core-bundle/tests/HttpClient/NoPrivateNetworkExceptRootPagesHttpClientTest.php
+++ b/core-bundle/tests/HttpClient/NoPrivateNetworkExceptRootPagesHttpClientTest.php
@@ -21,12 +21,15 @@ use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class NoPrivateNetworkExceptRootPagesHttpClientTest extends TestCase
 {
     protected function tearDown(): void
     {
+        $this->resetStaticProperties([IpUtils::class]);
+
         parent::tearDown();
     }
 


### PR DESCRIPTION
### Description

See https://github.com/contao/contao/actions/runs/29641225455/job/88071991156?pr=9931

Same as #10015 but for 5.3 - thus no need for an upstream.