### PR TITLE
Prevent array-to-string warnings in JSON-LD context definitions

### DIFF
--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -240,6 +240,10 @@ class Document
 
         if (\is_array($data['@context'])) {
             foreach ($data['@context'] as $prefix => $context) {
+                if (!\is_string($prefix) || !\is_string($context)) {
+                    continue;
+                }
+
                 if (isset($data['@type']) && 0 === strncmp($data['@type'], $prefix.':', \strlen((string) $prefix) + 1)) {
                     $data['@type'] = $context.substr($data['@type'], \strlen((string) $prefix) + 1);
                 }

--- a/core-bundle/tests/Search/DocumentTest.php
+++ b/core-bundle/tests/Search/DocumentTest.php
@@ -283,6 +283,22 @@ class DocumentTest extends TestCase
             ],
             '',
         ];
+
+        yield 'Test with an object context definition' => [
+            '<html><body><script type="application/ld+json">{"@context":{"schema":{"@id":"https:\/\/schema.org\/"}},"@type":"schema:WebPage","schema:name":"Foobar"}</script></body></html>',
+            [
+                [
+                    '@context' => [
+                        'schema' => [
+                            '@id' => 'https://schema.org/',
+                        ],
+                    ],
+                    '@type' => 'schema:WebPage',
+                    'schema:name' => 'Foobar',
+                ],
+            ],
+            '',
+        ];
     }
 
     public function testDoesNotExtractTheJsdonLdScriptIfTheContextOrTypeDoesNotMatch(): void


### PR DESCRIPTION
Skip non-string JSON-LD context definitions to prevent array-to-string warnings.