### PR TITLE
Increase the size of `tl_log.browser`

### DIFF
--- a/core-bundle/contao/dca/tl_log.php
+++ b/core-bundle/contao/dca/tl_log.php
@@ -104,7 +104,7 @@ $GLOBALS['TL_DCA']['tl_log'] = array
 		(
 			'sorting'                 => true,
 			'search'                  => true,
-			'sql'                     => array('type'=>'string', 'length'=>255, 'default'=>'')
+			'sql'                     => array('type'=>'text', 'length'=>AbstractMySQLPlatform::LENGTH_LIMIT_TEXT, 'notnull'=>false)
 		),
 		'uri' => array
 		(


### PR DESCRIPTION
Same as #10065 for Contao 6.0