### PR TITLE
Use a Twig template for the `{{news::*}}`, `{{event::*}}` and `{{faq::*}}` insert tag

### DIFF
--- a/calendar-bundle/config/services.yaml
+++ b/calendar-bundle/config/services.yaml
@@ -39,6 +39,8 @@ services:
         arguments:
             - '@contao.framework'
             - '@contao.routing.content_url_generator'
+            - '@twig'
+            - '@contao.html_sanitizer'
 
     contao_calendar.listener.add_feeds_from_layout:
         class: Contao\CalendarBundle\EventListener\AddFeedsFromLayoutListener

--- a/calendar-bundle/src/InsertTag/EventInsertTag.php
+++ b/calendar-bundle/src/InsertTag/EventInsertTag.php
@@ -21,8 +21,11 @@ use Contao\CoreBundle\InsertTag\OutputType;
 use Contao\CoreBundle\InsertTag\ResolvedInsertTag;
 use Contao\CoreBundle\InsertTag\Resolver\InsertTagResolverNestedResolvedInterface;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
+use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\StringUtil;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
 
 /**
  * @internal
@@ -37,6 +40,8 @@ class EventInsertTag implements InsertTagResolverNestedResolvedInterface
     public function __construct(
         private readonly ContaoFramework $framework,
         private readonly ContentUrlGenerator $urlGenerator,
+        private readonly Environment $twig,
+        private readonly HtmlSanitizerInterface $htmlSanitizer,
     ) {
     }
 
@@ -67,20 +72,18 @@ class EventInsertTag implements InsertTagResolverNestedResolvedInterface
 
         return match ($insertTag) {
             'event' => new InsertTagResult(
-                \sprintf(
-                    '<a href="%s"%s>%s</a>',
-                    StringUtil::specialcharsAttribute($generateUrl()),
-                    \in_array('blank', $arguments, true) ? ' target="_blank" rel="noreferrer noopener"' : '',
-                    $model->title,
-                ),
+                $this->twig->createTemplate('<a href="{{ url }}"{{ attributes }}>{{ label|insert_tag_raw }}</a>')->render([
+                    'url' => $generateUrl(),
+                    'attributes' => new HtmlAttributes(\in_array('blank', $arguments, true) ? 'target="_blank" rel="noreferrer noopener"' : ''),
+                    'label' => $model->title,
+                ]),
                 OutputType::html,
             ),
             'event_open' => new InsertTagResult(
-                \sprintf(
-                    '<a href="%s"%s>',
-                    StringUtil::specialcharsAttribute($generateUrl()),
-                    \in_array('blank', $arguments, true) ? ' target="_blank" rel="noreferrer noopener"' : '',
-                ),
+                $this->twig->createTemplate('<a href="{{ url }}"{{ attributes }}>')->render([
+                    'url' => $generateUrl(),
+                    'attributes' => new HtmlAttributes(\in_array('blank', $arguments, true) ? 'target="_blank" rel="noreferrer noopener"' : ''),
+                ]),
                 OutputType::html,
             ),
             'event_url' => new InsertTagResult(
@@ -88,7 +91,7 @@ class EventInsertTag implements InsertTagResolverNestedResolvedInterface
                 OutputType::url,
             ),
             'event_title' => new InsertTagResult($model->title),
-            'event_teaser' => new InsertTagResult($model->teaser ?? '', OutputType::html),
+            'event_teaser' => new InsertTagResult($this->htmlSanitizer->sanitize($model->teaser ?? ''), OutputType::html),
             default => throw new InvalidInsertTagException(),
         };
     }

--- a/calendar-bundle/tests/InsertTag/EventInsertTagTest.php
+++ b/calendar-bundle/tests/InsertTag/EventInsertTagTest.php
@@ -14,13 +14,24 @@ namespace Contao\CalendarBundle\Tests\InsertTag;
 
 use Contao\CalendarBundle\InsertTag\EventInsertTag;
 use Contao\CalendarEventsModel;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\InsertTag\OutputType;
 use Contao\CoreBundle\InsertTag\ResolvedInsertTag;
 use Contao\CoreBundle\InsertTag\ResolvedParameters;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
+use Contao\CoreBundle\Twig\Extension\ContaoExtension;
+use Contao\CoreBundle\Twig\Global\ContaoVariable;
+use Contao\CoreBundle\Twig\Inspector\InspectorNodeVisitor;
+use Contao\CoreBundle\Twig\Inspector\Storage;
+use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
+use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\TestCase\ContaoTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
+use Twig\Loader\LoaderInterface;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
 class EventInsertTagTest extends ContaoTestCase
 {
@@ -43,7 +54,7 @@ class EventInsertTagTest extends ContaoTestCase
             ->willReturn($url ?? '')
         ;
 
-        $listener = new EventInsertTag($this->createContaoFrameworkStub($adapters), $urlGenerator);
+        $listener = $this->createEventInsertTag($adapters, $urlGenerator);
         $result = $listener(new ResolvedInsertTag($insertTag, new ResolvedParameters($parameters), []));
 
         $this->assertSame($expectedValue, $result->getValue());
@@ -57,7 +68,7 @@ class EventInsertTagTest extends ContaoTestCase
             ['2'],
             UrlGeneratorInterface::ABSOLUTE_PATH,
             'events/the-foobar-event.html',
-            '<a href="events/the-foobar-event.html">The "foobar" event</a>',
+            '<a href="events/the-foobar-event.html">The &quot;foobar&quot; event</a>',
             OutputType::html,
         ];
 
@@ -66,7 +77,7 @@ class EventInsertTagTest extends ContaoTestCase
             ['2', 'blank'],
             UrlGeneratorInterface::ABSOLUTE_PATH,
             'events/the-foobar-event.html',
-            '<a href="events/the-foobar-event.html" target="_blank" rel="noreferrer noopener">The "foobar" event</a>',
+            '<a href="events/the-foobar-event.html" target="_blank" rel="noreferrer noopener">The &quot;foobar&quot; event</a>',
             OutputType::html,
         ];
 
@@ -168,8 +179,42 @@ class EventInsertTagTest extends ContaoTestCase
         ];
 
         $urlGenerator = $this->createStub(ContentUrlGenerator::class);
-        $listener = new EventInsertTag($this->createContaoFrameworkStub($adapters), $urlGenerator);
+        $listener = $this->createEventInsertTag($adapters, $urlGenerator);
 
         $this->assertSame('', $listener(new ResolvedInsertTag('event_url', new ResolvedParameters(['3']), []))->getValue());
+    }
+
+    private function createEventInsertTag(array $adapters, ContentUrlGenerator $urlGenerator): EventInsertTag
+    {
+        $twig = new Environment($this->createStub(LoaderInterface::class));
+
+        $twig->addExtension(
+            new ContaoExtension(
+                $twig,
+                $this->createStub(ContaoFilesystemLoader::class),
+                $this->createStub(ContaoVariable::class),
+                new InspectorNodeVisitor($this->createStub(Storage::class), $twig),
+            ),
+        );
+
+        $insertTagParser = $this->createStub(InsertTagParser::class);
+        $insertTagParser
+            ->method('replace')
+            ->willReturnArgument(0)
+        ;
+
+        $twig->addRuntimeLoader(
+            new FactoryRuntimeLoader([
+                InsertTagRuntime::class => static fn () => new InsertTagRuntime($insertTagParser),
+            ]),
+        );
+
+        $htmlSanitizer = $this->createStub(HtmlSanitizerInterface::class);
+        $htmlSanitizer
+            ->method('sanitize')
+            ->willReturnArgument(0)
+        ;
+
+        return new EventInsertTag($this->createContaoFrameworkStub($adapters), $urlGenerator, $twig, $htmlSanitizer);
     }
 }

--- a/faq-bundle/config/services.yaml
+++ b/faq-bundle/config/services.yaml
@@ -16,6 +16,7 @@ services:
         arguments:
             - '@contao.framework'
             - '@contao.routing.content_url_generator'
+            - '@twig'
 
     contao_faq.listener.data_container.faq_search:
         class: Contao\FaqBundle\EventListener\DataContainer\FaqSearchListener

--- a/faq-bundle/src/InsertTag/FaqInsertTag.php
+++ b/faq-bundle/src/InsertTag/FaqInsertTag.php
@@ -20,10 +20,11 @@ use Contao\CoreBundle\InsertTag\OutputType;
 use Contao\CoreBundle\InsertTag\ResolvedInsertTag;
 use Contao\CoreBundle\InsertTag\Resolver\InsertTagResolverNestedResolvedInterface;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
+use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\FaqModel;
-use Contao\StringUtil;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
 
 #[AsInsertTag('faq')]
 #[AsInsertTag('faq_open')]
@@ -34,6 +35,7 @@ class FaqInsertTag implements InsertTagResolverNestedResolvedInterface
     public function __construct(
         private readonly ContaoFramework $framework,
         private readonly ContentUrlGenerator $urlGenerator,
+        private readonly Environment $twig,
     ) {
     }
 
@@ -65,20 +67,18 @@ class FaqInsertTag implements InsertTagResolverNestedResolvedInterface
     {
         return match ($key) {
             'faq' => new InsertTagResult(
-                \sprintf(
-                    '<a href="%s"%s>%s</a>',
-                    StringUtil::specialcharsAttribute($url ?: './'),
-                    $blank ? ' target="_blank" rel="noreferrer noopener"' : '',
-                    $faq->question,
-                ),
+                $this->twig->createTemplate('<a href="{{ url }}"{{ attributes }}>{{ label|insert_tag_raw }}</a>')->render([
+                    'url' => $url ?: './',
+                    'attributes' => new HtmlAttributes($blank ? 'target="_blank" rel="noreferrer noopener"' : ''),
+                    'label' => $faq->question,
+                ]),
                 OutputType::html,
             ),
             'faq_open' => new InsertTagResult(
-                \sprintf(
-                    '<a href="%s"%s>',
-                    StringUtil::specialcharsAttribute($url ?: './'),
-                    $blank ? ' target="_blank" rel="noreferrer noopener"' : '',
-                ),
+                $this->twig->createTemplate('<a href="{{ url }}"{{ attributes }}>')->render([
+                    'url' => $url ?: './',
+                    'attributes' => new HtmlAttributes($blank ? 'target="_blank" rel="noreferrer noopener"' : ''),
+                ]),
                 OutputType::html,
             ),
             'faq_url' => new InsertTagResult($url ?: './', OutputType::url),

--- a/faq-bundle/tests/InsertTag/FaqInsertTagTest.php
+++ b/faq-bundle/tests/InsertTag/FaqInsertTagTest.php
@@ -13,10 +13,17 @@ declare(strict_types=1);
 namespace Contao\FaqBundle\Tests\InsertTag;
 
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\InsertTag\OutputType;
 use Contao\CoreBundle\InsertTag\ResolvedInsertTag;
 use Contao\CoreBundle\InsertTag\ResolvedParameters;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
+use Contao\CoreBundle\Twig\Extension\ContaoExtension;
+use Contao\CoreBundle\Twig\Global\ContaoVariable;
+use Contao\CoreBundle\Twig\Inspector\InspectorNodeVisitor;
+use Contao\CoreBundle\Twig\Inspector\Storage;
+use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
+use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\FaqBundle\InsertTag\FaqInsertTag;
 use Contao\FaqCategoryModel;
 use Contao\FaqModel;
@@ -24,6 +31,9 @@ use Contao\PageModel;
 use Contao\TestCase\ContaoTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
+use Twig\Loader\LoaderInterface;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
 class FaqInsertTagTest extends ContaoTestCase
 {
@@ -59,7 +69,7 @@ class FaqInsertTagTest extends ContaoTestCase
             ->willReturn($url ?? '')
         ;
 
-        $listener = new FaqInsertTag($this->createContaoFrameworkStub($adapters), $urlGenerator);
+        $listener = $this->createFaqInsertTag($adapters, $urlGenerator);
         $result = $listener(new ResolvedInsertTag($insertTag, new ResolvedParameters($parameters), []));
 
         $this->assertSame($expectedValue, $result->getValue());
@@ -73,7 +83,7 @@ class FaqInsertTagTest extends ContaoTestCase
             ['2'],
             UrlGeneratorInterface::ABSOLUTE_PATH,
             'faq/what-does-foobar-mean.html',
-            '<a href="faq/what-does-foobar-mean.html">What does "foobar" mean?</a>',
+            '<a href="faq/what-does-foobar-mean.html">What does &quot;foobar&quot; mean?</a>',
             OutputType::html,
         ];
 
@@ -82,7 +92,7 @@ class FaqInsertTagTest extends ContaoTestCase
             ['2', 'blank'],
             UrlGeneratorInterface::ABSOLUTE_PATH,
             'faq/what-does-foobar-mean.html',
-            '<a href="faq/what-does-foobar-mean.html" target="_blank" rel="noreferrer noopener">What does "foobar" mean?</a>',
+            '<a href="faq/what-does-foobar-mean.html" target="_blank" rel="noreferrer noopener">What does &quot;foobar&quot; mean?</a>',
             OutputType::html,
         ];
 
@@ -195,10 +205,10 @@ class FaqInsertTagTest extends ContaoTestCase
             FaqModel::class => $this->createConfiguredAdapterStub(['findByIdOrAlias' => $faqModel]),
         ];
 
-        $listener = new FaqInsertTag($this->createContaoFrameworkStub($adapters), $this->createStub(ContentUrlGenerator::class));
+        $listener = $this->createFaqInsertTag($adapters);
 
         $this->assertSame(
-            '<a href="./">What does "foobar" mean?</a>',
+            '<a href="./">What does &quot;foobar&quot; mean?</a>',
             $listener(new ResolvedInsertTag('faq', new ResolvedParameters(['2']), []))->getValue(),
         );
 
@@ -219,7 +229,7 @@ class FaqInsertTagTest extends ContaoTestCase
             FaqModel::class => $this->createConfiguredAdapterStub(['findByIdOrAlias' => null]),
         ];
 
-        $listener = new FaqInsertTag($this->createContaoFrameworkStub($adapters), $this->createStub(ContentUrlGenerator::class));
+        $listener = $this->createFaqInsertTag($adapters);
 
         $this->assertSame('', $listener(new ResolvedInsertTag('faq_url', new ResolvedParameters(['2']), []))->getValue());
     }
@@ -243,8 +253,38 @@ class FaqInsertTagTest extends ContaoTestCase
             ->willThrowException(new ForwardPageNotFoundException())
         ;
 
-        $listener = new FaqInsertTag($this->createContaoFrameworkStub($adapters), $urlGenerator);
+        $listener = $this->createFaqInsertTag($adapters, $urlGenerator);
 
         $this->assertSame('', $listener(new ResolvedInsertTag('faq_url', new ResolvedParameters(['3']), []))->getValue());
+    }
+
+    private function createFaqInsertTag(array $adapters = [], ContentUrlGenerator|null $urlGenerator = null): FaqInsertTag
+    {
+        $twig = new Environment($this->createStub(LoaderInterface::class));
+
+        $twig->addExtension(
+            new ContaoExtension(
+                $twig,
+                $this->createStub(ContaoFilesystemLoader::class),
+                $this->createStub(ContaoVariable::class),
+                new InspectorNodeVisitor($this->createStub(Storage::class), $twig),
+            ),
+        );
+
+        $insertTagParser = $this->createStub(InsertTagParser::class);
+        $insertTagParser
+            ->method('replace')
+            ->willReturnArgument(0)
+        ;
+
+        $twig->addRuntimeLoader(
+            new FactoryRuntimeLoader([
+                InsertTagRuntime::class => static fn () => new InsertTagRuntime($insertTagParser),
+            ]),
+        );
+
+        $urlGenerator ??= $this->createStub(ContentUrlGenerator::class);
+
+        return new FaqInsertTag($this->createContaoFrameworkStub($adapters), $urlGenerator, $twig);
     }
 }

--- a/news-bundle/config/services.yaml
+++ b/news-bundle/config/services.yaml
@@ -29,6 +29,8 @@ services:
         arguments:
             - '@contao.framework'
             - '@contao.routing.content_url_generator'
+            - '@twig'
+            - '@contao.html_sanitizer'
 
     contao_news.listener.add_feeds_from_layout:
         class: Contao\NewsBundle\EventListener\AddFeedsFromLayoutListener

--- a/news-bundle/src/InsertTag/NewsInsertTag.php
+++ b/news-bundle/src/InsertTag/NewsInsertTag.php
@@ -20,9 +20,11 @@ use Contao\CoreBundle\InsertTag\OutputType;
 use Contao\CoreBundle\InsertTag\ResolvedInsertTag;
 use Contao\CoreBundle\InsertTag\Resolver\InsertTagResolverNestedResolvedInterface;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
+use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\NewsModel;
-use Contao\StringUtil;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
 
 #[AsInsertTag('news')]
 #[AsInsertTag('news_open')]
@@ -34,6 +36,8 @@ class NewsInsertTag implements InsertTagResolverNestedResolvedInterface
     public function __construct(
         private readonly ContaoFramework $framework,
         private readonly ContentUrlGenerator $urlGenerator,
+        private readonly Environment $twig,
+        private readonly HtmlSanitizerInterface $htmlSanitizer,
     ) {
     }
 
@@ -50,25 +54,23 @@ class NewsInsertTag implements InsertTagResolverNestedResolvedInterface
 
         return match ($insertTag->getName()) {
             'news' => new InsertTagResult(
-                \sprintf(
-                    '<a href="%s"%s>%s</a>',
-                    StringUtil::specialcharsAttribute($this->generateNewsUrl($model, $arguments)),
-                    \in_array('blank', $arguments, true) ? ' target="_blank" rel="noreferrer noopener"' : '',
-                    $model->headline,
-                ),
+                $this->twig->createTemplate('<a href="{{ url }}"{{ attributes }}>{{ label|insert_tag_raw }}</a>')->render([
+                    'url' => $this->generateNewsUrl($model, $arguments),
+                    'attributes' => new HtmlAttributes(\in_array('blank', $arguments, true) ? 'target="_blank" rel="noreferrer noopener"' : ''),
+                    'label' => $model->headline,
+                ]),
                 OutputType::html,
             ),
             'news_open' => new InsertTagResult(
-                \sprintf(
-                    '<a href="%s"%s>',
-                    StringUtil::specialcharsAttribute($this->generateNewsUrl($model, $arguments)),
-                    \in_array('blank', $arguments, true) ? ' target="_blank" rel="noreferrer noopener"' : '',
-                ),
+                $this->twig->createTemplate('<a href="{{ url }}"{{ attributes }}>')->render([
+                    'url' => $this->generateNewsUrl($model, $arguments),
+                    'attributes' => new HtmlAttributes(\in_array('blank', $arguments, true) ? 'target="_blank" rel="noreferrer noopener"' : ''),
+                ]),
                 OutputType::html,
             ),
             'news_url' => new InsertTagResult($this->generateNewsUrl($model, $arguments), OutputType::url),
             'news_title' => new InsertTagResult($model->headline),
-            'news_teaser' => new InsertTagResult($model->teaser ?? '', OutputType::html),
+            'news_teaser' => new InsertTagResult($this->htmlSanitizer->sanitize($model->teaser ?? ''), OutputType::html),
             default => new InsertTagResult(''),
         };
     }

--- a/news-bundle/tests/InsertTag/NewsInsertTagTest.php
+++ b/news-bundle/tests/InsertTag/NewsInsertTagTest.php
@@ -13,15 +13,26 @@ declare(strict_types=1);
 namespace Contao\NewsBundle\Tests\InsertTag;
 
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\InsertTag\OutputType;
 use Contao\CoreBundle\InsertTag\ResolvedInsertTag;
 use Contao\CoreBundle\InsertTag\ResolvedParameters;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
+use Contao\CoreBundle\Twig\Extension\ContaoExtension;
+use Contao\CoreBundle\Twig\Global\ContaoVariable;
+use Contao\CoreBundle\Twig\Inspector\InspectorNodeVisitor;
+use Contao\CoreBundle\Twig\Inspector\Storage;
+use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
+use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\NewsBundle\InsertTag\NewsInsertTag;
 use Contao\NewsModel;
 use Contao\TestCase\ContaoTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
+use Twig\Loader\LoaderInterface;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
 class NewsInsertTagTest extends ContaoTestCase
 {
@@ -44,7 +55,7 @@ class NewsInsertTagTest extends ContaoTestCase
             ->willReturn($url ?? '')
         ;
 
-        $listener = new NewsInsertTag($this->createContaoFrameworkStub($adapters), $urlGenerator);
+        $listener = $this->createNewsInsertTag($adapters, $urlGenerator);
         $result = $listener(new ResolvedInsertTag($insertTag, new ResolvedParameters($parameters), []));
 
         $this->assertSame($expectedValue, $result->getValue());
@@ -58,7 +69,7 @@ class NewsInsertTagTest extends ContaoTestCase
             ['2'],
             UrlGeneratorInterface::ABSOLUTE_PATH,
             'news/foo-is-not-bar.html',
-            '<a href="news/foo-is-not-bar.html">"Foo" is not "bar"</a>',
+            '<a href="news/foo-is-not-bar.html">&quot;Foo&quot; is not &quot;bar&quot;</a>',
             OutputType::html,
         ];
 
@@ -67,7 +78,7 @@ class NewsInsertTagTest extends ContaoTestCase
             ['2', 'blank'],
             UrlGeneratorInterface::ABSOLUTE_PATH,
             'news/foo-is-not-bar.html',
-            '<a href="news/foo-is-not-bar.html" target="_blank" rel="noreferrer noopener">"Foo" is not "bar"</a>',
+            '<a href="news/foo-is-not-bar.html" target="_blank" rel="noreferrer noopener">&quot;Foo&quot; is not &quot;bar&quot;</a>',
             OutputType::html,
         ];
 
@@ -169,7 +180,7 @@ class NewsInsertTagTest extends ContaoTestCase
         ];
 
         $urlGenerator = $this->createStub(ContentUrlGenerator::class);
-        $listener = new NewsInsertTag($this->createContaoFrameworkStub($adapters), $urlGenerator);
+        $listener = $this->createNewsInsertTag($adapters, $urlGenerator);
 
         $this->assertSame('', $listener(new ResolvedInsertTag('news_url', new ResolvedParameters(['3']), []))->getValue());
     }
@@ -188,8 +199,42 @@ class NewsInsertTagTest extends ContaoTestCase
             ->willThrowException(new ForwardPageNotFoundException())
         ;
 
-        $listener = new NewsInsertTag($this->createContaoFrameworkStub($adapters), $urlGenerator);
+        $listener = $this->createNewsInsertTag($adapters, $urlGenerator);
 
         $this->assertSame('', $listener(new ResolvedInsertTag('news_url', new ResolvedParameters(['4']), []))->getValue());
+    }
+
+    private function createNewsInsertTag(array $adapters, ContentUrlGenerator $urlGenerator): NewsInsertTag
+    {
+        $twig = new Environment($this->createStub(LoaderInterface::class));
+
+        $twig->addExtension(
+            new ContaoExtension(
+                $twig,
+                $this->createStub(ContaoFilesystemLoader::class),
+                $this->createStub(ContaoVariable::class),
+                new InspectorNodeVisitor($this->createStub(Storage::class), $twig),
+            ),
+        );
+
+        $insertTagParser = $this->createStub(InsertTagParser::class);
+        $insertTagParser
+            ->method('replace')
+            ->willReturnArgument(0)
+        ;
+
+        $twig->addRuntimeLoader(
+            new FactoryRuntimeLoader([
+                InsertTagRuntime::class => static fn () => new InsertTagRuntime($insertTagParser),
+            ]),
+        );
+
+        $htmlSanitizer = $this->createStub(HtmlSanitizerInterface::class);
+        $htmlSanitizer
+            ->method('sanitize')
+            ->willReturnArgument(0)
+        ;
+
+        return new NewsInsertTag($this->createContaoFrameworkStub($adapters), $urlGenerator, $twig, $htmlSanitizer);
     }
 }


### PR DESCRIPTION
Fix encoding of `{{news::*}}`, `{{event::*}}` and `{{faq::*}}` by using inline Twig templates.