### PR TITLE
Merge the module CSS classes for root page dependent modules

### DIFF
--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -61,7 +61,7 @@ class RootPageDependentModulesController extends AbstractFrontendModuleControlle
         }
 
         // Merge the CSS classes (see #6011)
-        $cssID[1] = trim(\sprintf('%s %s %s', $cssID[1] ?? '', $modelCssID[1] ?? '', implode(' ', (array) $model->classes)));
+        $cssID[1] = implode(' ', array_filter(array_map(trim(...), [$cssID[1] ?? '', $modelCssID[1] ?? '', ...(array) $model->classes])));
 
         $module->cssID = $cssID;
 

--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -49,12 +49,18 @@ class RootPageDependentModulesController extends AbstractFrontendModuleControlle
         }
 
         $cssID = StringUtil::deserialize($module->cssID, true);
+        $modelCssID = StringUtil::deserialize($model->cssID, true);
+
+        // Override the CSS ID (see #305)
+        if (!empty($modelCssID[0])) {
+            $cssID[0] = $modelCssID[0];
+        }
 
         if ($idAttribute = $request->attributes->get('templateProperties', [])['cssID'] ?? null) {
             $cssID[0] = substr($idAttribute, 5, -1);
         }
 
-        $modelCssID = StringUtil::deserialize($model->cssID, true);
+        // Merge the CSS classes (see #6011)
         $cssID[1] = trim(\sprintf('%s %s %s', $cssID[1] ?? '', $modelCssID[1] ?? '', implode(' ', (array) $model->classes)));
 
         $module->cssID = $cssID;

--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -54,7 +54,8 @@ class RootPageDependentModulesController extends AbstractFrontendModuleControlle
             $cssID[0] = substr($idAttribute, 5, -1);
         }
 
-        $cssID[1] = trim(\sprintf('%s %s', $cssID[1] ?? '', implode(' ', (array) $model->classes)));
+        $modelCssID = StringUtil::deserialize($model->cssID, true);
+        $cssID[1] = trim(\sprintf('%s %s %s', $cssID[1] ?? '', $modelCssID[1] ?? '', implode(' ', (array) $model->classes)));
 
         $module->cssID = $cssID;
 


### PR DESCRIPTION
Fixes #10055

The `ContentModule` element merges its CSS class into the referenced module's `cssID[1]`, but `RootPageDependentModulesController` only forwards `$model->classes` and never reads the module's own `cssID` so the class is
dropped. This PR also merges `cssID[1]` into the inner module's classes.

## To reproduce

1. Create a "root page dependent modules" module referencing an inner module
2. Add a "module" content element referencing it and set a CSS class
3. The class is missing in the output