### PR TITLE
Support string UUIDs for `posterSRC` in the player element

### DIFF
--- a/core-bundle/src/Controller/ContentElement/PlayerController.php
+++ b/core-bundle/src/Controller/ContentElement/PlayerController.php
@@ -23,6 +23,7 @@ use Contao\CoreBundle\Filesystem\VirtualFilesystem;
 use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\StringUtil;
+use Contao\Validator;
 use Psr\Http\Message\UriInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -82,7 +83,7 @@ class PlayerController extends AbstractContentElementController
         $poster = null;
 
         if ($uuid = $model->posterSRC) {
-            $poster = $this->filesStorage->generatePublicUri(Uuid::fromBinary($uuid));
+            $poster = $this->filesStorage->generatePublicUri(Validator::isStringUuid($uuid) ? Uuid::fromString($uuid) : Uuid::fromBinary($uuid));
         }
 
         $size = StringUtil::deserialize($model->playerSize, true);


### PR DESCRIPTION
Although this is not a direct case when element is created in the database, it may fail when inserted via Twig function and with string UUID for poster:

```twig
{{ content_element('player', {
    playerSRC: ['b3deb9ac-8fd4-11f1-b902-e8e0a8a74f95'],
    playerOptions: ['player_autoplay', 'player_nocontrols', 'player_playsinline', 'player_muted', 'player_loop'],
    posterSRC: ['a37d63bc-cee1-4ace-a4d0-573f95eb5dbf'],
}) }}
```
