### PR TITLE
Include `#tl_search` in the element count of the filter button

### DIFF
--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -657,7 +657,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				data-contao--toggle-nodes-expand-all-title-value="' . $GLOBALS['TL_LANG']['DCA']['expandNodes'][1] . '"
 				data-contao--toggle-nodes-collapse-all-value="' . $GLOBALS['TL_LANG']['DCA']['collapseNodes'][0] . '"
 				data-contao--toggle-nodes-collapse-all-title-value="' . $GLOBALS['TL_LANG']['DCA']['collapseNodes'][1] . '"
-				' . ($panel ? 'data-contao--element-count-selector-value=".active:not(#tl_search_term,#tl_limit)"' : '') . '
+				' . ($panel ? 'data-contao--element-count-selector-value=".active:not(#tl_limit)"' : '') . '
 			>' . $return . '</div>';
 	}
 

--- a/core-bundle/contao/templates/twig/backend/data_container/table/show_all.html.twig
+++ b/core-bundle/contao/templates/twig/backend/data_container/table/show_all.html.twig
@@ -3,7 +3,7 @@
 {% set attributes = attrs()
     .addClass('tl_show_all')
     .set('data-controller', 'contao--element-count', panel)
-    .set('data-contao--element-count-selector-value', '.active:not(#tl_search_term,#tl_limit)', panel)
+    .set('data-contao--element-count-selector-value', '.active:not(#tl_limit)', panel)
 %}
 <div{{ attributes }}>
     {{ panel|raw }}


### PR DESCRIPTION
### Description

- fixes #9877

`#tl_search_termn` has been excluded since the beginning in #9160 as search semantically doesn't count as a filter but it makes sense to add it.