### PR TITLE
Do not render an empty row in the row wizard if all values are `null`

### DIFF
--- a/core-bundle/contao/widgets/RowWizard.php
+++ b/core-bundle/contao/widgets/RowWizard.php
@@ -162,6 +162,11 @@ class RowWizard extends Widget
 			$valuesEmpty = true;
 		}
 
+		// Make sure empty values do not generate an extra row (see #10073)
+		if (\count($this->varValue) === 1 && count(array_filter($this->varValue[0], fn($v) => $v !== null)) === 0) {
+			$valuesEmpty = true;
+		}
+
 		// Populate the rows if the initial count has not been reached
 		if (null !== $this->min)
 		{

--- a/core-bundle/contao/widgets/RowWizard.php
+++ b/core-bundle/contao/widgets/RowWizard.php
@@ -163,7 +163,8 @@ class RowWizard extends Widget
 		}
 
 		// Make sure empty values do not generate an empty row (see #10073)
-		if (\count($this->varValue) === 1 && count(array_filter($this->varValue[0], fn($v) => $v !== null)) === 0) {
+		if (\count($this->varValue) === 1 && \count(array_filter($this->varValue[0], static fn ($v) => $v !== null)) === 0)
+		{
 			$valuesEmpty = true;
 		}
 

--- a/core-bundle/contao/widgets/RowWizard.php
+++ b/core-bundle/contao/widgets/RowWizard.php
@@ -162,7 +162,7 @@ class RowWizard extends Widget
 			$valuesEmpty = true;
 		}
 
-		// Make sure empty values do not generate an extra row (see #10073)
+		// Make sure empty values do not generate an empty row (see #10073)
 		if (\count($this->varValue) === 1 && count(array_filter($this->varValue[0], fn($v) => $v !== null)) === 0) {
 			$valuesEmpty = true;
 		}


### PR DESCRIPTION
### Description

- fixes #10057

This PR passes `values_empty` to the template if only one row exists and all values are null, hence not rendering the extra row.
