### PR TITLE
Deprecate the obsolete `HtmlDecoder::inputEncodedToPlainText()` method

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -36,3 +36,8 @@ $locale = System::getContainer()->get('request_stack')->getCurrentRequest()->get
 ## Twig filter insert_tag_raw
 
 The Twig filter `|insert_tag_raw` will no longer work in Contao 7. Use `|insert_tag_html` instead.
+
+## Twig filter input_encoded_to_plain_text
+
+The Twig filter `|input_encoded_to_plain_text` and the corresponding `inputEncodedToPlainText()` methods of the
+`StringRuntime` and `HtmlDecoder` classes will no longer work in Contao 7.

--- a/calendar-bundle/contao/classes/Events.php
+++ b/calendar-bundle/contao/classes/Events.php
@@ -93,13 +93,12 @@ abstract class Events extends Module
 	 */
 	public static function getSchemaOrgData(CalendarEventsModel $objEvent): array
 	{
-		$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
 		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
 
 		$jsonLd = array(
 			'@type' => 'Event',
 			'identifier' => '#/schema/events/' . $objEvent->id,
-			'name' => $htmlDecoder->inputEncodedToPlainText($objEvent->title),
+			'name' => $objEvent->title,
 			'startDate' => $objEvent->addTime ? date('Y-m-d\TH:i:sP', $objEvent->startTime) : date('Y-m-d', $objEvent->startTime)
 		);
 
@@ -126,14 +125,14 @@ abstract class Events extends Module
 		{
 			$jsonLd['location'] = array(
 				'@type' => 'Place',
-				'name' => $htmlDecoder->inputEncodedToPlainText($objEvent->location)
+				'name' => $objEvent->location
 			);
 
 			if ($objEvent->address)
 			{
 				$jsonLd['location']['address'] = array(
 					'@type' => 'PostalAddress',
-					'description' => $htmlDecoder->inputEncodedToPlainText($objEvent->address)
+					'description' => $objEvent->address
 				);
 			}
 		}

--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -114,7 +114,6 @@ class ModuleEventReader extends Events
 		if ($responseContext?->has(HtmlHeadBag::class))
 		{
 			$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
-			$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
 
 			if ($objEvent->pageTitle)
 			{
@@ -122,15 +121,16 @@ class ModuleEventReader extends Events
 			}
 			elseif ($objEvent->title)
 			{
-				$htmlHeadBag->setTitle($htmlDecoder->inputEncodedToPlainText($objEvent->title));
+				$htmlHeadBag->setTitle($objEvent->title);
 			}
 
 			if ($objEvent->description)
 			{
-				$htmlHeadBag->setMetaDescription($htmlDecoder->inputEncodedToPlainText($objEvent->description));
+				$htmlHeadBag->setMetaDescription($objEvent->description);
 			}
 			elseif ($objEvent->teaser)
 			{
+				$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
 				$htmlHeadBag->setMetaDescription($htmlDecoder->htmlToPlainText($objEvent->teaser));
 			}
 

--- a/core-bundle/contao/modules/ModuleArticle.php
+++ b/core-bundle/contao/modules/ModuleArticle.php
@@ -167,13 +167,12 @@ class ModuleArticle extends Module
 
 			if ($responseContext?->has(HtmlHeadBag::class))
 			{
-				$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
-
 				$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
-				$htmlHeadBag->setTitle($htmlDecoder->inputEncodedToPlainText($this->title));
+				$htmlHeadBag->setTitle($this->title);
 
 				if ($this->teaser)
 				{
+					$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
 					$htmlHeadBag->setMetaDescription($htmlDecoder->htmlToPlainText($this->teaser));
 				}
 			}

--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -88,7 +88,7 @@ class ModuleBreadcrumb extends Module
 				'isRoot'   => true,
 				'isActive' => false,
 				'href'     => (($objFirstPage !== null) ? $this->generateContentUrl($objFirstPage) : $request?->getBasePath()),
-				'title'    => StringUtil::specialchars($objPages->pageTitle ?: $objPages->title, true),
+				'title'    => StringUtil::stripInsertTags($objPages->pageTitle ?: $objPages->title),
 				'link'     => $objPages->title,
 				'data'     => (($objFirstPage !== null) ? $objFirstPage->row() : array()),
 			);
@@ -146,7 +146,7 @@ class ModuleBreadcrumb extends Module
 					'isRoot'   => false,
 					'isActive' => false,
 					'href'     => $href,
-					'title'    => StringUtil::specialchars($pages[$i]->pageTitle ?: $pages[$i]->title, true),
+					'title'    => StringUtil::stripInsertTags($pages[$i]->pageTitle ?: $pages[$i]->title),
 					'link'     => $pages[$i]->title,
 					'data'     => $pages[$i]->row(),
 				);
@@ -161,7 +161,7 @@ class ModuleBreadcrumb extends Module
 				'isRoot'   => false,
 				'isActive' => false,
 				'href'     => $this->generateContentUrl($pages[0]),
-				'title'    => StringUtil::specialchars($pages[0]->pageTitle ?: $pages[0]->title, true),
+				'title'    => StringUtil::stripInsertTags($pages[0]->pageTitle ?: $pages[0]->title),
 				'link'     => $pages[0]->title,
 				'data'     => $pages[0]->row(),
 			);
@@ -175,7 +175,7 @@ class ModuleBreadcrumb extends Module
 					'isRoot'   => false,
 					'isActive' => true,
 					'href'     => $this->generateContentUrl($objArticle),
-					'title'    => StringUtil::specialchars($objArticle->title, true),
+					'title'    => StringUtil::stripInsertTags($objArticle->title),
 					'link'     => $objArticle->title,
 					'data'     => $objArticle->row(),
 				);
@@ -191,7 +191,7 @@ class ModuleBreadcrumb extends Module
 				'isActive' => true,
 				// Use the current request without query string for the current page (see #3450)
 				'href'     => $request?->getBaseUrl() . $request?->getPathInfo(),
-				'title'    => StringUtil::specialchars($pages[0]->pageTitle ?: $pages[0]->title),
+				'title'    => $pages[0]->pageTitle ?: $pages[0]->title,
 				'link'     => $pages[0]->title,
 				'data'     => $pages[0]->row(),
 			);
@@ -213,7 +213,6 @@ class ModuleBreadcrumb extends Module
 			);
 
 			$position = 0;
-			$htmlDecoder = $container->get('contao.string.html_decoder');
 			$insertTagParser = $container->get('contao.insert_tag.parser');
 
 			foreach ($items as $item)
@@ -229,7 +228,7 @@ class ModuleBreadcrumb extends Module
 					'position' => ++$position,
 					'item' => array(
 						'@id' => $insertTagParser->replaceInline($item['href']),
-						'name' => $insertTagParser->replaceInline($htmlDecoder->inputEncodedToPlainText($item['link']))
+						'name' => $insertTagParser->replaceInline($item['link'])
 					)
 				);
 			}

--- a/core-bundle/src/String/HtmlDecoder.php
+++ b/core-bundle/src/String/HtmlDecoder.php
@@ -30,19 +30,20 @@ class HtmlDecoder
      * @see StringUtil::revertInputEncoding()
      *
      * @param bool $removeInsertTags True to remove insert tags instead of replacing them, null to neither remove or replace them
+     *
+     * @deprecated Deprecated since Contao 6.0, to be removed in Contao 7.
      */
     public function inputEncodedToPlainText(string $val, bool|null $removeInsertTags = false): string
     {
+        trigger_deprecation('contao/core-bundle', '6.0', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
+
         if ($removeInsertTags) {
             $val = StringUtil::stripInsertTags($val);
         } elseif (false === $removeInsertTags) {
             $val = $this->insertTagParser->replaceInline($val);
         }
 
-        $val = strip_tags($val);
-        $val = StringUtil::revertInputEncoding($val);
-
-        return str_replace(['{{', '}}'], ['[{]', '[}]'], $val);
+        return $this->stripTagsDecodeEntities($val);
     }
 
     /**
@@ -77,7 +78,7 @@ class HtmlDecoder
             $val,
         );
 
-        $val = $this->inputEncodedToPlainText($val, null);
+        $val = $this->stripTagsDecodeEntities($val);
 
         // Remove duplicate line breaks and spaces
         $val = preg_replace(['/[^\S\n]+/', '/\s*\n\s*/'], [' ', "\n"], $val);
@@ -87,5 +88,13 @@ class HtmlDecoder
         }
 
         return $val;
+    }
+
+    private function stripTagsDecodeEntities(string $val): string
+    {
+        $val = strip_tags($val);
+        $val = StringUtil::revertInputEncoding($val);
+
+        return str_replace(['{{', '}}'], ['[{]', '[}]'], $val);
     }
 }

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -275,6 +275,9 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
             new TwigFilter(
                 'input_encoded_to_plain_text',
                 [StringRuntime::class, 'inputEncodedToPlainText'],
+                [
+                    'deprecation_info' => new DeprecatedCallableInfo('contao/core-bundle', '6.0'), // Backwards compatibility
+                ],
             ),
             new TwigFilter(
                 'html_to_plain_text',

--- a/core-bundle/src/Twig/Runtime/StringRuntime.php
+++ b/core-bundle/src/Twig/Runtime/StringRuntime.php
@@ -35,6 +35,9 @@ final class StringRuntime implements RuntimeExtensionInterface
         return $this->framework->getAdapter(StringUtil::class)->encodeEmail($html);
     }
 
+    /**
+     * @deprecated Deprecated since Contao 6.0, to be removed in Contao 7.
+     */
     public function inputEncodedToPlainText(string $value, bool $removeInsertTags = false): string
     {
         return $this->htmlDecoder->inputEncodedToPlainText($value, $removeInsertTags);

--- a/faq-bundle/contao/modules/ModuleFaq.php
+++ b/faq-bundle/contao/modules/ModuleFaq.php
@@ -42,7 +42,7 @@ class ModuleFaq extends Frontend
 		{
 			$jsonLd['mainEntity'][] = array(
 				'@type' => 'Question',
-				'name' => $htmlDecoder->inputEncodedToPlainText($objFaq->question),
+				'name' => $objFaq->question,
 				'acceptedAnswer' => array(
 					'@type' => 'Answer',
 					'text' => $htmlDecoder->htmlToPlainText(StringUtil::encodeEmail($objFaq->answer))

--- a/faq-bundle/contao/modules/ModuleFaqReader.php
+++ b/faq-bundle/contao/modules/ModuleFaqReader.php
@@ -96,7 +96,6 @@ class ModuleFaqReader extends Module
 		if ($responseContext?->has(HtmlHeadBag::class))
 		{
 			$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
-			$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
 
 			if ($objFaq->pageTitle)
 			{
@@ -104,16 +103,16 @@ class ModuleFaqReader extends Module
 			}
 			elseif ($objFaq->question)
 			{
-				$htmlHeadBag->setTitle($htmlDecoder->inputEncodedToPlainText($objFaq->question));
+				$htmlHeadBag->setTitle($objFaq->question);
 			}
 
 			if ($objFaq->description)
 			{
-				$htmlHeadBag->setMetaDescription($htmlDecoder->inputEncodedToPlainText($objFaq->description));
+				$htmlHeadBag->setMetaDescription($objFaq->description);
 			}
 			elseif ($objFaq->question)
 			{
-				$htmlHeadBag->setMetaDescription($htmlDecoder->inputEncodedToPlainText($objFaq->question));
+				$htmlHeadBag->setMetaDescription($objFaq->question);
 			}
 
 			if ($objFaq->robots)

--- a/news-bundle/contao/classes/News.php
+++ b/news-bundle/contao/classes/News.php
@@ -26,14 +26,13 @@ class News extends Frontend
 	 */
 	public static function getSchemaOrgData(NewsModel $objArticle): array
 	{
-		$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
 		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
 		$newsArchive = NewsArchiveModel::findById($objArticle->pid);
 
 		$jsonLd = array(
 			'@type' => $newsArchive?->jsonLdType ?: 'NewsArticle',
 			'identifier' => '#/schema/news/' . $objArticle->id,
-			'headline' => $htmlDecoder->inputEncodedToPlainText($objArticle->headline),
+			'headline' => $objArticle->headline,
 			'datePublished' => date('Y-m-d\TH:i:sP', $objArticle->date),
 		);
 
@@ -48,6 +47,7 @@ class News extends Frontend
 
 		if ($objArticle->teaser)
 		{
+			$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
 			$jsonLd['description'] = $htmlDecoder->htmlToPlainText($objArticle->teaser);
 		}
 

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -119,7 +119,6 @@ class ModuleNewsReader extends ModuleNews
 		if ($responseContext?->has(HtmlHeadBag::class))
 		{
 			$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
-			$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
 
 			if ($objArticle->pageTitle)
 			{
@@ -127,15 +126,16 @@ class ModuleNewsReader extends ModuleNews
 			}
 			elseif ($objArticle->headline)
 			{
-				$htmlHeadBag->setTitle($htmlDecoder->inputEncodedToPlainText($objArticle->headline));
+				$htmlHeadBag->setTitle($objArticle->headline);
 			}
 
 			if ($objArticle->description)
 			{
-				$htmlHeadBag->setMetaDescription($htmlDecoder->inputEncodedToPlainText($objArticle->description));
+				$htmlHeadBag->setMetaDescription($objArticle->description);
 			}
 			elseif ($objArticle->teaser)
 			{
+				$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
 				$htmlHeadBag->setMetaDescription($htmlDecoder->htmlToPlainText($objArticle->teaser));
 			}
 

--- a/newsletter-bundle/contao/modules/ModuleNewsletterReader.php
+++ b/newsletter-bundle/contao/modules/ModuleNewsletterReader.php
@@ -92,10 +92,8 @@ class ModuleNewsletterReader extends Module
 
 			if ($responseContext?->has(HtmlHeadBag::class))
 			{
-				$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
-
 				$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
-				$htmlHeadBag->setTitle($htmlDecoder->inputEncodedToPlainText($objNewsletter->subject));
+				$htmlHeadBag->setTitle($objNewsletter->subject);
 			}
 		}
 


### PR DESCRIPTION
`HtmlDecoder::inputEncodedToPlainText()` is no longer needed as we do not have input encoded data anymore 😎

But we need to keep `HtmlDecoder::htmlToPlainText()` as it is still relevant to get e.g. a plain text description out of a teaser field containing HTML from a rich text editor.