### PR TITLE
Allow mocking the date within the preview mode

### DIFF
--- a/core-bundle/config/controller.yaml
+++ b/core-bundle/config/controller.yaml
@@ -57,6 +57,7 @@ services:
             - '@security.helper'
             - '@security.authenticator.firewall_aware_login_link_handler'
             - '@uri_signer'
+            - '@contao.security.token_checker'
         tags:
             - controller.service_arguments
 

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -580,6 +580,12 @@ services:
             - '@router'
             - '@uri_signer'
 
+    contao.listener.preview_time:
+        class: Contao\CoreBundle\EventListener\PreviewTimeListener
+        arguments:
+            - '@contao.security.token_checker'
+            - '@clock'
+
     contao.listener.preview_toolbar:
         class: Contao\CoreBundle\EventListener\PreviewToolbarListener
         arguments:

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -480,6 +480,7 @@ services:
         class: Contao\CoreBundle\EventListener\MakeResponsePrivateListener
         arguments:
             - '@contao.routing.scope_matcher'
+            - '@contao.security.token_checker'
 
     contao.listener.menu.backend_breadcrumb:
         class: Contao\CoreBundle\EventListener\Menu\BackendBreadcrumbListener

--- a/core-bundle/contao/dca/tl_preview_link.php
+++ b/core-bundle/contao/dca/tl_preview_link.php
@@ -60,7 +60,7 @@ $GLOBALS['TL_DCA']['tl_preview_link'] = array
 	// Palettes
 	'palettes' => array
 	(
-		'default'                     => '{url_legend},url;{config_legend},showUnpublished,restrictToUrl,expiresAt,createdAt;{publishing_legend},published',
+		'default'                     => '{url_legend},url;{config_legend},showUnpublished,restrictToUrl,expiresAt,previewTime,createdAt;{publishing_legend},published',
 	),
 
 	// Fields
@@ -107,6 +107,13 @@ $GLOBALS['TL_DCA']['tl_preview_link'] = array
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'readonly'=>true, 'doNotCopy'=>true, 'tl_class'=>'w50'),
 			'sql'                     => array('type'=>'integer', 'unsigned'=>true, 'default'=>0)
+		),
+		'previewTime' => array
+		(
+			'exclude'                 => false,
+			'inputType'               => 'text',
+			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'expiresAt' => array
 		(

--- a/core-bundle/contao/elements/ContentElement.php
+++ b/core-bundle/contao/elements/ContentElement.php
@@ -284,7 +284,10 @@ abstract class ContentElement extends Frontend
 			return true;
 		}
 
-		$isInvisible = $this->invisible || ($this->start && $this->start > time()) || ($this->stop && $this->stop <= time());
+		// Same time as within the Model (see #10108)
+		$time = Date::floorToMinute();
+
+		$isInvisible = $this->invisible || ($this->start && $this->start > $time) || ($this->stop && $this->stop <= $time);
 
 		// The element is visible, so show it
 		if (!$isInvisible)

--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -2414,6 +2414,9 @@
       <trans-unit id="MSC.scrollRight">
         <source>Scroll right</source>
       </trans-unit>
+      <trans-unit id="MSC.previewTime">
+        <source>Time</source>
+      </trans-unit>
       <trans-unit id="UNITS.0">
         <source>Byte</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_preview_link.xlf
+++ b/core-bundle/contao/languages/en/tl_preview_link.xlf
@@ -14,6 +14,12 @@
       <trans-unit id="tl_preview_link.showUnpublished.1">
         <source>Show unpublished pages and elements when sharing this link.</source>
       </trans-unit>
+      <trans-unit id="tl_preview_link.previewTime.0">
+        <source>Preview time</source>
+      </trans-unit>
+      <trans-unit id="tl_preview_link.previewTime.1">
+        <source>Show the preview at a specific date and time.</source>
+      </trans-unit>
       <trans-unit id="tl_preview_link.restrictToUrl.0">
         <source>Restrict access to specified URL</source>
       </trans-unit>

--- a/core-bundle/contao/library/Contao/Date.php
+++ b/core-bundle/contao/library/Contao/Date.php
@@ -628,7 +628,7 @@ class Date
 	{
 		if ($intTime === null)
 		{
-			// Get time from the clock component (see #10110)
+			// Get time from the clock component (see #10108)
 			$intTime = Clock::get()->now()->getTimestamp();
 		}
 

--- a/core-bundle/contao/library/Contao/Date.php
+++ b/core-bundle/contao/library/Contao/Date.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Symfony\Component\Clock\Clock;
+
 /**
  * Converts dates and date format string
  *
@@ -626,7 +628,8 @@ class Date
 	{
 		if ($intTime === null)
 		{
-			$intTime = time();
+			// Get time from the clock component (see #10110)
+			$intTime = Clock::get()->now()->getTimestamp();
 		}
 
 		return $intTime - ($intTime % 60);

--- a/core-bundle/contao/modules/ModuleArticle.php
+++ b/core-bundle/contao/modules/ModuleArticle.php
@@ -81,7 +81,10 @@ class ModuleArticle extends Module
 
 	protected function isHidden()
 	{
-		$isUnpublished = !$this->published || ($this->start && $this->start > time()) || ($this->stop && $this->stop <= time());
+		// Same time as within the Model (see #10108)
+		$time = Date::floorToMinute();
+
+		$isUnpublished = !$this->published || ($this->start && $this->start > $time) || ($this->stop && $this->stop <= $time);
 
 		// The article is published, so show it
 		if (!$isUnpublished)

--- a/core-bundle/contao/templates/frontend_preview/toolbar.html.twig
+++ b/core-bundle/contao/templates/frontend_preview/toolbar.html.twig
@@ -34,6 +34,11 @@
                         </div>
                     {% endif %}
                     <div>
+                        <label for="ctrl_preview_time">{{ 'MSC.previewTime'|trans }}:</label>
+                        <input type="datetime-local" name="previewTime" id="ctrl_preview_time" class="tl_text" value="{{ previewTime }}">
+                        <button type="button" id="ctrl_preview_time_reset" class="tl_submit">{{ 'MSC.reset'|trans }}</button>
+                    </div>
+                    <div>
                         <label for="ctrl_unpublished">{{ 'MSC.hiddenElements'|trans }}:</label>
                         <select name="unpublished" id="ctrl_unpublished" class="tl_select">
                             <option value="hide">{{ 'MSC.hiddenHide'|trans }}</option>

--- a/core-bundle/contao/templates/frontend_preview/toolbar_js.html.twig
+++ b/core-bundle/contao/templates/frontend_preview/toolbar_js.html.twig
@@ -128,7 +128,8 @@
                 margin: 0 3px 0 0;
             }
 
-            .cto-toolbar input[type="text"] {
+            .cto-toolbar input[type="text"],
+            .cto-toolbar input[type="datetime-local"] {
                 margin: 0;
                 width: auto;
                 box-sizing: border-box;
@@ -285,6 +286,12 @@
                 }
 
                 const userField = form.querySelector('input[name="user"]');
+                const timeField = form.querySelector('input[name="previewTime"]');
+
+                form.querySelector('#ctrl_preview_time_reset')?.addEventListener('click', function () {
+                    timeField.value = '';
+                    form.requestSubmit();
+                });
 
                 form.addEventListener('submit', function (e) {
                     e.preventDefault();

--- a/core-bundle/src/Controller/Backend/PreviewController.php
+++ b/core-bundle/src/Controller/Backend/PreviewController.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Controller\Backend;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\PreviewUrlConvertEvent;
 use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Nyholm\Psr7\Uri;
 use Scheb\TwoFactorBundle\Security\Http\Authenticator\TwoFactorAuthenticator;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -41,6 +42,7 @@ class PreviewController
         private readonly Security $security,
         private readonly LoginLinkHandlerInterface $loginLinkHandler,
         private readonly UriSigner $uriSigner,
+        private readonly TokenChecker|null $tokenChecker,
     ) {
     }
 
@@ -60,9 +62,13 @@ class PreviewController
 
         $frontendUser = $request->query->get('user');
 
+        $previewTime = $this->tokenChecker?->getPreviewTime();
+
         // Switch to a particular member (see contao/core#6546)
         if ($frontendUser && !$this->previewAuthenticator->authenticateFrontendUser($frontendUser, false)) {
             $this->previewAuthenticator->removeFrontendAuthentication();
+        } elseif ($frontendUser) {
+            $this->previewAuthenticator->setPreviewTime($previewTime);
         }
 
         $urlConvertEvent = new PreviewUrlConvertEvent($request);

--- a/core-bundle/src/Controller/Backend/PreviewSwitchController.php
+++ b/core-bundle/src/Controller/Backend/PreviewSwitchController.php
@@ -85,6 +85,7 @@ class PreviewSwitchController
         $canSwitchUser = $this->security->isGranted('ROLE_ALLOWED_TO_SWITCH_MEMBER');
         $frontendUsername = $this->tokenChecker->getFrontendUsername();
         $showUnpublished = $this->tokenChecker->isPreviewMode();
+        $previewTime = $this->tokenChecker->getPreviewTime();
         $shareLink = '';
 
         if ($this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'preview_link')) {
@@ -92,6 +93,7 @@ class PreviewSwitchController
                 'do' => 'preview_link',
                 'act' => 'create',
                 'showUnpublished' => $showUnpublished,
+                'previewTime' => $previewTime?->getTimestamp(),
                 'rt' => $this->tokenManager->getDefaultTokenValue(),
                 'nb' => '1', // Do not show the "Save & Close" button
             ]);
@@ -114,6 +116,7 @@ class PreviewSwitchController
                 'canSwitchUser' => $canSwitchUser,
                 'user' => $frontendUsername,
                 'show' => $showUnpublished,
+                'previewTime' => $previewTime?->format('Y-m-d\TH:i'),
                 'attributes' => $attributes,
                 'badgeTitle' => $this->backendBadgeTitle,
                 'share' => $shareLink,
@@ -139,6 +142,13 @@ class PreviewSwitchController
 
         $showUnpublished = 'hide' !== $request->request->get('unpublished');
 
+        $previewTime = null;
+
+        // Only set previewTime if we are not showing unpublished
+        if (!$showUnpublished && $input = $request->request->get('previewTime')) {
+            $previewTime = \DateTimeImmutable::createFromFormat('!Y-m-d\TH:i', $input) ?: null;
+        }
+
         if ($frontendUsername) {
             if (!$this->previewAuthenticator->authenticateFrontendUser((string) $frontendUsername, $showUnpublished)) {
                 $message = $this->translator->trans('ERR.previewSwitchInvalidUsername', [$frontendUsername], 'contao_default');
@@ -148,6 +158,9 @@ class PreviewSwitchController
         } else {
             $this->previewAuthenticator->authenticateFrontendGuest($showUnpublished);
         }
+
+        // Authentication replaces the session payload so we set previewTime afterward
+        $this->previewAuthenticator->setPreviewTime($previewTime);
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }

--- a/core-bundle/src/EventListener/DataContainer/PreviewLinkListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PreviewLinkListener.php
@@ -96,6 +96,7 @@ class PreviewLinkListener
 
         $GLOBALS['TL_DCA']['tl_preview_link']['fields']['url']['default'] = $url;
         $GLOBALS['TL_DCA']['tl_preview_link']['fields']['showUnpublished']['default'] = $request->query->getBoolean('showUnpublished');
+        $GLOBALS['TL_DCA']['tl_preview_link']['fields']['previewTime']['default'] = $request->query->getString('previewTime');
         $GLOBALS['TL_DCA']['tl_preview_link']['fields']['createdAt']['default'] = $now->getTimestamp();
         $GLOBALS['TL_DCA']['tl_preview_link']['fields']['expiresAt']['default'] = strtotime('+1 day', $now->getTimestamp());
         $GLOBALS['TL_DCA']['tl_preview_link']['fields']['createdBy']['default'] = $user instanceof BackendUser ? (int) $user->id : 0;

--- a/core-bundle/src/EventListener/MakeResponsePrivateListener.php
+++ b/core-bundle/src/EventListener/MakeResponsePrivateListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Routing\ScopeMatcher;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,8 +27,10 @@ class MakeResponsePrivateListener
 {
     final public const DEBUG_HEADER = 'Contao-Private-Response-Reason';
 
-    public function __construct(private readonly ScopeMatcher $scopeMatcher)
-    {
+    public function __construct(
+        private readonly ScopeMatcher $scopeMatcher,
+        private readonly TokenChecker|null $tokenChecker = null,
+    ) {
     }
 
     /**
@@ -40,8 +43,15 @@ class MakeResponsePrivateListener
             return;
         }
 
+        $response = $event->getResponse();
+
         // Disable the default Symfony auto cache control
-        $event->getResponse()->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '1');
+        $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '1');
+
+        // Set no-store when the clock is mocked
+        if ($this->tokenChecker?->getPreviewTime()) {
+            $response->headers->addCacheControlDirective('no-store');
+        }
     }
 
     /**

--- a/core-bundle/src/EventListener/PreviewTimeListener.php
+++ b/core-bundle/src/EventListener/PreviewTimeListener.php
@@ -35,8 +35,9 @@ class PreviewTimeListener
 
     /**
      * The priority must be lower than the Symfony route listener because of the
-     * _preview request attribute (defaults to 32), and lower than the Symfony firewall listener so the token
-     * is available and the authentication (e.g. 2FA) is not affected by the mocked clock (defaults to 8).
+     * _preview request attribute (defaults to 32), and lower than the Symfony
+     * firewall listener so the token is available and the authentication (e.g. 2FA)
+     * is not affected by the mocked clock (defaults to 8).
      */
     #[AsEventListener(priority: 6)]
     public function onKernelRequest(RequestEvent $event): void

--- a/core-bundle/src/EventListener/PreviewTimeListener.php
+++ b/core-bundle/src/EventListener/PreviewTimeListener.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+/**
+ * Renders the front end preview at a simulated time. We replace the clock
+ * globally because legacy classes like Date and Model are static.
+ *
+ * @internal
+ */
+class PreviewTimeListener
+{
+    private ClockInterface|null $originalClock = null;
+
+    public function __construct(private readonly TokenChecker $tokenChecker)
+    {
+    }
+
+    /**
+     * The priority must be lower than the Symfony route listener because of the
+     * _preview request attribute (defaults to 32), and lower than the Symfony firewall listener so the token
+     * is available and the authentication (e.g. 2FA) is not affected by the mocked clock (defaults to 8).
+     */
+    #[AsEventListener(priority: 6)]
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $this->restoreClock();
+
+        if (!$previewTime = $this->tokenChecker->getPreviewTime()) {
+            return;
+        }
+
+        // Keep current clock as the mocked one is stopping time for the whole request
+        $this->originalClock = Clock::get();
+
+        Clock::set(new MockClock($previewTime));
+    }
+
+    private function restoreClock(): void
+    {
+        if (!$this->originalClock) {
+            return;
+        }
+
+        Clock::set($this->originalClock);
+
+        $this->originalClock = null;
+    }
+}

--- a/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
@@ -59,7 +59,12 @@ class FrontendPreviewAuthenticator
             return false;
         }
 
-        $session->set(self::SESSION_NAME, ['showUnpublished' => $showUnpublished]);
+        $preview = $session->get(self::SESSION_NAME);
+
+        $session->set(self::SESSION_NAME, [
+            'showUnpublished' => $showUnpublished,
+            'previewTime' => $preview['previewTime'] ?? null,
+        ]);
 
         return true;
     }
@@ -70,7 +75,30 @@ class FrontendPreviewAuthenticator
             return false;
         }
 
-        $session->set(self::SESSION_NAME, ['previewLinkId' => $previewLinkId, 'showUnpublished' => $showUnpublished]);
+        $preview = $session->get(self::SESSION_NAME);
+
+        $session->set(self::SESSION_NAME, [
+            'previewLinkId' => $previewLinkId,
+            'showUnpublished' => $showUnpublished,
+            'previewTime' => $preview['previewTime'] ?? null,
+        ]);
+
+        return true;
+    }
+
+    public function setPreviewTime(\DateTimeImmutable|null $previewTime): bool
+    {
+        if (!$session = $this->getSession()) {
+            return false;
+        }
+
+        if (!$preview = $session->get(self::SESSION_NAME)) {
+            return false;
+        }
+
+        $preview['previewTime'] = $previewTime?->getTimestamp();
+
+        $session->set(self::SESSION_NAME, $preview);
 
         return true;
     }

--- a/core-bundle/src/Security/Authentication/Token/TokenChecker.php
+++ b/core-bundle/src/Security/Authentication/Token/TokenChecker.php
@@ -141,25 +141,21 @@ class TokenChecker
      */
     public function isPreviewMode(): bool
     {
-        $request = $this->requestStack->getCurrentRequest();
-
-        if (!$request?->attributes->get('_preview', false) || !$this->canAccessPreview()) {
+        if (!$preview = $this->getPreviewRequest()) {
             return false;
         }
 
-        if (!$request->hasPreviousSession()) {
+        // Unpublished also handled in getPreviewTimeFromRequest
+        if ($this->getPreviewTimeFromRequest($preview)) {
             return false;
         }
-
-        $session = $request->getSession();
-
-        if (!$session->has(FrontendPreviewAuthenticator::SESSION_NAME)) {
-            return false;
-        }
-
-        $preview = $session->get(FrontendPreviewAuthenticator::SESSION_NAME);
 
         return (bool) $preview['showUnpublished'];
+    }
+
+    public function getPreviewTime(): \DateTimeImmutable|null
+    {
+        return $this->getPreviewTimeFromRequest($this->getPreviewRequest());
     }
 
     public function isFrontendFirewall(): bool
@@ -251,26 +247,7 @@ class TokenChecker
             return false;
         }
 
-        $id = (int) $token['previewLinkId'];
-
-        if (!isset($this->previewLinks[$id])) {
-            $this->previewLinks[$id] = $this->connection->fetchAssociative(
-                <<<'SQL'
-                    SELECT
-                        url,
-                        showUnpublished,
-                        restrictToUrl
-                    FROM tl_preview_link
-                    WHERE
-                        id = :id
-                        AND published = 1
-                        AND expiresAt > UNIX_TIMESTAMP()
-                    SQL,
-                ['id' => $id],
-            );
-        }
-
-        $previewLink = $this->previewLinks[$id];
+        $previewLink = $this->getPreviewLink((int) $token['previewLinkId']);
 
         if (!$previewLink) {
             return false;
@@ -287,5 +264,73 @@ class TokenChecker
         $request = $this->requestStack->getMainRequest();
 
         return $request && strtok($request->getUri(), '?') === strtok(Request::create($previewLink['url'])->getUri(), '?');
+    }
+
+    private function getPreviewRequest(): array|null
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request?->attributes->get('_preview', false) || !$this->canAccessPreview()) {
+            return null;
+        }
+
+        if (!$request->hasPreviousSession()) {
+            return null;
+        }
+
+        $session = $request->getSession();
+
+        if (!$session->has(FrontendPreviewAuthenticator::SESSION_NAME)) {
+            return null;
+        }
+
+        return $session->get(FrontendPreviewAuthenticator::SESSION_NAME) ?: null;
+    }
+
+    private function getPreviewLink(int $id): array|false
+    {
+        if (!isset($this->previewLinks[$id])) {
+            $this->previewLinks[$id] = $this->connection->fetchAssociative(
+                <<<'SQL'
+                    SELECT
+                        url,
+                        showUnpublished,
+                        previewTime,
+                        restrictToUrl
+                    FROM tl_preview_link
+                    WHERE
+                        id = :id
+                        AND published = 1
+                        AND expiresAt > UNIX_TIMESTAMP()
+                    SQL,
+                ['id' => $id],
+            );
+        }
+
+        return $this->previewLinks[$id];
+    }
+
+    private function getPreviewTimeFromRequest(array|null $preview): \DateTimeImmutable|null
+    {
+        if (!$preview) {
+            return null;
+        }
+
+        if (isset($preview['previewLinkId'])) {
+            $previewLink = $this->getPreviewLink((int) $preview['previewLinkId']);
+
+            // Unpublished links should ignore previewTime completely
+            if (!$previewLink || $previewLink['showUnpublished'] || !$previewLink['previewTime']) {
+                return null;
+            }
+
+            return new \DateTimeImmutable('@'.$previewLink['previewTime']);
+        }
+
+        if (!isset($preview['previewTime'])) {
+            return null;
+        }
+
+        return new \DateTimeImmutable('@'.$preview['previewTime']);
     }
 }

--- a/core-bundle/tests/Controller/Backend/PreviewControllerTest.php
+++ b/core-bundle/tests/Controller/Backend/PreviewControllerTest.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Controller\Backend\PreviewController;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\PreviewUrlConvertEvent;
 use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Stub;
@@ -43,6 +44,7 @@ class PreviewControllerTest extends TestCase
             $this->mockSecurityHelper(),
             $this->createStub(LoginLinkHandlerInterface::class),
             $this->createStub(UriSigner::class),
+            $this->createStub(TokenChecker::class),
         );
 
         $response = $controller(new Request());
@@ -60,6 +62,7 @@ class PreviewControllerTest extends TestCase
             $this->mockSecurityHelper(),
             $this->createStub(LoginLinkHandlerInterface::class),
             $this->createStub(UriSigner::class),
+            $this->createStub(TokenChecker::class),
         );
 
         $request = Request::create('https://localhost/managed-edition/public/contao/preview?page=123');
@@ -81,6 +84,7 @@ class PreviewControllerTest extends TestCase
             $this->mockSecurityHelper(false),
             $this->createStub(LoginLinkHandlerInterface::class),
             $this->createStub(UriSigner::class),
+            $this->createStub(TokenChecker::class),
         );
 
         $request = Request::create('https://localhost/preview.php/en/');
@@ -114,6 +118,7 @@ class PreviewControllerTest extends TestCase
             $this->mockSecurityHelper(),
             $this->createStub(LoginLinkHandlerInterface::class),
             $this->createStub(UriSigner::class),
+            $this->createStub(TokenChecker::class),
         );
 
         $response = $controller($request);
@@ -137,6 +142,7 @@ class PreviewControllerTest extends TestCase
             $this->mockSecurityHelper(),
             $this->createStub(LoginLinkHandlerInterface::class),
             $this->createStub(UriSigner::class),
+            $this->createStub(TokenChecker::class),
         );
 
         $request = Request::create('https://localhost/preview.php/en/');
@@ -179,6 +185,7 @@ class PreviewControllerTest extends TestCase
             $this->mockSecurityHelper(true, $this->createClassWithPropertiesStub(BackendUser::class), $twoFactorComplete),
             $loginLinkHandler,
             $uriSigner,
+            $this->createStub(TokenChecker::class),
         );
 
         $request = Request::create($requestUrl);
@@ -230,6 +237,7 @@ class PreviewControllerTest extends TestCase
             $this->mockSecurityHelper(),
             $this->createStub(LoginLinkHandlerInterface::class),
             $this->createStub(UriSigner::class),
+            $this->createStub(TokenChecker::class),
         );
 
         $request = Request::create('https://localhost/preview.php/en/');

--- a/core-bundle/tests/Controller/Backend/PreviewSwitchControllerTest.php
+++ b/core-bundle/tests/Controller/Backend/PreviewSwitchControllerTest.php
@@ -130,7 +130,7 @@ class PreviewSwitchControllerTest extends TestCase
             ->willReturnMap([
                 [
                     'contao_backend',
-                    ['do' => 'preview_link', 'act' => 'create', 'showUnpublished' => true, 'rt' => 'csrf', 'nb' => '1'],
+                    ['do' => 'preview_link', 'act' => 'create', 'showUnpublished' => true, 'previewTime' => null, 'rt' => 'csrf', 'nb' => '1'],
                     '/_contao/preview/1',
                 ],
                 ['contao_backend_switch', '/contao/preview_switch'],
@@ -205,6 +205,54 @@ class PreviewSwitchControllerTest extends TestCase
         yield [null, 'authenticateFrontendGuest'];
         yield ['', 'authenticateFrontendGuest'];
         yield ['k.jones', 'authenticateFrontendUser'];
+    }
+
+    #[DataProvider('providePreviewTimeScenarios')]
+    public function testProcessesThePreviewTime(string $previewTime, string $unpublished, \DateTimeImmutable|null $expect): void
+    {
+        $frontendPreviewAuthenticator = $this->createMock(FrontendPreviewAuthenticator::class);
+        $frontendPreviewAuthenticator
+            ->expects($this->once())
+            ->method('setPreviewTime')
+            ->with($expect)
+            ->willReturn(true)
+        ;
+
+        $controller = new PreviewSwitchController(
+            $frontendPreviewAuthenticator,
+            $this->mockTokenChecker(),
+            $this->createStub(Connection::class),
+            $this->mockSecurity(),
+            $this->getTwigMock(),
+            $this->mockRouter(),
+            $this->mockTokenManager(),
+            $this->mockTranslator(),
+        );
+
+        $request = new Request(
+            request: [
+                'FORM_SUBMIT' => 'tl_switch',
+                'user' => '',
+                'unpublished' => $unpublished,
+                'previewTime' => $previewTime,
+            ],
+            server: ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest', 'REQUEST_METHOD' => 'POST'],
+        );
+
+        $response = $controller($request);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+    }
+
+    public static function providePreviewTimeScenarios(): iterable
+    {
+        yield 'Setting a time' => ['2027-06-01T12:00', 'hide', new \DateTimeImmutable('2027-06-01 12:00:00')];
+
+        yield 'Resetting the time' => ['', 'hide', null];
+
+        yield 'Unpublished should always show all' => ['2027-06-01T12:00', 'show', null];
+
+        yield 'Ignore invalid date values' => ['foobar', 'hide', null];
     }
 
     public function testReturnsErrorWithInvalidUsername(): void
@@ -336,7 +384,7 @@ class PreviewSwitchControllerTest extends TestCase
         return $router;
     }
 
-    private function mockTokenChecker(string|null $frontendUsername = null): TokenChecker&Stub
+    private function mockTokenChecker(string|null $frontendUsername = null, \DateTimeImmutable|null $previewTime = null): TokenChecker&Stub
     {
         $tokenChecker = $this->createStub(TokenChecker::class);
         $tokenChecker
@@ -347,6 +395,11 @@ class PreviewSwitchControllerTest extends TestCase
         $tokenChecker
             ->method('isPreviewMode')
             ->willReturn(true)
+        ;
+
+        $tokenChecker
+            ->method('getPreviewTime')
+            ->willReturn($previewTime)
         ;
 
         return $tokenChecker;

--- a/core-bundle/tests/EventListener/DataContainer/PreviewLinkListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/PreviewLinkListenerTest.php
@@ -101,7 +101,7 @@ class PreviewLinkListenerTest extends TestCase
     }
 
     #[DataProvider('defaultDcaValueProvider')]
-    public function testSetsTheDefaultValueForDcaFields(string $url, bool $showUnpublished, int $userId): void
+    public function testSetsTheDefaultValueForDcaFields(string $url, bool $showUnpublished, string $previewTime, int $userId): void
     {
         /** @phpstan-var array $GLOBALS (signals PHPStan that the array shape may change) */
         $GLOBALS['TL_DCA']['tl_preview_link'] = [
@@ -109,13 +109,14 @@ class PreviewLinkListenerTest extends TestCase
             'fields' => [
                 'url' => ['default' => ''],
                 'showUnpublished' => ['default' => false],
+                'previewTime' => ['default' => ''],
                 'createdAt' => ['default' => 0],
                 'expiresAt' => ['default' => 0],
                 'createdBy' => ['default' => 0],
             ],
         ];
 
-        $request = Request::create("/contao?do=preview_link&act=edit&url=$url&showUnpublished=$showUnpublished");
+        $request = Request::create("/contao?do=preview_link&act=edit&url=$url&showUnpublished=$showUnpublished&previewTime=$previewTime");
         $clock = new MockClock();
 
         $listener = new PreviewLinkListener(
@@ -135,6 +136,7 @@ class PreviewLinkListenerTest extends TestCase
         $this->assertTrue($GLOBALS['TL_DCA']['tl_preview_link']['config']['notCreatable']);
         $this->assertSame($url, $GLOBALS['TL_DCA']['tl_preview_link']['fields']['url']['default']);
         $this->assertSame($showUnpublished, $GLOBALS['TL_DCA']['tl_preview_link']['fields']['showUnpublished']['default']);
+        $this->assertSame($previewTime, $GLOBALS['TL_DCA']['tl_preview_link']['fields']['previewTime']['default']);
         $this->assertSame($clock->now()->getTimestamp(), $GLOBALS['TL_DCA']['tl_preview_link']['fields']['createdAt']['default']);
         $this->assertSame(strtotime('+1 day', $clock->now()->getTimestamp()), $GLOBALS['TL_DCA']['tl_preview_link']['fields']['expiresAt']['default']);
         $this->assertSame($userId, $GLOBALS['TL_DCA']['tl_preview_link']['fields']['createdBy']['default']);
@@ -145,12 +147,14 @@ class PreviewLinkListenerTest extends TestCase
         yield [
             '/preview.php/foo/bar',
             true,
+            '',
             1,
         ];
 
         yield [
             '/preview.php/foo/baz',
             false,
+            '637974000',
             2,
         ];
     }

--- a/core-bundle/tests/EventListener/MakeResponsePrivateListenerTest.php
+++ b/core-bundle/tests/EventListener/MakeResponsePrivateListenerTest.php
@@ -14,7 +14,9 @@ namespace Contao\CoreBundle\Tests\EventListener;
 
 use Contao\CoreBundle\EventListener\MakeResponsePrivateListener;
 use Contao\CoreBundle\Routing\ScopeMatcher;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Tests\TestCase;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -295,6 +297,65 @@ class MakeResponsePrivateListenerTest extends TestCase
         $this->assertFalse($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
     }
 
+    public function testAddsNoStoreIfClockIsMocked(): void
+    {
+        $response = new Response();
+
+        $event = new ResponseEvent(
+            $this->createStub(KernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            $response,
+        );
+
+        $listener = new MakeResponsePrivateListener(
+            $this->createScopeMatcher(true),
+            $this->createTokenCheckerStub(new \DateTimeImmutable('@637974000')),
+        );
+
+        $listener->disableSymfonyAutoCacheControl($event);
+
+        $this->assertTrue($response->headers->hasCacheControlDirective('no-store'));
+    }
+
+    public function testDoesNotAddNoStoreIfClockIsNotMocked(): void
+    {
+        $response = new Response();
+
+        $event = new ResponseEvent(
+            $this->createStub(KernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            $response,
+        );
+
+        $listener = new MakeResponsePrivateListener($this->createScopeMatcher(true), $this->createTokenCheckerStub(null));
+        $listener->disableSymfonyAutoCacheControl($event);
+
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
+    }
+
+    public function testDoesNotAddNoStoreIfIsNotAContaoMainRequest(): void
+    {
+        $response = new Response();
+
+        $event = new ResponseEvent(
+            $this->createStub(KernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            $response,
+        );
+
+        $listener = new MakeResponsePrivateListener(
+            $this->createScopeMatcher(false),
+            $this->createTokenCheckerStub(new \DateTimeImmutable('@637974000')),
+        );
+
+        $listener->disableSymfonyAutoCacheControl($event);
+
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
+    }
+
     private function createScopeMatcher(bool $isContaoMainRequest): ScopeMatcher
     {
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
@@ -305,5 +366,16 @@ class MakeResponsePrivateListenerTest extends TestCase
         ;
 
         return $scopeMatcher;
+    }
+
+    private function createTokenCheckerStub(\DateTimeImmutable|null $previewTime): TokenChecker&Stub
+    {
+        $tokenChecker = $this->createStub(TokenChecker::class);
+        $tokenChecker
+            ->method('getPreviewTime')
+            ->willReturn($previewTime)
+        ;
+
+        return $tokenChecker;
     }
 }

--- a/core-bundle/tests/EventListener/PreviewTimeListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewTimeListenerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener;
+
+use Contao\CoreBundle\EventListener\PreviewTimeListener;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
+use Contao\CoreBundle\Tests\TestCase;
+use PHPUnit\Framework\MockObject\Stub;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Clock\NativeClock;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class PreviewTimeListenerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Clock::set(new NativeClock());
+
+        parent::tearDown();
+    }
+
+    public function testMocksTheClockIfAPreviewTimeIsSet(): void
+    {
+        $listener = new PreviewTimeListener($this->createTokenCheckerStub(new \DateTimeImmutable('@637974000')));
+        $listener->onKernelRequest($this->getRequestEvent());
+
+        $this->assertInstanceOf(MockClock::class, Clock::get());
+        $this->assertSame(637974000, Clock::get()->now()->getTimestamp());
+    }
+
+    public function testDoesNotMockTheClockWithoutAPreviewTime(): void
+    {
+        $listener = new PreviewTimeListener($this->createTokenCheckerStub(null));
+        $listener->onKernelRequest($this->getRequestEvent());
+
+        $this->assertNotInstanceOf(MockClock::class, Clock::get());
+    }
+
+    public function testDoesNotMockTheClockInASubRequest(): void
+    {
+        $tokenChecker = $this->createMock(TokenChecker::class);
+        $tokenChecker
+            ->expects($this->never())
+            ->method('getPreviewTime')
+        ;
+
+        $listener = new PreviewTimeListener($tokenChecker);
+        $listener->onKernelRequest($this->getRequestEvent(HttpKernelInterface::SUB_REQUEST));
+
+        $this->assertNotInstanceOf(MockClock::class, Clock::get());
+    }
+
+    public function testDoesNotRestoreAClockThatWasNeverReplaced(): void
+    {
+        $originalClock = new NativeClock();
+        Clock::set($originalClock);
+
+        $listener = new PreviewTimeListener($this->createTokenCheckerStub(null));
+        $listener->onKernelRequest($this->getRequestEvent());
+
+        $this->assertSame($originalClock, Clock::get());
+    }
+
+    public function testMockedClockTimeDoesNotAdvance(): void
+    {
+        $listener = new PreviewTimeListener($this->createTokenCheckerStub(new \DateTimeImmutable('@637974000')));
+        $listener->onKernelRequest($this->getRequestEvent());
+
+        $clock = Clock::get();
+        $time = $clock->now();
+
+        usleep(1000);
+
+        $this->assertSame($time->getTimestamp(), $clock->now()->getTimestamp());
+    }
+
+    private function getRequestEvent(int $requestType = HttpKernelInterface::MAIN_REQUEST): RequestEvent
+    {
+        return new RequestEvent($this->createStub(KernelInterface::class), new Request(), $requestType);
+    }
+
+    private function createTokenCheckerStub(\DateTimeImmutable|null $previewTime): TokenChecker&Stub
+    {
+        $tokenChecker = $this->createStub(TokenChecker::class);
+        $tokenChecker
+            ->method('getPreviewTime')
+            ->willReturn($previewTime)
+        ;
+
+        return $tokenChecker;
+    }
+}

--- a/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
@@ -191,6 +191,72 @@ class FrontendPreviewAuthenticatorTest extends TestCase
         $this->assertSame($previewLinkId, $session->get(FrontendPreviewAuthenticator::SESSION_NAME)['previewLinkId']);
     }
 
+    public function testSetsThePreviewTime(): void
+    {
+        $session = $this->mockSession();
+        $authenticator = $this->getAuthenticator(null, null, null, $session);
+
+        $this->assertTrue($authenticator->authenticateFrontendGuest(false));
+        $this->assertTrue($authenticator->setPreviewTime(new \DateTimeImmutable('@637974000')));
+
+        $this->assertSame(637974000, $session->get(FrontendPreviewAuthenticator::SESSION_NAME)['previewTime']);
+
+        $this->assertTrue($authenticator->setPreviewTime(null));
+        $this->assertNull($session->get(FrontendPreviewAuthenticator::SESSION_NAME)['previewTime']);
+    }
+
+    public function testDoesNotSetThePreviewTimeWithoutPreviewSession(): void
+    {
+        $session = $this->mockSession();
+        $authenticator = $this->getAuthenticator(null, null, null, $session);
+
+        $this->assertFalse($authenticator->setPreviewTime(new \DateTimeImmutable('@637974000')));
+        $this->assertFalse($session->has(FrontendPreviewAuthenticator::SESSION_NAME));
+    }
+
+    public function testKeepsPreviewTimeWhenSwitchingToAnotherFrontendUser(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects($this->once())
+            ->method('isGranted')
+            ->willReturnOnConsecutiveCalls(true)
+        ;
+
+        $session = $this->mockSession();
+        $user = new \ReflectionClass(FrontendUser::class)->newInstanceWithoutConstructor();
+
+        $userProvider = $this->createStub(UserProviderInterface::class);
+        $userProvider
+            ->method('loadUserByIdentifier')
+            ->willReturn($user)
+        ;
+
+        $authenticator = $this->getAuthenticator($security, null, null, $session, $userProvider);
+
+        $this->assertTrue($authenticator->authenticateFrontendGuest(false));
+        $this->assertTrue($authenticator->setPreviewTime(new \DateTimeImmutable('@637974000')));
+
+        // Authentication should not remove the previewTime
+        $this->assertTrue($authenticator->authenticateFrontendUser('foobar', false));
+
+        $payload = $session->get(FrontendPreviewAuthenticator::SESSION_NAME);
+
+        $this->assertSame(637974000, $payload['previewTime']);
+    }
+
+    public function testResetsThePreviewTimeWhenAuthenticationIsRemoved(): void
+    {
+        $session = $this->mockSession();
+        $authenticator = $this->getAuthenticator(null, null, null, $session);
+
+        $this->assertTrue($authenticator->authenticateFrontendGuest(false));
+        $this->assertTrue($authenticator->setPreviewTime(new \DateTimeImmutable('@1700000000')));
+        $this->assertTrue($authenticator->removeFrontendAuthentication());
+
+        $this->assertFalse($session->has(FrontendPreviewAuthenticator::SESSION_NAME));
+    }
+
     public static function getShowUnpublishedPreviewLinkIdData(): iterable
     {
         yield [true, null];

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -219,6 +219,7 @@ class TokenCheckerTest extends TestCase
                 'url' => 'https://localhost/',
                 'showUnpublished' => true,
                 'restrictToUrl' => false,
+                'previewTime' => '',
             ],
             null,
             true,
@@ -230,6 +231,7 @@ class TokenCheckerTest extends TestCase
                 'url' => 'https://localhost/page1?foo=bar',
                 'showUnpublished' => true,
                 'restrictToUrl' => true,
+                'previewTime' => '',
             ],
             'https://localhost/page1?bar=baz',
             true,
@@ -241,6 +243,7 @@ class TokenCheckerTest extends TestCase
                 'url' => 'https://example.com:443/page1',
                 'showUnpublished' => true,
                 'restrictToUrl' => true,
+                'previewTime' => '',
             ],
             'https://example.com/page1?foo=bar',
             true,
@@ -252,6 +255,7 @@ class TokenCheckerTest extends TestCase
                 'url' => 'https://localhost/page2',
                 'showUnpublished' => true,
                 'restrictToUrl' => true,
+                'previewTime' => '',
             ],
             'https://localhost/page1',
             false,
@@ -263,6 +267,7 @@ class TokenCheckerTest extends TestCase
                 'url' => 'https://localhost/',
                 'showUnpublished' => true,
                 'restrictToUrl' => false,
+                'previewTime' => '',
             ],
             null,
             false,
@@ -276,6 +281,7 @@ class TokenCheckerTest extends TestCase
                 'url' => 'https://localhost/',
                 'showUnpublished' => false,
                 'restrictToUrl' => false,
+                'previewTime' => '',
             ],
             null,
             false,
@@ -297,10 +303,10 @@ class TokenCheckerTest extends TestCase
     }
 
     #[DataProvider('getPreviewModeData')]
-    public function testChecksIfThePreviewModeIsActive(bool $isPreview, bool $expect): void
+    public function testChecksIfThePreviewModeIsActive(bool $isPreview, int|null $previewTime, bool $expect): void
     {
         $request = new Request();
-        $session = $this->mockSessionWithPreview($isPreview);
+        $session = $this->mockSessionWithPreview($isPreview, $previewTime);
 
         if ($isPreview) {
             $request->attributes->set('_preview', true);
@@ -316,6 +322,7 @@ class TokenCheckerTest extends TestCase
                 'url' => 'https://localhost/',
                 'showUnpublished' => $isPreview,
                 'restrictToUrl' => false,
+                'previewTime' => '',
             ])
         ;
 
@@ -333,8 +340,120 @@ class TokenCheckerTest extends TestCase
 
     public static function getPreviewModeData(): iterable
     {
-        yield [false, false];
-        yield [true, true];
+        yield 'No preview' => [false, null, false];
+        yield 'Show unpublished' => [true, null, true];
+        // Mocked time should turn preview mode off
+        yield 'Mocked time' => [true, 637974000, false];
+    }
+
+    #[DataProvider('getPreviewTimeData')]
+    public function testReturnsThePreviewTime(bool $isPreview, int|null $previewTime, int|null $expect): void
+    {
+        $request = new Request();
+        $session = $this->mockSessionWithPreview($isPreview, $previewTime);
+
+        if ($isPreview) {
+            $request->attributes->set('_preview', true);
+            $request->cookies->set($session->getName(), 'foo');
+        }
+
+        $request->setSession($session);
+
+        $tokenChecker = new TokenChecker(
+            new RequestStack([$request]),
+            $this->mockFirewallMapWithConfigContext('contao_backend'),
+            $this->createTokenStorageStub(BackendUser::class),
+            new AuthenticationTrustResolver(),
+            $this->getRoleVoter(),
+            $this->createStub(Connection::class),
+        );
+
+        $this->assertSame($expect, $tokenChecker->getPreviewTime()?->getTimestamp());
+    }
+
+    public static function getPreviewTimeData(): iterable
+    {
+        yield 'Not in preview' => [false, 637974000, null];
+        yield 'No time set' => [true, null, null];
+        yield 'Time set' => [true, 637974000, 637974000];
+    }
+
+    #[DataProvider('getPreviewLinkTimeData')]
+    public function testReadsPreviewTimeFromPreviewLink(array|null $previewLinkRow, int|null $expect): void
+    {
+        $request = Request::create('https://localhost/');
+        $request->attributes->set('_preview', true);
+
+        $session = $this->createStub(Session::class);
+        $session
+            ->method('has')
+            ->willReturn(true)
+        ;
+
+        $session
+            ->method('get')
+            ->willReturnMap([[FrontendPreviewAuthenticator::SESSION_NAME, [
+                'showUnpublished' => false,
+                'previewLinkId' => 1,
+                'previewTime' => 1600000000,
+            ]]])
+        ;
+
+        $request->setSession($session);
+        $request->cookies->set($session->getName(), 'foo');
+
+        $connection = $this->createStub(Connection::class);
+        $connection
+            ->method('fetchAssociative')
+            ->willReturn($previewLinkRow ?? false)
+        ;
+
+        $tokenChecker = new TokenChecker(
+            new RequestStack([$request]),
+            $this->mockFirewallMapWithConfigContext('contao_backend'),
+            $this->createTokenStorageStub(FrontendUser::class),
+            new AuthenticationTrustResolver(),
+            $this->getRoleVoter(),
+            $connection,
+        );
+
+        // The time saved in the preview link is the source of the truth.
+        $this->assertSame($expect, $tokenChecker->getPreviewTime()?->getTimestamp());
+    }
+
+    public static function getPreviewLinkTimeData(): iterable
+    {
+        yield 'Preview link time' => [
+            [
+                'url' => 'https://localhost/',
+                'showUnpublished' => false,
+                'restrictToUrl' => false,
+                'previewTime' => 637974000,
+            ],
+            637974000,
+        ];
+
+        yield 'Preview link without time' => [
+            [
+                'url' => 'https://localhost/',
+                'showUnpublished' => false,
+                'restrictToUrl' => false,
+                'previewTime' => '',
+            ],
+            null,
+        ];
+
+        yield 'Preview link that shows all unpublished' => [
+            [
+                'url' => 'https://localhost/',
+                'showUnpublished' => true,
+                'restrictToUrl' => false,
+                'previewTime' => 637974000,
+            ],
+            null,
+        ];
+
+        yield 'Preview link expired' => [null, null];
     }
 
     public function testDoesNotReturnATokenIfTheSessionIsNotStarted(): void
@@ -512,6 +631,7 @@ class TokenCheckerTest extends TestCase
             ->willReturn([
                 'url' => 'https://localhost/',
                 'showUnpublished' => false,
+                'previewTime' => '',
                 'restrictToUrl' => false,
             ])
         ;
@@ -586,7 +706,7 @@ class TokenCheckerTest extends TestCase
         return $session;
     }
 
-    private function mockSessionWithPreview(bool $isPreview): SessionInterface&MockObject
+    private function mockSessionWithPreview(bool $isPreview, int|null $previewTime = null): SessionInterface&MockObject
     {
         $session = $this->createMock(SessionInterface::class);
         $session
@@ -606,7 +726,10 @@ class TokenCheckerTest extends TestCase
             ->expects($isPreview ? $this->once() : $this->never())
             ->method('get')
             ->with(FrontendPreviewAuthenticator::SESSION_NAME)
-            ->willReturn(['showUnpublished' => $isPreview])
+            ->willReturn([
+                'showUnpublished' => $isPreview,
+                'previewTime' => $previewTime,
+            ])
         ;
 
         return $session;


### PR DESCRIPTION
### Description

- implements #4561

Implements time travel aka allowing to set a time within the preview to show content at a specific date and time.
We are mocking the clock with the clock component as discussed in https://github.com/contao/contao/issues/4561#issuecomment-1255131817.

<img width="640" height="360" alt="bill_ted_excellent_adventure" src="https://github.com/user-attachments/assets/27b159fe-5e5a-488b-b601-a24fc15e53a1" />

### Notable things

1. Most elements are taken through the model and most if not all use `Date::floorToMinute` to get the current time. That's why I've decided to add it here. I've also updated the `isHidden` methods in `ModuleArticle` and `ContentElement` to use `Date::floorToMinute` (as that one also matches the one in the models + us using the Mocked clock) 3fd58987015f251698fb76c74bd14ff1cabbca7a
2. I introduced a `PreviewTimeListener` that replaces the Clock globally when a previewTime exists (can be gotten via the TokenChecker same as `isPreviewMode`), reason for that because our Model classes, Date etc. being static.
3. I've added the `no-store` directive to not store pages when mocking the time within the preview daf7ea85471a7626f960944f51550b712527baa1

### Frontend and Backend

<img width="1498" height="638" alt="Bildschirmfoto 2026-08-09 um 21 57 33" src="https://github.com/user-attachments/assets/f739e041-f4fe-4aa2-bb78-cd1f24dba843" />

<img width="1200" height="397" alt="Bildschirmfoto 2026-08-09 um 21 57 10" src="https://github.com/user-attachments/assets/9c47b107-ee72-4c44-8a0a-3202785e312b" />