### PR TITLE
Use a higher priority for the output encoding migration

### DIFF
--- a/core-bundle/config/migrations.yaml
+++ b/core-bundle/config/migrations.yaml
@@ -40,5 +40,5 @@ services:
         arguments:
             - '@database_connection'
         tags:
-            # Use a higher priority for the output encoding migration (see #10042)
+            # The priority must be higher than the one of the "column to virtual" migration (see #10042)
             - { name: contao.migration, priority: 1 }

--- a/core-bundle/config/migrations.yaml
+++ b/core-bundle/config/migrations.yaml
@@ -39,3 +39,6 @@ services:
         class: Contao\CoreBundle\Migration\Version600\OutputEncodingMigration
         arguments:
             - '@database_connection'
+        tags:
+            # Use a higher priority for the output encoding migration (see #10042)
+            - { name: contao.migration, priority: 1 }


### PR DESCRIPTION
### Description

Whilst updating data from Contao 5.7 to 6.0, I ran into an error with the output encoding migration failing due to the `player*` fields not existing as columns anymore. Using a higher priority as suggested by ~~@Toflar~~ @ausi does work as the output encoding migration will be run first, just before these fields will be migrated to virtual fields.