### PR TITLE
Store the page name in the `HtmlHeadBag` and use it in the breadcrumbs module

### DIFF
--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -115,6 +115,11 @@ class ModuleEventReader extends Events
 		{
 			$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
 
+			if ($objEvent->title)
+			{
+				$htmlHeadBag->setName($objEvent->title);
+			}
+
 			if ($objEvent->pageTitle)
 			{
 				$htmlHeadBag->setTitle($objEvent->pageTitle); // Already stored decoded

--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
@@ -185,6 +186,15 @@ class ModuleBreadcrumb extends Module
 		// Active page
 		else
 		{
+			$pageName = null;
+			$responseContext = System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext();
+
+			if ($responseContext?->has(HtmlHeadBag::class))
+			{
+				$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
+				$pageName = $htmlHeadBag->getName();
+			}
+
 			$items[] = array
 			(
 				'isRoot'   => false,
@@ -192,7 +202,7 @@ class ModuleBreadcrumb extends Module
 				// Use the current request without query string for the current page (see #3450)
 				'href'     => $request?->getBaseUrl() . $request?->getPathInfo(),
 				'title'    => $pages[0]->pageTitle ?: $pages[0]->title,
-				'link'     => $pages[0]->title,
+				'link'     => $pageName ?: $pages[0]->title,
 				'data'     => $pages[0]->row(),
 			);
 		}

--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -187,12 +187,14 @@ class ModuleBreadcrumb extends Module
 		else
 		{
 			$pageName = null;
+			$pageTitle = null;
 			$responseContext = System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext();
 
 			if ($responseContext?->has(HtmlHeadBag::class))
 			{
 				$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
 				$pageName = $htmlHeadBag->getName();
+				$pageTitle = $htmlHeadBag->getTitle();
 			}
 
 			$items[] = array
@@ -201,7 +203,7 @@ class ModuleBreadcrumb extends Module
 				'isActive' => true,
 				// Use the current request without query string for the current page (see #3450)
 				'href'     => $request?->getBaseUrl() . $request?->getPathInfo(),
-				'title'    => $pages[0]->pageTitle ?: $pages[0]->title,
+				'title'    => $pageTitle ?: $pages[0]->pageTitle ?: $pageName ?: $pages[0]->title,
 				'link'     => $pageName ?: $pages[0]->title,
 				'data'     => $pages[0]->row(),
 			);

--- a/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
@@ -78,10 +78,12 @@ class CoreResponseContextFactory
     public function createContaoWebpageResponseContext(PageModel $pageModel): ResponseContext
     {
         $context = $this->createWebpageResponseContext();
+        $name = $this->insertTagParser->replaceInline($pageModel->title ?: '');
         $title = $this->insertTagParser->replaceInline($pageModel->pageTitle ?: $pageModel->title ?: '');
 
         $htmlHeadBag = $context->get(HtmlHeadBag::class);
         $htmlHeadBag
+            ->setName($name ?: '')
             ->setTitle($title ?: '')
             ->setMetaDescription($this->insertTagParser->replaceInline($pageModel->description ?: ''))
         ;

--- a/core-bundle/src/Routing/ResponseContext/HtmlHeadBag/HtmlHeadBag.php
+++ b/core-bundle/src/Routing/ResponseContext/HtmlHeadBag/HtmlHeadBag.php
@@ -17,6 +17,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class HtmlHeadBag
 {
+    private string $name = '';
+
     private string $title = '';
 
     private string $metaDescription = '';
@@ -36,6 +38,18 @@ final class HtmlHeadBag
      * @var list<HtmlAttributes>
      */
     private array $linkTags = [];
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
 
     public function getTitle(): string
     {

--- a/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
@@ -145,7 +145,7 @@ class CoreResponseContextFactoryTest extends TestCase
 
         $insertTagsParser = $this->createMock(InsertTagParser::class);
         $insertTagsParser
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(4))
             ->method('replaceInline')
             ->willReturnMap([
                 ['My title', 'My title'],
@@ -251,7 +251,7 @@ class CoreResponseContextFactoryTest extends TestCase
 
         $insertTagsParser = $this->createMock(InsertTagParser::class);
         $insertTagsParser
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('replaceInline')
             ->willReturnMap([
                 ['My title', 'My title'],
@@ -350,7 +350,7 @@ class CoreResponseContextFactoryTest extends TestCase
 
         $insertTagsParser = $this->createMock(InsertTagParser::class);
         $insertTagsParser
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(4))
             ->method('replaceInline')
             ->willReturnMap([
                 ['', 'My title'],

--- a/core-bundle/tests/Routing/ResponseContext/HtmlHeadBag/HtmlHeadBagTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/HtmlHeadBag/HtmlHeadBagTest.php
@@ -22,6 +22,7 @@ class HtmlHeadBagTest extends TestCase
     public function testHeadManagerBasics(): void
     {
         $manager = new HtmlHeadBag();
+        $manager->setName('foobar');
         $manager->setTitle('foobar title');
         $manager->setMetaDescription('foobar description');
 
@@ -29,6 +30,7 @@ class HtmlHeadBagTest extends TestCase
 
         $manager->setMetaRobots('noindex,nofollow');
 
+        $this->assertSame('foobar', $manager->getName());
         $this->assertSame('foobar title', $manager->getTitle());
         $this->assertSame('foobar description', $manager->getMetaDescription());
         $this->assertSame('noindex,nofollow', $manager->getMetaRobots());

--- a/faq-bundle/contao/modules/ModuleFaqReader.php
+++ b/faq-bundle/contao/modules/ModuleFaqReader.php
@@ -97,6 +97,11 @@ class ModuleFaqReader extends Module
 		{
 			$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
 
+			if ($objFaq->question)
+			{
+				$htmlHeadBag->setName($objFaq->question);
+			}
+
 			if ($objFaq->pageTitle)
 			{
 				$htmlHeadBag->setTitle($objFaq->pageTitle); // Already stored decoded

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -120,6 +120,11 @@ class ModuleNewsReader extends ModuleNews
 		{
 			$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
 
+			if ($objArticle->headline)
+			{
+				$htmlHeadBag->setName($objArticle->headline);
+			}
+
 			if ($objArticle->pageTitle)
 			{
 				$htmlHeadBag->setTitle($objArticle->pageTitle); // Already stored decoded

--- a/newsletter-bundle/contao/modules/ModuleNewsletterReader.php
+++ b/newsletter-bundle/contao/modules/ModuleNewsletterReader.php
@@ -93,6 +93,7 @@ class ModuleNewsletterReader extends Module
 			if ($responseContext?->has(HtmlHeadBag::class))
 			{
 				$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
+				$htmlHeadBag->setName($objNewsletter->subject);
 				$htmlHeadBag->setTitle($objNewsletter->subject);
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/6050#issuecomment-5059313621

<img width="827" height="324" alt="Bildschirmfoto 2026-07-30 um 15 58 20" src="https://github.com/user-attachments/assets/63622e96-92bb-40ee-ae0c-71417e8ca27f" />
