### PR TITLE
Fix the `Twig` code style in the `player.html.twig` template

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/player.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/player.html.twig
@@ -37,12 +37,12 @@
 {# Add metadata #}
 {% block metadata %}
     {% for source_file in source_files %}
-        {% set schemaOrgData = source_file.schemaOrgData|default({}) %}
+        {% set schema_org_data = source_file.schemaOrgData|default({}) %}
         {% if figure.media.attributes.poster|default %}
-            {% set schemaOrgData = schemaOrgData|merge({
-                'thumbnailUrl': figure.media.attributes.poster
+            {% set schema_org_data = schema_org_data|merge({
+                thumbnailUrl: figure.media.attributes.poster,
             }) %}
         {% endif %}
-        {% do add_schema_org(schemaOrgData) %}
+        {% do add_schema_org(schema_org_data) %}
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
### Description

Applies the code style changes to the failing Twig CS test (see https://github.com/contao/contao/actions/runs/29874178929/job/88780928063?pr=10043)

We can safely use snake_case for the variable as well as it can't be changed without overriding the whole block anyways.