### PR TITLE
Use `NodeCaptureInterface` for `AddNode`

### DIFF
--- a/core-bundle/src/Twig/ResponseContext/AddNode.php
+++ b/core-bundle/src/Twig/ResponseContext/AddNode.php
@@ -15,13 +15,13 @@ namespace Contao\CoreBundle\Twig\ResponseContext;
 use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Node\Node;
-use Twig\Node\NodeOutputInterface;
+use Twig\Node\NodeCaptureInterface;
 
 /**
  * @experimental
  */
 #[YieldReady]
-final class AddNode extends Node implements NodeOutputInterface
+final class AddNode extends Node implements NodeCaptureInterface
 {
     public function __construct(string $extensionName, Node $body, string|null $identifier, DocumentLocation $location, int $lineno)
     {


### PR DESCRIPTION
Currently you cannot do the following:

```twig
{# templates/form_wrapper.html.twig #}
{% extends '@Contao/form_wrapper.html.twig' %}

{% add 'foobar' to stylesheets %}
    <!-- foo -->
{% endadd %}
```

i.e. you want add something to the response context in a template where the original template has no blocks.

Twig will complain:

> A template that extends another one cannot include content outside Twig blocks. Did you forget to put the content inside a {% block %} tag in @Contao/form_wrapper.html.twig at line 4?

But `{% add … %}` should be usable with any template and outside of blocks, since it doesn't actually output anything - just like `{% set … %}` for example. This PR fixes that by switching that node to the `NodeCaptureInterface`.