### PR TITLE
Fix the cache settings inheritance

### DIFF
--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -934,6 +934,7 @@ class PageModel extends Model
 		$ptitle = '';
 		$trail = array($this->id, $pid);
 		$time = time();
+		$cacheInherited = false;
 
 		// Inherit the settings
 		if ($this->type == 'root')
@@ -977,11 +978,13 @@ class PageModel extends Model
 					}
 
 					// Cache
-					if ($objParentPage->includeCache && !$this->includeCache)
+					if ($objParentPage->includeCache && !$this->includeCache && !$cacheInherited)
 					{
 						$this->cache = $objParentPage->cache;
 						$this->alwaysLoadFromCache = $objParentPage->alwaysLoadFromCache;
 						$this->clientCache = $objParentPage->clientCache;
+
+						$cacheInherited = true;
 					}
 
 					// Layout


### PR DESCRIPTION
Fixes #10061

Alternatively we could also revert to how it was in Contao 4.13 - but I think this is cleaner.