### PR TITLE
Use consistent `datim` field definitions

### DIFF
--- a/calendar-bundle/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/contao/dca/tl_calendar_events.php
@@ -465,13 +465,13 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		)
 	)
 );

--- a/calendar-bundle/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/contao/dca/tl_calendar_events.php
@@ -465,13 +465,13 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		)
 	)
 );

--- a/comments-bundle/contao/dca/tl_comments.php
+++ b/comments-bundle/contao/dca/tl_comments.php
@@ -148,7 +148,7 @@ $GLOBALS['TL_DCA']['tl_comments'] = array
 			'filter'                  => true,
 			'flag'                    => DataContainer::SORT_MONTH_DESC,
 			'eval'                    => array('rgxp'=>'datim'),
-			'sql'                     => "varchar(64) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'name' => array
 		(

--- a/comments-bundle/contao/dca/tl_comments.php
+++ b/comments-bundle/contao/dca/tl_comments.php
@@ -148,7 +148,7 @@ $GLOBALS['TL_DCA']['tl_comments'] = array
 			'filter'                  => true,
 			'flag'                    => DataContainer::SORT_MONTH_DESC,
 			'eval'                    => array('rgxp'=>'datim'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'name' => array
 		(

--- a/comments-bundle/contao/dca/tl_comments_notify.php
+++ b/comments-bundle/contao/dca/tl_comments_notify.php
@@ -63,7 +63,7 @@ $GLOBALS['TL_DCA']['tl_comments_notify'] = array
 		),
 		'addedOn' => array
 		(
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'active' => array
 		(

--- a/comments-bundle/contao/dca/tl_comments_notify.php
+++ b/comments-bundle/contao/dca/tl_comments_notify.php
@@ -63,7 +63,7 @@ $GLOBALS['TL_DCA']['tl_comments_notify'] = array
 		),
 		'addedOn' => array
 		(
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'active' => array
 		(

--- a/core-bundle/contao/dca/tl_article.php
+++ b/core-bundle/contao/dca/tl_article.php
@@ -225,13 +225,13 @@ $GLOBALS['TL_DCA']['tl_article'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		)
 	)
 );

--- a/core-bundle/contao/dca/tl_article.php
+++ b/core-bundle/contao/dca/tl_article.php
@@ -225,13 +225,13 @@ $GLOBALS['TL_DCA']['tl_article'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		)
 	)
 );

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -755,13 +755,13 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		)
 	)
 );

--- a/core-bundle/contao/dca/tl_member.php
+++ b/core-bundle/contao/dca/tl_member.php
@@ -281,13 +281,13 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'dateAdded' => array
 		(

--- a/core-bundle/contao/dca/tl_member.php
+++ b/core-bundle/contao/dca/tl_member.php
@@ -281,13 +281,13 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'dateAdded' => array
 		(

--- a/core-bundle/contao/dca/tl_member_group.php
+++ b/core-bundle/contao/dca/tl_member_group.php
@@ -107,13 +107,13 @@ $GLOBALS['TL_DCA']['tl_member_group'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		)
 	)
 );

--- a/core-bundle/contao/dca/tl_member_group.php
+++ b/core-bundle/contao/dca/tl_member_group.php
@@ -107,13 +107,13 @@ $GLOBALS['TL_DCA']['tl_member_group'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		)
 	)
 );

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -622,13 +622,13 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'enforceTwoFactor' => array
 		(

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -622,13 +622,13 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'enforceTwoFactor' => array
 		(

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -339,13 +339,13 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'session' => array
 		(

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -339,13 +339,13 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'session' => array
 		(

--- a/core-bundle/contao/dca/tl_user_group.php
+++ b/core-bundle/contao/dca/tl_user_group.php
@@ -225,13 +225,13 @@ $GLOBALS['TL_DCA']['tl_user_group'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		)
 	)
 );

--- a/core-bundle/contao/dca/tl_user_group.php
+++ b/core-bundle/contao/dca/tl_user_group.php
@@ -225,13 +225,13 @@ $GLOBALS['TL_DCA']['tl_user_group'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		)
 	)
 );

--- a/news-bundle/contao/dca/tl_news.php
+++ b/news-bundle/contao/dca/tl_news.php
@@ -398,13 +398,13 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		)
 	)
 );

--- a/news-bundle/contao/dca/tl_news.php
+++ b/news-bundle/contao/dca/tl_news.php
@@ -398,13 +398,13 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'stop' => array
 		(
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		)
 	)
 );

--- a/newsletter-bundle/contao/dca/tl_newsletter.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter.php
@@ -249,7 +249,7 @@ $GLOBALS['TL_DCA']['tl_newsletter'] = array
 			'sorting'                 => true,
 			'flag'                    => DataContainer::SORT_MONTH_DESC,
 			'eval'                    => array('rgxp'=>'datim'),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		)
 	)
 );

--- a/newsletter-bundle/contao/dca/tl_newsletter.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter.php
@@ -249,7 +249,7 @@ $GLOBALS['TL_DCA']['tl_newsletter'] = array
 			'sorting'                 => true,
 			'flag'                    => DataContainer::SORT_MONTH_DESC,
 			'eval'                    => array('rgxp'=>'datim'),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		)
 	)
 );

--- a/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
@@ -116,7 +116,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_recipients'] = array
 			'sorting'                 => true,
 			'flag'                    => DataContainer::SORT_MONTH_DESC,
 			'eval'                    => array('rgxp'=>'datim', 'doNotCopy'=>true),
-			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => array('type'=>'string', 'length'=>10, 'default'=>'', 'platformOptions'=>array('collation'=>'ascii_bin'))
 		)
 	)
 );

--- a/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
@@ -116,7 +116,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_recipients'] = array
 			'sorting'                 => true,
 			'flag'                    => DataContainer::SORT_MONTH_DESC,
 			'eval'                    => array('rgxp'=>'datim', 'doNotCopy'=>true),
-			'sql'                     => "varchar(10) NOT NULL default ''"
+			'sql'                     => "varchar(10) COLLATE ascii_bin NOT NULL default ''"
 		)
 	)
 );


### PR DESCRIPTION
As noticed in https://github.com/contao/contao/pull/10108#discussion_r3748690313 our (string based) `datim` fields do not use consistent database field definitions currently.