### PR TITLE
Allow searching for meta information in `DC_Folder`

### DIFF
--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -3220,7 +3220,8 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			}
 			else
 			{
-				$strLabel = match ($field) {
+				$strLabel = match ($field)
+				{
 					'name' => 'MSC.name',
 					'uuid' => 'MSC.fileUuid',
 					default => $this->strTable . '.' . $field . '.0',

--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -396,7 +396,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 
 				$strField = $session['search'][$this->strTable]['field'] ?? 'name';
 
-				if (!\in_array($strField, array('name', 'meta.title', 'meta.alt', 'meta.link', 'meta.caption', 'meta.license'), true))
+				if ('uuid' === $strField || !\in_array($strField, $this->getSearchFields(), true))
 				{
 					$strField = 'name';
 				}
@@ -3157,6 +3157,27 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 	}
 
 	/**
+	 * Return searchable fields
+	 *
+	 * @return array
+	 */
+	protected function getSearchFields()
+	{
+		$arrFields = array('name', 'uuid');
+		$arrMeta = array('meta.title', 'meta.alt', 'meta.link', 'meta.caption', 'meta.license');
+
+		foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'] as $field => $config)
+		{
+			if (($config['search'] ?? null) && !\in_array($field, $arrFields, true))
+			{
+				$arrFields[] = $field;
+			}
+		}
+
+		return array_merge($arrFields, $arrMeta);
+	}
+
+	/**
 	 * Return a search form that allows to search results using regular expressions
 	 *
 	 * @return string
@@ -3166,7 +3187,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 		$objSessionBag = System::getContainer()->get('request_stack')->getSession()->getBag('contao_backend');
 
 		$session = $objSessionBag->all();
-		$searchFields = array('name', 'uuid', 'meta.title', 'meta.alt', 'meta.link', 'meta.caption', 'meta.license');
+		$searchFields = $this->getSearchFields();
 
 		// Store search value in the current session
 		if (Input::post('FORM_SUBMIT') == 'tl_filters')
@@ -3199,7 +3220,12 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			}
 			else
 			{
-				$strLabel = 'uuid' === $field ? 'MSC.fileUuid' : 'MSC.' . $field;
+				$strLabel = match ($field) {
+					'name' => 'MSC.name',
+					'uuid' => 'MSC.fileUuid',
+					default => $this->strTable . '.' . $field . '.0',
+				};
+
 				$strGroup = 'MSC.field';
 			}
 

--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -405,7 +405,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				if (str_contains($strField, 'meta.'))
 				{
 					list($strField, $strSubField) = explode('.', $strField, 2);
-					$for = preg_quote($strSubField) . '";s:[0-9]+:"[^"]*' . $for;
+					$for = preg_quote($strSubField, '/') . '";s:[0-9]+:"[^"]*' . $for;
 				}
 
 				$strPattern = "LOWER(CAST(" . Database::getInstance()->quoteIdentifier($strField) . " AS CHAR)) REGEXP LOWER(?)";

--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -3192,13 +3192,22 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 
 		foreach ($searchFields as $field)
 		{
-			$strMetaField = str_contains($field, 'meta.') ?: '';
+			if (str_contains($field, 'meta.'))
+			{
+				$strLabel = 'MSC.aw_' . explode('.', $field)[1];
+				$strGroup = $this->strTable . '.' . explode('.', $field)[0] . '.0';
+			}
+			else
+			{
+				$strLabel = 'uuid' === $field ? 'MSC.fileUuid' : 'MSC.' . $field;
+				$strGroup = 'MSC.field';
+			}
 
 			$options[] = array(
 				'value' => $field,
 				'selected' => $strSelected === $field,
-				'label' => $translator->trans($strMetaField ? 'MSC.aw_' . substr($strMetaField, 1) : ('uuid' === $field ? 'MSC.fileUuid' : 'MSC.' . $field), array(), 'contao_default'),
-				'group' => $translator->trans($strMetaField ? $this->strTable . '.' . strstr($field, '.', true) . '.0' : 'MSC.field', array(), 'contao_default'),
+				'label' => $translator->trans($strLabel, array(), 'contao_default'),
+				'group' => $translator->trans($strGroup, array(), 'contao_default'),
 			);
 		}
 

--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -394,7 +394,21 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 					$for = preg_quote($for, null);
 				}
 
-				$strPattern = "LOWER(CAST(name AS CHAR)) REGEXP LOWER(?)";
+				$strField = $session['search'][$this->strTable]['field'] ?? 'name';
+
+				if (!\in_array($strField, array('name', 'meta.title', 'meta.alt', 'meta.link', 'meta.caption', 'meta.license'), true))
+				{
+					$strField = 'name';
+				}
+
+				// Regex search serialized meta field
+				if (str_contains($strField, 'meta.'))
+				{
+					list($strField, $strSubField) = explode('.', $strField, 2);
+					$for = preg_quote($strSubField) . '";s:[0-9]+:"[^"]*' . $for;
+				}
+
+				$strPattern = "LOWER(CAST(" . Database::getInstance()->quoteIdentifier($strField) . " AS CHAR)) REGEXP LOWER(?)";
 
 				$objRoot = $db
 					->prepare("SELECT path, type, extension FROM " . $this->strTable . " WHERE " . $strPattern)
@@ -3152,7 +3166,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 		$objSessionBag = System::getContainer()->get('request_stack')->getSession()->getBag('contao_backend');
 
 		$session = $objSessionBag->all();
-		$searchFields = array('name', 'uuid');
+		$searchFields = array('name', 'uuid', 'meta.title', 'meta.alt', 'meta.link', 'meta.caption', 'meta.license');
 
 		// Store search value in the current session
 		if (Input::post('FORM_SUBMIT') == 'tl_filters')
@@ -3173,39 +3187,33 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 		}
 
 		$options = array();
+		$strSelected = $session['search'][$this->strTable]['field'] ?? null;
+		$translator = System::getContainer()->get('translator');
 
 		foreach ($searchFields as $field)
 		{
-			$option_label = $field;
+			$strMetaField = str_contains($field, 'meta.') ?: '';
 
-			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label']))
-			{
-				$option_label = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label']) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'];
-			}
-			elseif (isset($GLOBALS['TL_LANG']['MSC'][$field]))
-			{
-				$option_label = \is_array($GLOBALS['TL_LANG']['MSC'][$field]) ? $GLOBALS['TL_LANG']['MSC'][$field][0] : $GLOBALS['TL_LANG']['MSC'][$field];
-			}
-
-			$options[] = '  <option value="' . StringUtil::specialchars($field) . '"' . ((($session['search'][$this->strTable]['field'] ?? null) === $field) ? ' selected="selected"' : '') . '>' . $option_label . '</option>';
+			$options[] = array(
+				'value' => $field,
+				'selected' => $strSelected === $field,
+				'label' => $translator->trans($strMetaField ? 'MSC.aw_' . substr($strMetaField, 1) : ('uuid' === $field ? 'MSC.fileUuid' : 'MSC.' . $field), array(), 'contao_default'),
+				'group' => $translator->trans($strMetaField ? $this->strTable . '.' . strstr($field, '.', true) . '.0' : 'MSC.field', array(), 'contao_default'),
+			);
 		}
 
 		$active = isset($session['search'][$this->strTable]['value']) && (string) $session['search'][$this->strTable]['value'] !== '';
 
 		$this->setPanelState($active);
 
-		return '
-    <fieldset class="tl_search tl_subpanel">
-      <legend>' . $GLOBALS['TL_LANG']['MSC']['search'] . '</legend>
-      <label for="tl_search">' . $GLOBALS['TL_LANG']['MSC']['field'] . '</label>
-      <div class="tl_select_wrapper" data-controller="contao--choices">
-          <select id="tl_search" name="tl_search" class="tl_select">
-            ' . implode("\n", $options) . '
-          </select>
-      </div>
-      <label for="tl_search_term">' . $GLOBALS['TL_LANG']['MSC']['keyword'] . '</label>
-      <input id="tl_search_term" type="search" name="tl_value" class="tl_text' . ($active ? ' active' : '') . '" value="' . StringUtil::specialchars($session['search'][$this->strTable]['value'] ?? '') . '">
-    </fieldset>';
+		return System::getContainer()
+			->get('twig')
+			->render('@Contao/backend/data_container/table/menu/search.html.twig', array(
+				'options' => $options,
+				'active' => $active,
+				'value' => $session['search'][$this->strTable]['value'] ?? '',
+			))
+		;
 	}
 
 	/**

--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -408,7 +408,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 					$for = preg_quote($strSubField, '/') . '";s:[0-9]+:"[^"]*' . $for;
 				}
 
-				$strPattern = "LOWER(CAST(" . Database::getInstance()->quoteIdentifier($strField) . " AS CHAR)) REGEXP LOWER(?)";
+				$strPattern = "LOWER(CAST(" . Database::quoteIdentifier($strField) . " AS CHAR)) REGEXP LOWER(?)";
 
 				$objRoot = $db
 					->prepare("SELECT path, type, extension FROM " . $this->strTable . " WHERE " . $strPattern)

--- a/core-bundle/contao/templates/backend/data_container/table/menu/_select.html.twig
+++ b/core-bundle/contao/templates/backend/data_container/table/menu/_select.html.twig
@@ -5,6 +5,7 @@
     .set('data-controller', 'contao--choices')
 %}
 <div{{ select_wrapper_attributes }}>
+    {% set group = null %}
     {% set select_attributes = attrs()
         .set('name', name)
         .set('id', name)
@@ -15,6 +16,11 @@
     %}
     <select{{ select_attributes }}>
         {% for option in options %}
+            {% if option.group|default != group %}
+                {% if group %}</optgroup>{% endif %}
+                {% set group = option.group|default %}
+                {% if group %}<optgroup label="{{ group }}">{% endif %}
+            {% endif %}
             {% set option_attributes = attrs()
                 .set('value', option.value)
                 .set('selected', option.selected)
@@ -22,6 +28,7 @@
             {% block option %}
                 <option{{ option_attributes }}>{{ option.label }}</option>
             {% endblock %}
+            {% if loop.last and group %}</optgroup>{% endif %}
         {% endfor %}
     </select>
 </div>


### PR DESCRIPTION
### Description

- implements #610

This PR allows searching for meta information within `DC_Folder` and also allows adding searching for fields using the flag `search` (as in DC_Table).

Also unlocks `'search' => true` for own fields.

Mind that I also introduce optgroups into `_select.html.twig` as we want to group meta fields differently ☺️ (all fields with `'search' => true` land in the `field` group.

<img width="304" height="292" alt="Bildschirmfoto 2026-08-08 um 14 12 02" src="https://github.com/user-attachments/assets/cbef1674-42b7-4316-8434-839ae134bb7d" />

The regex searches inside `metadata` and basically checks for a the leading `subfield` and then the coming value inside. Quoting the identifier as well to match DC_Table and as I had a shitty experience with an extension that didn't quote reserved groups but w/e.


<img width="652" height="510" alt="Bildschirmfoto 2026-08-08 um 14 11 13" src="https://github.com/user-attachments/assets/9de434f4-3734-4bcb-9153-caaed7114847" />
<img width="670" height="494" alt="Bildschirmfoto 2026-08-08 um 14 11 47" src="https://github.com/user-attachments/assets/1d26f9a6-3f68-4bae-ad3d-59c664927aee" />
<img width="1473" height="339" alt="Bildschirmfoto 2026-08-08 um 14 11 25" src="https://github.com/user-attachments/assets/55153ca0-d160-4f4b-93c7-c7c0d2e9fe04" />
<img width="1466" height="364" alt="Bildschirmfoto 2026-08-08 um 14 11 54" src="https://github.com/user-attachments/assets/292ad797-e667-4d49-84f4-938902e32428" />

