### PR TITLE
Backend search permissions/facet improvements

### DIFF
--- a/core-bundle/config/backend_search.yaml
+++ b/core-bundle/config/backend_search.yaml
@@ -55,8 +55,21 @@ services:
         arguments:
             - !tagged_iterator contao.backend_search_provider
             - '@event_dispatcher'
+            - '@contao.search.backend.security.document_allowed_groups_resolver'
         tags:
             - { name: cmsig_seal.reindex_provider }
+
+    contao.search.backend.security.document_access_evaluator:
+        class: Contao\CoreBundle\Search\Backend\Security\DocumentAccessEvaluator
+        arguments:
+            - '@contao.search.security.virtual_backend_user_factory'
+            - '@contao.security.authentication.contao_strategy_context'
+
+    contao.search.backend.security.document_allowed_groups_resolver:
+        class: Contao\CoreBundle\Search\Backend\Security\DocumentAllowedGroupsResolver
+        arguments:
+            - '@database_connection'
+            - '@contao.search.backend.security.document_access_evaluator'
 
     contao.search.backend.table_data_container_provider:
         class: Contao\CoreBundle\Search\Backend\Provider\TableDataContainerProvider
@@ -80,6 +93,11 @@ services:
         class: Contao\CoreBundle\Search\Backend\EventListener\TriggerReindexOnTableDataContainerInvalidationListener
         arguments:
             - '@contao.search.backend'
+
+    contao.search.security.virtual_backend_user_factory:
+        class: Contao\CoreBundle\Search\Backend\Security\VirtualBackendUserFactory
+        arguments:
+            - '@contao.framework'
 
     contao.search_backend.adapter:
         class: CmsIg\Seal\Adapter\AdapterInterface

--- a/core-bundle/contao/classes/BackendUser.php
+++ b/core-bundle/contao/classes/BackendUser.php
@@ -67,6 +67,18 @@ class BackendUser extends User
 	}
 
 	/**
+	 * @param array<string, mixed> $data
+	 */
+	public static function createFromData(array $data): self
+	{
+		$user = new self();
+		$user->arrData = $data;
+		$user->setUserFromDb();
+
+		return $user;
+	}
+
+	/**
 	 * Instantiate a new user object
 	 *
 	 * @return static|User The object instance

--- a/core-bundle/src/DependencyInjection/Compiler/AccessDecisionStrategyPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AccessDecisionStrategyPass.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
 use Contao\CoreBundle\Security\Authentication\ContaoStrategy;
+use Contao\CoreBundle\Security\Authentication\ContaoStrategyContext;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -33,13 +34,19 @@ class AccessDecisionStrategyPass implements CompilerPassInterface
         $accessDecisionManager = $container->getDefinition('security.access.decision_manager');
         $originalStrategy = $accessDecisionManager->getArgument(1);
 
-        $strategy = new Definition(ContaoStrategy::class, [
-            $originalStrategy,
-            new Definition(PriorityStrategy::class),
+        $strategyContext = new Definition(ContaoStrategyContext::class, [
             new Reference('request_stack'),
             new Reference('security.firewall.map'),
         ]);
+        $container->setDefinition('contao.security.authentication.contao_strategy_context', $strategyContext);
 
-        $accessDecisionManager->replaceArgument(1, $strategy);
+        $strategy = new Definition(ContaoStrategy::class, [
+            $originalStrategy,
+            new Definition(PriorityStrategy::class),
+            new Reference('contao.security.authentication.contao_strategy_context'),
+        ]);
+        $container->setDefinition('contao.security.authentication.contao_strategy', $strategy);
+
+        $accessDecisionManager->replaceArgument(1, new Reference('contao.security.authentication.contao_strategy'));
     }
 }

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -700,6 +700,16 @@ class Configuration implements ConfigurationInterface
                     ->info('The name of the search index')
                     ->defaultValue('contao_backend')
                 ->end()
+                ->arrayNode('permission_aware_facets')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->integerNode('max_groups')
+                            ->info('Maximum number of backend user groups that are evaluated for indexing allowed group access. Set to 0 for no limit.')
+                            ->min(0)
+                            ->defaultValue(10)
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
     }

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -409,6 +409,13 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
                 ->setArgument('$indexName', $indexName),
             )
         ;
+
+        if ($container->hasDefinition('contao.search.backend.security.document_allowed_groups_resolver')) {
+            $resolverDefinition = $container->getDefinition('contao.search.backend.security.document_allowed_groups_resolver');
+            $resolverDefinition
+                ->setArgument('$maxGroups', $config['backend_search']['permission_aware_facets']['max_groups'])
+            ;
+        }
     }
 
     private function handleCrawlConfig(array $config, ContainerBuilder $container): void

--- a/core-bundle/src/Search/Backend/BackendSearch.php
+++ b/core-bundle/src/Search/Backend/BackendSearch.php
@@ -12,6 +12,7 @@ use CmsIg\Seal\Schema\Schema;
 use CmsIg\Seal\Search\Condition\Condition;
 use CmsIg\Seal\Search\Facet\Facet;
 use CmsIg\Seal\Search\SearchBuilder;
+use Contao\BackendUser;
 use Contao\CoreBundle\Event\BackendSearch\EnhanceHitEvent;
 use Contao\CoreBundle\Job\Jobs;
 use Contao\CoreBundle\Messenger\Message\BackendSearch\DeleteDocumentsMessage;
@@ -249,6 +250,7 @@ class BackendSearch
                 'type' => new TextField('type', searchable: false, filterable: true),
                 'searchableContent' => new TextField('searchableContent', searchable: true),
                 'tags' => new TextField('tags', multiple: true, searchable: false, filterable: true),
+                'allowedGroups' => new TextField('allowedGroups', multiple: true, searchable: false, filterable: true),
                 'document' => new TextField('document', searchable: false),
             ]),
         ]);
@@ -271,6 +273,16 @@ class BackendSearch
 
         if ($query->getKeywords()) {
             $sb->addFilter(Condition::search($query->getKeywords()));
+        }
+
+        $user = $this->security->getUser();
+
+        if (
+            $user instanceof BackendUser
+            && !$this->security->isGranted('ROLE_ADMIN')
+            && [] !== $user->groups
+        ) {
+            $sb->addFilter(Condition::in('allowedGroups', array_map(intval(...), $user->groups)));
         }
 
         if ($query->getType()) {

--- a/core-bundle/src/Search/Backend/Seal/SealReindexProvider.php
+++ b/core-bundle/src/Search/Backend/Seal/SealReindexProvider.php
@@ -10,6 +10,7 @@ use Contao\CoreBundle\Event\BackendSearch\IndexDocumentEvent;
 use Contao\CoreBundle\Search\Backend\BackendSearch;
 use Contao\CoreBundle\Search\Backend\Document;
 use Contao\CoreBundle\Search\Backend\Provider\ProviderInterface;
+use Contao\CoreBundle\Search\Backend\Security\DocumentAllowedGroupsResolver;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -27,6 +28,7 @@ class SealReindexProvider implements ReindexProviderInterface
     public function __construct(
         private readonly iterable $providers,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly DocumentAllowedGroupsResolver $documentAllowedGroupsResolver,
     ) {
     }
 
@@ -54,6 +56,11 @@ class SealReindexProvider implements ReindexProviderInterface
                 if (!$document = $event->getDocument()) {
                     continue;
                 }
+
+                $document = $document->withMetadata([
+                    ...$document->getMetadata(),
+                    'allowedGroups' => $this->documentAllowedGroupsResolver->resolveAllowedGroups($provider, $document),
+                ]);
 
                 yield SealUtil::convertProviderDocumentForSearchIndex($document);
             }

--- a/core-bundle/src/Search/Backend/Seal/SealUtil.php
+++ b/core-bundle/src/Search/Backend/Seal/SealUtil.php
@@ -79,11 +79,14 @@ class SealUtil
 
     public static function convertProviderDocumentForSearchIndex(Document $document): array
     {
+        $allowedGroups = $document->getMetadata()['allowedGroups'] ?? [];
+
         return [
             'id' => self::getGlobalDocumentId($document->getType(), $document->getId()),
             'type' => $document->getType(),
             'searchableContent' => $document->getSearchableContent(),
             'tags' => $document->getTags(),
+            'allowedGroups' => \is_array($allowedGroups) ? array_values(array_filter(array_map(intval(...), $allowedGroups), static fn (int $id): bool => $id > 0)) : [],
             'document' => json_encode($document->toArray(), JSON_THROW_ON_ERROR),
         ];
     }

--- a/core-bundle/src/Search/Backend/Security/DocumentAccessEvaluator.php
+++ b/core-bundle/src/Search/Backend/Security/DocumentAccessEvaluator.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Search\Backend\Security;
+
+use Contao\CoreBundle\Search\Backend\Document;
+use Contao\CoreBundle\Search\Backend\Provider\ProviderInterface;
+use Contao\CoreBundle\Security\Authentication\ContaoStrategyContext;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+class DocumentAccessEvaluator
+{
+    /**
+     * @var array<int, TokenInterface>
+     */
+    private array $tokensByGroupId = [];
+
+    public function __construct(
+        private readonly VirtualBackendUserFactory $virtualBackendUserFactory,
+        private readonly ContaoStrategyContext $strategyContext,
+    ) {
+    }
+
+    public function isGrantedForGroup(ProviderInterface $provider, Document $document, int $groupId): bool
+    {
+        $token = $this->tokensByGroupId[$groupId] ??= $this->createTokenForGroup($groupId);
+
+        return $this->strategyContext->runInContext(
+            ContaoStrategyContext::CONTEXT_BACKEND,
+            static fn (): bool => $provider->isDocumentGranted($token, $document),
+        );
+    }
+
+    private function createTokenForGroup(int $groupId): TokenInterface
+    {
+        $user = $this->virtualBackendUserFactory->createForGroupId($groupId);
+
+        return new UsernamePasswordToken($user, 'contao_backend', $user->getRoles());
+    }
+}

--- a/core-bundle/src/Search/Backend/Security/DocumentAllowedGroupsResolver.php
+++ b/core-bundle/src/Search/Backend/Security/DocumentAllowedGroupsResolver.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Search\Backend\Security;
+
+use Contao\CoreBundle\Search\Backend\Document;
+use Contao\CoreBundle\Search\Backend\Provider\ProviderInterface;
+use Contao\Date;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @experimental
+ */
+class DocumentAllowedGroupsResolver
+{
+    /**
+     * @var array<int>|null
+     */
+    private array|null $backendGroupIds = null;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly DocumentAccessEvaluator $documentAccessEvaluator,
+        private readonly int $maxGroups = 10,
+    ) {
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function resolveAllowedGroups(ProviderInterface $provider, Document $document): array
+    {
+        $allowedGroups = [];
+
+        foreach ($this->getActiveBackendGroupIds() as $groupId) {
+            if ($this->documentAccessEvaluator->isGrantedForGroup($provider, $document, $groupId)) {
+                $allowedGroups[] = $groupId;
+            }
+        }
+
+        return $allowedGroups;
+    }
+
+    /**
+     * @return array<int>
+     */
+    private function getActiveBackendGroupIds(): array
+    {
+        if (null !== $this->backendGroupIds) {
+            return $this->backendGroupIds;
+        }
+
+        $time = Date::floorToMinute();
+        $groups = [];
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('id')
+            ->from('tl_user_group')
+            ->where("disable=0 AND (start='' OR start<=:time) AND (stop='' OR stop>:time)")
+            ->orderBy('name', 'ASC')
+            ->setParameter('time', $time)
+        ;
+
+        if ($this->maxGroups > 0) {
+            $qb->setMaxResults($this->maxGroups);
+        }
+
+        $result = $qb->fetchFirstColumn();
+
+        foreach ($result as $groupId) {
+            $groups[] = (int) $groupId;
+        }
+
+        return $this->backendGroupIds = $groups;
+    }
+}

--- a/core-bundle/src/Search/Backend/Security/VirtualBackendUserFactory.php
+++ b/core-bundle/src/Search/Backend/Security/VirtualBackendUserFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Search\Backend\Security;
+
+use Contao\BackendUser;
+use Contao\Controller;
+use Contao\CoreBundle\Framework\ContaoFramework;
+
+class VirtualBackendUserFactory
+{
+    /**
+     * @var array<string, mixed>|null
+     */
+    private array|null $cachedDefaults = null;
+
+    public function __construct(private readonly ContaoFramework $framework)
+    {
+    }
+
+    public function createForGroupId(int $groupId): BackendUser
+    {
+        return BackendUser::createFromData([
+            ...$this->getDefaultUserDataFromDca(),
+            'id' => 0,
+            'username' => '__contao_backend_search_group_'.$groupId,
+            'name' => '__contao_backend_search_group_'.$groupId,
+            'admin' => false,
+            'inherit' => 'group',
+            'groups' => [$groupId],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getDefaultUserDataFromDca(): array
+    {
+        if (null !== $this->cachedDefaults) {
+            return $this->cachedDefaults;
+        }
+
+        $this->framework->initialize();
+        $this->framework->getAdapter(Controller::class)->loadDataContainer('tl_user');
+
+        $defaults = [];
+
+        foreach ($GLOBALS['TL_DCA']['tl_user']['fields'] ?? [] as $field => $config) {
+            if (!\array_key_exists('default', $config)) {
+                continue;
+            }
+
+            $value = $config['default'];
+
+            if (\is_callable($value)) {
+                $value = $value();
+            }
+
+            if (\is_array($value) || \is_object($value)) {
+                $value = serialize($value);
+            }
+
+            $defaults[$field] = $value;
+        }
+
+        return $this->cachedDefaults = $defaults;
+    }
+}

--- a/core-bundle/src/Security/Authentication/ContaoStrategy.php
+++ b/core-bundle/src/Security/Authentication/ContaoStrategy.php
@@ -12,30 +12,21 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Security\Authentication;
 
-use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
-use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
-use Symfony\Component\Security\Http\FirewallMapInterface;
 
 class ContaoStrategy implements AccessDecisionStrategyInterface, \Stringable
 {
-    private int|null $contaoContextRequestId = null;
-
-    private bool|null $contaoContext = null;
-
     public function __construct(
         private readonly AccessDecisionStrategyInterface $defaultStrategy,
         private readonly AccessDecisionStrategyInterface $contaoStrategy,
-        private readonly RequestStack $requestStack,
-        private readonly FirewallMapInterface $firewallMap,
+        private readonly ContaoStrategyContext $strategyContext,
     ) {
     }
 
     public function __toString(): string
     {
-        $strategy = $this->isContaoContext() ? $this->contaoStrategy : $this->defaultStrategy;
+        $strategy = $this->strategyContext->isContaoContext() ? $this->contaoStrategy : $this->defaultStrategy;
 
         if (method_exists($strategy, '__toString')) {
             return (string) $strategy;
@@ -46,44 +37,10 @@ class ContaoStrategy implements AccessDecisionStrategyInterface, \Stringable
 
     public function decide(\Traversable $results, AccessDecision|null $accessDecision = null): bool
     {
-        if ($this->isContaoContext()) {
+        if ($this->strategyContext->isContaoContext()) {
             return $this->contaoStrategy->decide($results, $accessDecision);
         }
 
         return $this->defaultStrategy->decide($results, $accessDecision);
-    }
-
-    private function isContaoContext(): bool
-    {
-        // Use the main request here because sub-requests cannot have their own firewall
-        // in Symfony
-        $request = $this->requestStack->getMainRequest();
-
-        if (!$request || !$this->firewallMap instanceof FirewallMap) {
-            $this->contaoContextRequestId = null;
-            $this->contaoContext = false;
-
-            return false;
-        }
-
-        $requestId = spl_object_id($request);
-
-        if ($this->contaoContextRequestId === $requestId && null !== $this->contaoContext) {
-            return $this->contaoContext;
-        }
-
-        $this->contaoContextRequestId = $requestId;
-
-        $config = $this->firewallMap->getFirewallConfig($request);
-
-        if (!$config instanceof FirewallConfig) {
-            $this->contaoContext = false;
-
-            return false;
-        }
-
-        $context = $config->getContext();
-
-        return $this->contaoContext = 'contao_frontend' === $context || 'contao_backend' === $context;
     }
 }

--- a/core-bundle/src/Security/Authentication/ContaoStrategyContext.php
+++ b/core-bundle/src/Security/Authentication/ContaoStrategyContext.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Authentication;
+
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Http\FirewallMapInterface;
+
+class ContaoStrategyContext
+{
+    public const CONTEXT_BACKEND = 'contao_backend';
+
+    public const CONTEXT_FRONTEND = 'contao_frontend';
+
+    private int|null $contaoContextRequestId = null;
+
+    private string|null $contaoContext = null;
+
+    /**
+     * @var list<string>
+     */
+    private array $forcedContexts = [];
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly FirewallMapInterface $firewallMap,
+    ) {
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(): T $callback
+     *
+     * @return T
+     */
+    public function runInContext(string $context, callable $callback): mixed
+    {
+        if (!\in_array($context, [self::CONTEXT_BACKEND, self::CONTEXT_FRONTEND], true)) {
+            throw new \InvalidArgumentException(\sprintf('Invalid Contao strategy context "%s".', $context));
+        }
+
+        $this->forcedContexts[] = $context;
+
+        try {
+            return $callback();
+        } finally {
+            array_pop($this->forcedContexts);
+        }
+    }
+
+    public function isContaoContext(): bool
+    {
+        return null !== $this->getContext();
+    }
+
+    public function getContext(): string|null
+    {
+        if ([] !== $this->forcedContexts) {
+            return $this->forcedContexts[array_key_last($this->forcedContexts)];
+        }
+
+        // Use the main request here because sub-requests cannot have their own firewall
+        // in Symfony
+        $request = $this->requestStack->getMainRequest();
+
+        if (!$request || !$this->firewallMap instanceof FirewallMap) {
+            $this->contaoContextRequestId = null;
+
+            return $this->contaoContext = null;
+        }
+
+        $requestId = spl_object_id($request);
+
+        if ($this->contaoContextRequestId === $requestId) {
+            return $this->contaoContext;
+        }
+
+        $this->contaoContextRequestId = $requestId;
+        $config = $this->firewallMap->getFirewallConfig($request);
+
+        if (!$config instanceof FirewallConfig) {
+            return $this->contaoContext = null;
+        }
+
+        $context = $config->getContext();
+
+        return $this->contaoContext = \in_array($context, [self::CONTEXT_BACKEND, self::CONTEXT_FRONTEND], true) ? $context : null;
+    }
+}

--- a/core-bundle/tests/Contao/BackendUserTest.php
+++ b/core-bundle/tests/Contao/BackendUserTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao;
+
+use Contao\BackendUser;
+use Contao\Config;
+use Contao\Database;
+use Contao\Environment;
+use Contao\System;
+use Contao\TestCase\ContaoTestCase;
+use Doctrine\DBAL\Connection;
+
+class BackendUserTest extends ContaoTestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_MIME'], $GLOBALS['TL_USERNAME']);
+
+        $this->resetStaticProperties([
+            BackendUser::class,
+            Config::class,
+            Database::class,
+            Environment::class,
+            System::class,
+        ]);
+
+        parent::tearDown();
+    }
+
+    public function testCreatesUserFromData(): void
+    {
+        $container = $this->getContainerWithContaoConfiguration();
+        $container->set('database_connection', $this->createStub(Connection::class));
+
+        System::setContainer($container);
+
+        $user = BackendUser::createFromData([
+            'id' => 0,
+            'username' => 'virtual-user',
+            'admin' => false,
+            'inherit' => 'group',
+            'groups' => [],
+            'showHelp' => true,
+            'useRTE' => false,
+            'useCE' => false,
+            'doNotCollapse' => false,
+            'thumbnails' => true,
+            'backendTheme' => 'flexible',
+        ]);
+
+        $this->assertSame('virtual-user', $user->getUserIdentifier());
+        $this->assertFalse($user->isAdmin);
+        $this->assertSame([], $user->groups);
+    }
+}

--- a/core-bundle/tests/DependencyInjection/Compiler/AccessDecisionStrategyPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/AccessDecisionStrategyPassTest.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\DependencyInjection\Compiler;
 
 use Contao\CoreBundle\DependencyInjection\Compiler\AccessDecisionStrategyPass;
+use Contao\CoreBundle\Security\Authentication\ContaoStrategy;
+use Contao\CoreBundle\Security\Authentication\ContaoStrategyContext;
 use Contao\CoreBundle\Tests\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
 use Symfony\Component\Security\Core\Authorization\Strategy\PriorityStrategy;
 
@@ -44,46 +47,28 @@ class AccessDecisionStrategyPassTest extends TestCase
     public function testReplacesTheAccessDecisionStrategy(): void
     {
         $strategy = $this->createStub(AccessDecisionStrategyInterface::class);
-
-        $definition = $this->createMock(Definition::class);
-        $definition
-            ->expects($this->once())
-            ->method('getArgument')
-            ->with(1)
-            ->willReturn($strategy)
-        ;
-
-        $definition
-            ->expects($this->once())
-            ->method('replaceArgument')
-            ->with(
-                1,
-                $this->callback(
-                    static fn (Definition $definition) => $definition->getArgument(0) === $strategy
-                        && $definition->getArgument(1) instanceof Definition
-                        && PriorityStrategy::class === $definition->getArgument(1)->getClass()
-                        && 'request_stack' === (string) $definition->getArgument(2)
-                        && 'security.firewall.map' === (string) $definition->getArgument(3),
-                ),
-            )
-        ;
-
-        $container = $this->createMock(ContainerBuilder::class);
-        $container
-            ->expects($this->once())
-            ->method('hasDefinition')
-            ->with('security.access.decision_manager')
-            ->willReturn(true)
-        ;
-
-        $container
-            ->expects($this->once())
-            ->method('getDefinition')
-            ->with('security.access.decision_manager')
-            ->willReturn($definition)
-        ;
+        $container = new ContainerBuilder();
+        $container->setDefinition('security.access.decision_manager', new Definition(null, [null, $strategy]));
 
         $pass = new AccessDecisionStrategyPass();
         $pass->process($container);
+
+        $accessDecisionManager = $container->getDefinition('security.access.decision_manager');
+        $this->assertSame(
+            'contao.security.authentication.contao_strategy',
+            (string) $accessDecisionManager->getArgument(1),
+        );
+
+        $context = $container->getDefinition('contao.security.authentication.contao_strategy_context');
+        $this->assertSame(ContaoStrategyContext::class, $context->getClass());
+        $this->assertSame('request_stack', (string) $context->getArgument(0));
+        $this->assertSame('security.firewall.map', (string) $context->getArgument(1));
+
+        $contaoStrategy = $container->getDefinition('contao.security.authentication.contao_strategy');
+        $this->assertSame(ContaoStrategy::class, $contaoStrategy->getClass());
+        $this->assertSame($strategy, $contaoStrategy->getArgument(0));
+        $this->assertInstanceOf(Definition::class, $contaoStrategy->getArgument(1));
+        $this->assertSame(PriorityStrategy::class, $contaoStrategy->getArgument(1)->getClass());
+        $this->assertInstanceOf(Reference::class, $contaoStrategy->getArgument(2));
     }
 }

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -693,6 +693,9 @@ class ContaoCoreExtensionTest extends TestCase
                     'backend_search' => [
                         'dsn' => 'whatever://search-adapter-you-like',
                         'index_name' => 'my_backend_search_index',
+                        'permission_aware_facets' => [
+                            'max_groups' => 42,
+                        ],
                     ],
                 ],
             ],
@@ -707,6 +710,15 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('contao.search_backend.engine'));
         $backendSearchEngine = $container->getDefinition('contao.search_backend.engine');
         $this->assertSame('my_backend_search_index', $backendSearchEngine->getArgument(1)->getArgument('$indexName'));
+
+        $allowedGroupsResolver = $container->getDefinition('contao.search.backend.security.document_allowed_groups_resolver');
+        $this->assertSame(42, $allowedGroupsResolver->getArgument('$maxGroups'));
+
+        $documentAccessEvaluator = $container->getDefinition('contao.search.backend.security.document_access_evaluator');
+        $this->assertSame(
+            'contao.security.authentication.contao_strategy_context',
+            (string) $documentAccessEvaluator->getArgument(1),
+        );
     }
 
     public function testCspConfiguration(): void

--- a/core-bundle/tests/Search/Backend/BackendSearchTest.php
+++ b/core-bundle/tests/Search/Backend/BackendSearchTest.php
@@ -18,6 +18,7 @@ use CmsIg\Seal\Engine;
 use CmsIg\Seal\EngineInterface;
 use CmsIg\Seal\Reindex\ReindexConfig as SealReindexConfig;
 use CmsIg\Seal\Schema\Index;
+use Contao\BackendUser;
 use Contao\CoreBundle\Event\BackendSearch\EnhanceHitEvent;
 use Contao\CoreBundle\Job\Job;
 use Contao\CoreBundle\Job\Jobs;
@@ -201,14 +202,33 @@ class BackendSearchTest extends TestCase
         ;
 
         $security = $this->createMock(Security::class);
+        $user = $this->createMock(BackendUser::class);
+        $user
+            ->method('__get')
+            ->with('groups')
+            ->willReturn([1])
+        ;
+
         $security
-            ->expects($this->exactly(2))
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+        $security
+            ->expects($this->exactly(4))
             ->method('isGranted')
-            ->with(
-                ContaoCorePermissions::USER_CAN_ACCESS_BACKEND_SEARCH_DOCUMENT,
-                $this->callback(static fn (Document $document): bool => '42' === $document->getId()),
+            ->willReturnCallback(
+                function (string $attribute, mixed $subject = null): bool {
+                    if ('ROLE_ADMIN' === $attribute) {
+                        return false;
+                    }
+
+                    $this->assertSame(ContaoCorePermissions::USER_CAN_ACCESS_BACKEND_SEARCH_DOCUMENT, $attribute);
+                    $this->assertInstanceOf(Document::class, $subject);
+                    $this->assertSame('42', $subject->getId());
+
+                    return true;
+                },
             )
-            ->willReturn(true)
         ;
 
         $engine = new Engine(new MemoryAdapter(), BackendSearch::getSearchEngineSchema($indexName));
@@ -219,6 +239,7 @@ class BackendSearchTest extends TestCase
             'type' => 'type',
             'searchableContent' => 'search me',
             'tags' => ['tag-1'],
+            'allowedGroups' => [1],
             'document' => '{"id":"42","type":"type","searchableContent":"search me","tags":[],"metadata":[]}',
         ]);
 

--- a/core-bundle/tests/Search/Backend/Seal/SealReindexProviderTest.php
+++ b/core-bundle/tests/Search/Backend/Seal/SealReindexProviderTest.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Search\Backend\BackendSearch;
 use Contao\CoreBundle\Search\Backend\Document;
 use Contao\CoreBundle\Search\Backend\Provider\ProviderInterface;
 use Contao\CoreBundle\Search\Backend\Seal\SealReindexProvider;
+use Contao\CoreBundle\Search\Backend\Security\DocumentAllowedGroupsResolver;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -28,6 +29,7 @@ class SealReindexProviderTest extends TestCase
         $provider = new SealReindexProvider(
             [$this->createStub(ProviderInterface::class)],
             $this->createStub(EventDispatcherInterface::class),
+            $this->createStub(DocumentAllowedGroupsResolver::class),
         );
 
         $this->assertNull($provider->total());
@@ -46,6 +48,7 @@ class SealReindexProviderTest extends TestCase
         $provider = new SealReindexProvider(
             [$internalProvider],
             $this->createStub(EventDispatcherInterface::class),
+            $this->createStub(DocumentAllowedGroupsResolver::class),
         );
 
         $provider->provide($reindexConfig);
@@ -76,9 +79,18 @@ class SealReindexProviderTest extends TestCase
             )
         ;
 
+        $allowedGroupsResolver = $this->createMock(DocumentAllowedGroupsResolver::class);
+        $allowedGroupsResolver
+            ->expects($this->once())
+            ->method('resolveAllowedGroups')
+            ->with($internalProvider, $document)
+            ->willReturn([1, 2])
+        ;
+
         $provider = new SealReindexProvider(
             [$internalProvider],
             $eventDispatcher,
+            $allowedGroupsResolver,
         );
 
         $result = iterator_to_array($provider->provide(new SealReindexConfig()));
@@ -87,6 +99,7 @@ class SealReindexProviderTest extends TestCase
         $this->assertSame('type__42', $result[0]['id']);
         $this->assertSame('type', $result[0]['type']);
         $this->assertSame('searchable', $result[0]['searchableContent']);
+        $this->assertSame([1, 2], $result[0]['allowedGroups']);
     }
 
     public function testGetIndexReturnsCorrectValue(): void

--- a/core-bundle/tests/Search/Backend/Seal/SealUtilTest.php
+++ b/core-bundle/tests/Search/Backend/Seal/SealUtilTest.php
@@ -83,7 +83,7 @@ class SealUtilTest extends TestCase
     public function testConvertProviderDocumentForSearchIndex(): void
     {
         $document = new Document('42', 'foobar', 'searchable');
-        $document = $document->withMetadata(['meta' => 'data']);
+        $document = $document->withMetadata(['meta' => 'data', 'allowedGroups' => [1, 2]]);
         $document = $document->withTags(['tag1', 'tag2']);
 
         $this->assertSame(
@@ -95,7 +95,8 @@ class SealUtilTest extends TestCase
                     'tag1',
                     'tag2',
                 ],
-                'document' => '{"id":"42","type":"foobar","searchableContent":"searchable","tags":["tag1","tag2"],"metadata":{"meta":"data"}}',
+                'allowedGroups' => [1, 2],
+                'document' => '{"id":"42","type":"foobar","searchableContent":"searchable","tags":["tag1","tag2"],"metadata":{"meta":"data","allowedGroups":[1,2]}}',
             ],
             SealUtil::convertProviderDocumentForSearchIndex($document),
         );

--- a/core-bundle/tests/Search/Backend/Security/DocumentAccessEvaluatorTest.php
+++ b/core-bundle/tests/Search/Backend/Security/DocumentAccessEvaluatorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Search\Backend\Security;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Search\Backend\Document;
+use Contao\CoreBundle\Search\Backend\Provider\ProviderInterface;
+use Contao\CoreBundle\Search\Backend\Security\DocumentAccessEvaluator;
+use Contao\CoreBundle\Search\Backend\Security\VirtualBackendUserFactory;
+use Contao\CoreBundle\Security\Authentication\ContaoStrategyContext;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class DocumentAccessEvaluatorTest extends TestCase
+{
+    public function testEvaluatesAndCachesTheVirtualUserInAContaoContext(): void
+    {
+        $user = $this->createStub(BackendUser::class);
+        $user
+            ->method('getUserIdentifier')
+            ->willReturn('group-42')
+        ;
+
+        $factory = $this->createMock(VirtualBackendUserFactory::class);
+        $factory
+            ->expects($this->once())
+            ->method('createForGroupId')
+            ->with(42)
+            ->willReturn($user)
+        ;
+
+        $strategyContext = $this->createMock(ContaoStrategyContext::class);
+        $strategyContext
+            ->expects($this->exactly(2))
+            ->method('runInContext')
+            ->with(ContaoStrategyContext::CONTEXT_BACKEND, $this->isCallable())
+            ->willReturnCallback(static fn (string $context, callable $callback): mixed => $callback())
+        ;
+
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider
+            ->expects($this->exactly(2))
+            ->method('isDocumentGranted')
+            ->with(
+                $this->callback(
+                    static fn (TokenInterface $token): bool => 'group-42' === $token->getUser()->getUserIdentifier(),
+                ),
+                $this->isInstanceOf(Document::class),
+            )
+            ->willReturn(true)
+        ;
+
+        $evaluator = new DocumentAccessEvaluator($factory, $strategyContext);
+        $document = new Document('5', 'type', 'content');
+
+        $this->assertTrue($evaluator->isGrantedForGroup($provider, $document, 42));
+        $this->assertTrue($evaluator->isGrantedForGroup($provider, $document, 42));
+    }
+}

--- a/core-bundle/tests/Search/Backend/Security/DocumentAllowedGroupsResolverTest.php
+++ b/core-bundle/tests/Search/Backend/Security/DocumentAllowedGroupsResolverTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Search\Backend\Security;
+
+use Contao\CoreBundle\Search\Backend\Document;
+use Contao\CoreBundle\Search\Backend\Provider\ProviderInterface;
+use Contao\CoreBundle\Search\Backend\Security\DocumentAccessEvaluator;
+use Contao\CoreBundle\Search\Backend\Security\DocumentAllowedGroupsResolver;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\TestCase;
+
+class DocumentAllowedGroupsResolverTest extends TestCase
+{
+    public function testResolvesAllowedGroupsAndCachesUsers(): void
+    {
+        $connection = $this->createConnection();
+        $provider = $this->createStub(ProviderInterface::class);
+        $documentAccessEvaluator = $this->createMock(DocumentAccessEvaluator::class);
+        $documentAccessEvaluator
+            ->expects($this->exactly(4))
+            ->method('isGrantedForGroup')
+            ->willReturnCallback(
+                static fn (ProviderInterface $provider, Document $document, int $groupId): bool => 2 === $groupId,
+            )
+        ;
+
+        $resolver = new DocumentAllowedGroupsResolver($connection, $documentAccessEvaluator, 2);
+        $document = new Document('42', 'type', 'content');
+
+        $this->assertSame([2], $resolver->resolveAllowedGroups($provider, $document));
+
+        $connection->executeStatement('DROP TABLE tl_user_group');
+
+        $this->assertSame([2], $resolver->resolveAllowedGroups($provider, $document));
+    }
+
+    public function testDoesNotLimitGroupsIfConfiguredWithZero(): void
+    {
+        $provider = $this->createStub(ProviderInterface::class);
+        $documentAccessEvaluator = $this->createStub(DocumentAccessEvaluator::class);
+        $documentAccessEvaluator
+            ->method('isGrantedForGroup')
+            ->willReturn(true)
+        ;
+
+        $resolver = new DocumentAllowedGroupsResolver($this->createConnection(), $documentAccessEvaluator, 0);
+
+        $this->assertSame(
+            [1, 2, 3],
+            $resolver->resolveAllowedGroups($provider, new Document('42', 'type', 'content')),
+        );
+    }
+
+    private function createConnection(): Connection
+    {
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $connection->executeStatement('CREATE TABLE tl_user_group (id INTEGER, name VARCHAR(255), disable INTEGER, start VARCHAR(10), stop VARCHAR(10))');
+
+        foreach ([[3, 'C', 0], [1, 'A', 0], [2, 'B', 0], [4, 'D', 1]] as [$id, $name, $disable]) {
+            $connection->insert('tl_user_group', [
+                'id' => $id,
+                'name' => $name,
+                'disable' => $disable,
+                'start' => '',
+                'stop' => '',
+            ]);
+        }
+
+        return $connection;
+    }
+}

--- a/core-bundle/tests/Search/Backend/Security/VirtualBackendUserFactoryTest.php
+++ b/core-bundle/tests/Search/Backend/Security/VirtualBackendUserFactoryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Search\Backend\Security;
+
+use Contao\BackendUser;
+use Contao\Config;
+use Contao\Controller;
+use Contao\CoreBundle\Search\Backend\Security\VirtualBackendUserFactory;
+use Contao\Database;
+use Contao\Environment;
+use Contao\System;
+use Contao\TestCase\ContaoTestCase;
+use Doctrine\DBAL\Connection;
+
+class VirtualBackendUserFactoryTest extends ContaoTestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_DCA'], $GLOBALS['TL_MIME'], $GLOBALS['TL_USERNAME']);
+
+        $this->resetStaticProperties([
+            BackendUser::class,
+            Config::class,
+            Database::class,
+            Environment::class,
+            System::class,
+        ]);
+
+        parent::tearDown();
+    }
+
+    public function testCreatesUsersFromDcaDefaultsAndCachesTheDefaults(): void
+    {
+        $controllerAdapter = $this->createAdapterMock(['loadDataContainer']);
+        $controllerAdapter
+            ->expects($this->once())
+            ->method('loadDataContainer')
+            ->with('tl_user')
+            ->willReturnCallback(
+                static function (): void {
+                    $GLOBALS['TL_DCA']['tl_user']['fields'] = self::getDcaFields();
+                },
+            )
+        ;
+
+        $framework = $this->createContaoFrameworkMock([Controller::class => $controllerAdapter]);
+        $framework
+            ->expects($this->once())
+            ->method('initialize')
+        ;
+
+        $container = $this->getContainerWithContaoConfiguration();
+        $container->set('database_connection', $this->createStub(Connection::class));
+        System::setContainer($container);
+
+        $factory = new VirtualBackendUserFactory($framework);
+        $user = $factory->createForGroupId(42);
+
+        $this->assertSame('__contao_backend_search_group_42', $user->getUserIdentifier());
+        $this->assertSame([42], $user->groups);
+        $this->assertSame('computed', $user->computed);
+        $this->assertSame(['value'], $user->serialized);
+        $this->assertFalse(isset($user->withoutDefault));
+
+        $this->assertSame([43], $factory->createForGroupId(43)->groups);
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private static function getDcaFields(): array
+    {
+        return [
+            'showHelp' => ['default' => true],
+            'useRTE' => ['default' => false],
+            'useCE' => ['default' => false],
+            'doNotCollapse' => ['default' => false],
+            'thumbnails' => ['default' => true],
+            'backendTheme' => ['default' => 'flexible'],
+            'computed' => ['default' => static fn (): string => 'computed'],
+            'serialized' => ['default' => ['value']],
+            'withoutDefault' => [],
+        ];
+    }
+}

--- a/core-bundle/tests/Security/Authentication/ContaoStrategyTest.php
+++ b/core-bundle/tests/Security/Authentication/ContaoStrategyTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Security\Authentication;
 
 use Contao\CoreBundle\Security\Authentication\ContaoStrategy;
+use Contao\CoreBundle\Security\Authentication\ContaoStrategyContext;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
@@ -29,8 +30,7 @@ class ContaoStrategyTest extends TestCase
         $accessDecisionManager = new ContaoStrategy(
             $this->mockAccessDecisionStrategy(true),
             $this->mockAccessDecisionStrategy(false),
-            new RequestStack(),
-            $this->createStub(FirewallMapInterface::class),
+            new ContaoStrategyContext(new RequestStack(), $this->createStub(FirewallMapInterface::class)),
         );
 
         $accessDecisionManager->decide($this->createStub(\Traversable::class));
@@ -41,8 +41,7 @@ class ContaoStrategyTest extends TestCase
         $accessDecisionManager = new ContaoStrategy(
             $this->mockAccessDecisionStrategy(true),
             $this->mockAccessDecisionStrategy(false),
-            new RequestStack(),
-            $this->createStub(FirewallMap::class),
+            new ContaoStrategyContext(new RequestStack(), $this->createStub(FirewallMap::class)),
         );
 
         $accessDecisionManager->decide($this->createStub(\Traversable::class));
@@ -55,8 +54,7 @@ class ContaoStrategyTest extends TestCase
         $accessDecisionManager = new ContaoStrategy(
             $this->mockAccessDecisionStrategy(true),
             $this->mockAccessDecisionStrategy(false),
-            $requestStack,
-            $this->createStub(FirewallMap::class),
+            new ContaoStrategyContext($requestStack, $this->createStub(FirewallMap::class)),
         );
 
         $accessDecisionManager->decide($this->createStub(\Traversable::class));
@@ -69,8 +67,7 @@ class ContaoStrategyTest extends TestCase
         $accessDecisionManager = new ContaoStrategy(
             $this->mockAccessDecisionStrategy(false),
             $this->mockAccessDecisionStrategy(true),
-            $requestStack,
-            $this->mockFirewallMap('contao_frontend'),
+            new ContaoStrategyContext($requestStack, $this->mockFirewallMap('contao_frontend')),
         );
 
         $accessDecisionManager->decide($this->createStub(\Traversable::class));
@@ -83,11 +80,74 @@ class ContaoStrategyTest extends TestCase
         $accessDecisionManager = new ContaoStrategy(
             $this->mockAccessDecisionStrategy(false),
             $this->mockAccessDecisionStrategy(true),
-            $requestStack,
-            $this->mockFirewallMap('contao_backend'),
+            new ContaoStrategyContext($requestStack, $this->mockFirewallMap('contao_backend')),
         );
 
         $accessDecisionManager->decide($this->createStub(\Traversable::class));
+    }
+
+    public function testCanForceTheContaoStrategyWithoutARequest(): void
+    {
+        $strategyContext = new ContaoStrategyContext(new RequestStack(), $this->createStub(FirewallMap::class));
+        $accessDecisionManager = new ContaoStrategy(
+            $this->mockAccessDecisionStrategy(false),
+            $this->mockAccessDecisionStrategy(true),
+            $strategyContext,
+        );
+
+        $strategyContext->runInContext(
+            ContaoStrategyContext::CONTEXT_BACKEND,
+            fn () => $accessDecisionManager->decide($this->createStub(\Traversable::class)),
+        );
+    }
+
+    public function testRestoresTheContextIfTheCallbackThrows(): void
+    {
+        $strategyContext = new ContaoStrategyContext(new RequestStack(), $this->createStub(FirewallMap::class));
+
+        try {
+            $strategyContext->runInContext(
+                ContaoStrategyContext::CONTEXT_BACKEND,
+                static function (): void {
+                    throw new \RuntimeException();
+                },
+            );
+        } catch (\RuntimeException) {
+            // Expected
+        }
+
+        $this->assertFalse($strategyContext->isContaoContext());
+        $this->assertNull($strategyContext->getContext());
+    }
+
+    public function testCanNestExplicitContexts(): void
+    {
+        $strategyContext = new ContaoStrategyContext(new RequestStack(), $this->createStub(FirewallMap::class));
+
+        $contexts = $strategyContext->runInContext(
+            ContaoStrategyContext::CONTEXT_BACKEND,
+            static fn (): array => [
+                $strategyContext->getContext(),
+                $strategyContext->runInContext(
+                    ContaoStrategyContext::CONTEXT_FRONTEND,
+                    static fn (): string|null => $strategyContext->getContext(),
+                ),
+                $strategyContext->getContext(),
+            ],
+        );
+
+        $this->assertSame(['contao_backend', 'contao_frontend', 'contao_backend'], $contexts);
+        $this->assertNull($strategyContext->getContext());
+    }
+
+    public function testRejectsInvalidExplicitContext(): void
+    {
+        $strategyContext = new ContaoStrategyContext(new RequestStack(), $this->createStub(FirewallMap::class));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid Contao strategy context "invalid".');
+
+        $strategyContext->runInContext('invalid', static fn (): null => null);
     }
 
     private function mockAccessDecisionStrategy(bool $shouldBeCalled): AccessDecisionStrategyInterface&MockObject


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/9424 (or "fixes", it implements idea number 3 of that ticket).

In simple images that's now:

<img width="1012" height="469" alt="Bildschirmfoto 2026-07-31 um 11 16 00" src="https://github.com/user-attachments/assets/ccec4a96-13e3-4972-89e3-6c32b8bf64d3" />

and that's after this PR:

<img width="904" height="621" alt="Bildschirmfoto 2026-07-31 um 14 42 39" src="https://github.com/user-attachments/assets/9cd23156-cf59-4bb8-8339-5b8af09733e1" />

So when indexing, we just index every document for the first 10 (currently, we can experiment and later increase that value) user groups with a virtual user that belongs to just that group. If it has access, it becomes part of the `allowedGroups` property we add to every document. When searching, we add the groups of the currently logged in user and that's it.

The main obstacles in this PR are not really the backend search stuff but the concept of 

- creating a virtual user with only one group
- forcing the `contao_backend` security context. Currently we only apply the `ContaoStrategy` which is a `AccessDecisionStrategyInterface` only if we are in the Contao backend which is based on the current request. This is to ensure we don't interfere with the access decision managers and their voting strategy for stuff that is not happening in either the Contao backend or frontend. However, when you are on CLI (and you are when indexing search documents), there is no request. So we need a way to force a given execution context. I've introduced a `ContaoStrategyContext` for that. It basically does the existing logic but also allows to force either `CONTEXT_BACKEND` or `CONTEXT_FRONTEND` which I made constants. That way, we can force access decision to happen in the backend context even on CLI.