### PR TITLE
Do not deprecate `Input::get()` for dynamic URL parameters like `auto_item`

### DIFF
--- a/core-bundle/contao/library/Contao/Input.php
+++ b/core-bundle/contao/library/Contao/Input.php
@@ -124,11 +124,15 @@ class Input
 	 *
 	 * @return array|string|null The cleaned variable value
 	 *
-	 * @deprecated Deprecated since Contao 6.0, to be removed in Contao 7.
+	 * @deprecated Deprecated since Contao 6.0, to be removed in Contao 7. Except for dynamic URL parameters like auto_item.
 	 */
 	public static function get($strKey, $blnDecodeEntities=false, $blnKeepUnusedRouteParameter=false)
 	{
-		DeprecationHelper::triggerIfCalledFromOutside('contao/core-bundle', '6.0', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the request object instead.', __METHOD__);
+		// Using Input::get() for dynamic URL parameters like auto_item is not yet deprecated
+		if ('auto_item' !== $strKey && !isset(self::$arrUnusedRouteParameters[$strKey]))
+		{
+			DeprecationHelper::triggerIfCalledFromOutside('contao/core-bundle', '6.0', 'Using "%s()" is deprecated and will no longer work in Contao 7. Use the request object instead.', __METHOD__);
+		}
 
 		$varValue = static::findGet($strKey);
 


### PR DESCRIPTION
Since dynamic URL parameters like `auto_item` are not deprecated yet, we cannot deprecate `Input::get('auto_item')`

See also https://github.com/contao/contao/pull/9944#issuecomment-4848433887