### PR TITLE
Add the new element CSS classes in addition to the old ones

### DIFF
--- a/calendar-bundle/contao/templates/events/event_full.html5
+++ b/calendar-bundle/contao/templates/events/event_full.html5
@@ -16,7 +16,7 @@
   <?php if ($this->details): ?>
     <?= $this->details ?>
   <?php else: ?>
-    <div class="ce_text block">
+    <div class="ce_text content-text block">
       <?php if (!$this->addBefore): ?>
         <?= $this->cspInlineStyles($this->teaser) ?>
       <?php endif; ?>

--- a/calendar-bundle/contao/templates/events/event_list.html5
+++ b/calendar-bundle/contao/templates/events/event_list.html5
@@ -21,7 +21,7 @@
   <?php if ($this->details): ?>
     <?= $this->details ?>
   <?php else: ?>
-    <div class="ce_text block">
+    <div class="ce_text content-text block">
       <?= $this->cspInlineStyles($this->teaser) ?>
     </div>
   <?php endif; ?>

--- a/calendar-bundle/contao/templates/events/event_teaser.html5
+++ b/calendar-bundle/contao/templates/events/event_teaser.html5
@@ -19,7 +19,7 @@
     <p class="location"><?= $this->location ?><?php if ($this->address): ?> (<?= $this->address ?>)<?php endif; ?></p>
   <?php endif; ?>
 
-  <div class="ce_text block">
+  <div class="ce_text content-text block">
     <?php if (!$this->addBefore): ?>
       <?= $this->cspInlineStyles($this->teaser) ?>
     <?php endif; ?>

--- a/core-bundle/contao/templates/elements/ce_accordionSingle.html5
+++ b/core-bundle/contao/templates/elements/ce_accordionSingle.html5
@@ -1,5 +1,5 @@
 
-<section class="<?= $this->class ?> ce_accordion content-accordion ce_text content-text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<section class="<?= $this->class ?> ce_accordion ce_text content-text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
 
   <div<?= $this->attrs()->addClass($this->toggler)->addStyle($this->headlineStyle) ?>>
     <?= $this->headline ?>

--- a/core-bundle/contao/templates/elements/ce_accordionSingle.html5
+++ b/core-bundle/contao/templates/elements/ce_accordionSingle.html5
@@ -1,5 +1,5 @@
 
-<section class="<?= $this->class ?> ce_accordion ce_text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<section class="<?= $this->class ?> ce_accordion content-accordion ce_text content-text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
 
   <div<?= $this->attrs()->addClass($this->toggler)->addStyle($this->headlineStyle) ?>>
     <?= $this->headline ?>

--- a/core-bundle/contao/templates/elements/ce_teaser.html5
+++ b/core-bundle/contao/templates/elements/ce_teaser.html5
@@ -1,5 +1,5 @@
 
-<div class="<?= $this->class ?> ce_text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> ce_text content-text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
 
   <?php if ($this->headline): ?>
     <h1><?= $this->headline ?></h1>

--- a/core-bundle/contao/templates/modules/mod_article.html5
+++ b/core-bundle/contao/templates/modules/mod_article.html5
@@ -3,7 +3,7 @@
 
   <?php $this->block('alias'); ?>
     <article class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
-      <div class="ce_text block">
+      <div class="ce_text content-text block">
         <h2><?= $this->headline ?></h2>
         <div class="teaser">
           <?= $this->cspInlineStyles($this->teaser) ?>

--- a/faq-bundle/contao/templates/modules/mod_faqpage.html5
+++ b/faq-bundle/contao/templates/modules/mod_faqpage.html5
@@ -10,7 +10,7 @@
         <section>
           <h3 id="<?= $faq->alias ?>"><?= $faq->question ?></h3>
 
-          <div class="ce_text block">
+          <div class="ce_text content-text block">
             <?php if (!$faq->addBefore): ?>
               <?= $this->cspInlineStyles($faq->answer) ?>
             <?php endif; ?>

--- a/faq-bundle/contao/templates/modules/mod_faqreader.html5
+++ b/faq-bundle/contao/templates/modules/mod_faqreader.html5
@@ -7,7 +7,7 @@
   <?php else: ?>
     <h1><?= $this->question ?></h1>
 
-    <div class="ce_text block">
+    <div class="ce_text content-text block">
       <?php if (!$this->addBefore): ?>
         <?= $this->cspInlineStyles($this->answer) ?>
       <?php endif; ?>

--- a/listing-bundle/contao/templates/listing/list_default.html5
+++ b/listing-bundle/contao/templates/listing/list_default.html5
@@ -1,5 +1,5 @@
 
-<div class="<?= $this->class ?> ce_table listing block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> ce_table content-table listing block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
 
   <?php if ($this->headline): ?>
     <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>

--- a/news-bundle/contao/templates/news/news_full.html5
+++ b/news-bundle/contao/templates/news/news_full.html5
@@ -14,7 +14,7 @@
   <?php if ($this->hasText): ?>
     <?= $this->text ?>
   <?php else: ?>
-    <div class="ce_text block">
+    <div class="ce_text content-text block">
       <?php if (!$this->addBefore): ?>
         <?= $this->cspInlineStyles($this->teaser) ?>
       <?php endif; ?>

--- a/news-bundle/contao/templates/news/news_latest.html5
+++ b/news-bundle/contao/templates/news/news_latest.html5
@@ -11,7 +11,7 @@
 
   <h2><?= $this->linkHeadline ?></h2>
 
-  <div class="ce_text block">
+  <div class="ce_text content-text block">
     <?= $this->cspInlineStyles($this->teaser) ?>
   </div>
 

--- a/news-bundle/contao/templates/news/news_short.html5
+++ b/news-bundle/contao/templates/news/news_short.html5
@@ -7,7 +7,7 @@
 
   <h2><?= $this->linkHeadline ?></h2>
 
-  <div class="ce_text block">
+  <div class="ce_text content-text block">
     <?= $this->cspInlineStyles($this->teaser) ?>
   </div>
 


### PR DESCRIPTION
Fixes #10026

This PR converts `class="ce_text"` to `class="ce_text content-text"` and `class="ce_accordion ce_text"` to `class="ce_accordion content-accordion ce_text content-text"`.