### PR TITLE
Paste items directly when the target is unambiguous

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -479,6 +479,13 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 			$children = Input::get('children');
 
+			// Backwards compatibility
+			if (Input::get('childs') !== null)
+			{
+				trigger_deprecation('contao/core-bundle', '5.3', 'Using the "childs" query parameter is deprecated and will no longer work in Contao 7. Use the "children" parameter instead.');
+				$children = Input::get('childs');
+			}
+
 			// Paste directly if the target is unambiguous (see #10103)
 			if (
 				$mode === ClipboardManager::MODE_COPY
@@ -490,13 +497,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				&& Database::getInstance()->prepare("SELECT COUNT(*) AS count FROM " . $this->ptable)->execute()->count == 1
 			) {
 				$this->redirect(Backend::addToUrl('act=copy&mode=' . self::PASTE_INTO . '&pid=' . $this->currentPid, false, array('mode')));
-			}
-
-			// Backwards compatibility
-			if (Input::get('childs') !== null)
-			{
-				trigger_deprecation('contao/core-bundle', '5.3', 'Using the "childs" query parameter is deprecated and will no longer work in Contao 7. Use the "children" parameter instead.');
-				$children = Input::get('childs');
 			}
 
 			System::getContainer()->get('contao.data_container.clipboard_manager')->set($this->strTable, Input::get('id'), $children, Input::get('mode'));

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -473,9 +473,24 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		// Add to clipboard
 		if (Input::get('act') == 'paste')
 		{
-			$this->denyAccessUnlessGranted(...$this->getClipboardPermission(Input::get('mode'), (int) Input::get('id')));
+			$mode = Input::get('mode');
+
+			$this->denyAccessUnlessGranted(...$this->getClipboardPermission($mode, (int) Input::get('id')));
 
 			$children = Input::get('children');
+
+			// Paste directly if the target is unambiguous (see #10103)
+			if (
+				$mode === ClipboardManager::MODE_COPY
+				&& !$children
+				&& $this->ptable
+				&& $this->currentPid
+				&& !($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
+				&& ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'][0] ?? null) != 'sorting'
+				&& Database::getInstance()->prepare("SELECT COUNT(*) AS count FROM " . $this->ptable)->execute()->count == 1
+			) {
+				$this->redirect(Backend::addToUrl('act=copy&mode=' . self::PASTE_INTO . '&pid=' . $this->currentPid, false, array('mode')));
+			}
 
 			// Backwards compatibility
 			if (Input::get('childs') !== null)


### PR DESCRIPTION
### Description

Implements #2826 with the outlined logic from https://github.com/contao/contao/issues/2826#issuecomment-815910749 and just pastes directly.

Logically, the PR would apply to the following tables right now (have ptable and no dynamic ptable, dont have sorting)

- tl_module
- tl_news
- tl_calendar_events

One caveat or rather known limitation I could be thinking of right now is the count for the parent table doesn't include a permission check for the explicit user (imho too much to check right now) so it would just show the `paste into` button instead of pasting directly.