### PR TITLE
Fix video detection logic in PlayerController

### DIFF
--- a/core-bundle/src/Controller/ContentElement/PlayerController.php
+++ b/core-bundle/src/Controller/ContentElement/PlayerController.php
@@ -60,7 +60,7 @@ class PlayerController extends AbstractContentElementController
         }
 
         // Compile data
-        $figureData = $filesystemItems->first()?->isVideo() ?? false
+        $figureData = ($sourceFiles[0] ?? null)?->isVideo() ?? false
             ? $this->buildVideoFigureData($model, $sourceFiles)
             : $this->buildAudioFigureData($model, $sourceFiles);
 


### PR DESCRIPTION
I stumbled across the following bug when upgrading an older Contao project to Contao 5.7.

Before building the FigureData, the PlayerController.php checks the unsorted $filesystemItems iterator to determine if it is a video or not. If your playerSRC field has the poster image listed before the video in the database, first() returns the image, isVideo() returns false, and it renders an audio tag.

The fix is to check $sourceFiles[0] instead. This has worked for me so far. There are other ways to fix this, but I think this is the easiest. Hope this helps! :) 