### PR TITLE
Add configurable HTML document tags to the response context

### DIFF
--- a/.twig-cs-fixer.php
+++ b/.twig-cs-fixer.php
@@ -60,7 +60,7 @@ $ruleset->addRule(new ForbiddenFunctionRule([
 $config = new Config();
 $config->allowNonFixableRules();
 $config->addTokenParser(new DeferTokenParser());
-$config->addTokenParser(new AddTokenParser(''));
+$config->addTokenParser(new AddTokenParser());
 $config->addTokenParser(new SlotTokenParser());
 $config->setRuleset($ruleset);
 $config->setFinder(new Finder()->in(__DIR__ . '/*-bundle/contao/templates/*'));

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -41,3 +41,16 @@ The Twig filter `|insert_tag_raw` will no longer work in Contao 7. Use `|insert_
 
 The Twig filter `|input_encoded_to_plain_text` and the corresponding `inputEncodedToPlainText()` methods of the
 `StringRuntime` and `HtmlDecoder` classes will no longer work in Contao 7.
+
+## Legacy document content APIs
+
+The `response_context.end_of_head` Twig variable, the `end_of_head` Twig block and adding HTML head content through
+`$GLOBALS['TL_CSS']`, `$GLOBALS['TL_JAVASCRIPT']`, `$GLOBALS['TL_STYLE_SHEETS']` or `$GLOBALS['TL_HEAD']`, as well as
+the `response_context.end_of_body` Twig variable and adding end-of-body content through `$GLOBALS['TL_BODY']`, will
+no longer work in Contao 7. Add `HtmlTag` instances to
+the `HtmlHeadBag` or `HtmlBodyBag`, or use the
+`{% add to head %}`, `{% add to stylesheets %}` and `{% add to body %}` Twig tags instead. Override the `head_tags` or
+`end_of_body` Twig block to customize how the content is rendered.
+
+The global-array fallback when using the Twig `add` tag without the corresponding response context bag will no longer
+work in Contao 7.

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1524,6 +1524,12 @@ services:
     contao.twig.highlighter_runtime:
         class: Contao\CoreBundle\Twig\Runtime\HighlighterRuntime
 
+    contao.twig.html_document_runtime:
+        class: Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime
+        arguments:
+            - '@contao.routing.response_context_accessor'
+            - '%kernel.debug%'
+
     contao.twig.ide.namespace_lookup_file_generator:
         class: Contao\CoreBundle\Twig\Ide\NamespaceLookupFileGenerator
         arguments:

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1528,7 +1528,6 @@ services:
         class: Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime
         arguments:
             - '@contao.routing.response_context_accessor'
-            - '%kernel.debug%'
 
     contao.twig.ide.namespace_lookup_file_generator:
         class: Contao\CoreBundle\Twig\Ide\NamespaceLookupFileGenerator

--- a/core-bundle/contao/library/Contao/ArrayUtil.php
+++ b/core-bundle/contao/library/Contao/ArrayUtil.php
@@ -73,6 +73,169 @@ class ArrayUtil
 	}
 
 	/**
+	 * Stably sorts an associative array according to before and after constraints.
+	 * References to keys that do not exist are ignored.
+	 *
+	 * @template TKey of array-key
+	 * @template TValue
+	 *
+	 * @param array<TKey, TValue>                                                 $items
+	 * @param array<TKey, array{before?: array-key|null, after?: array-key|null}> $constraints
+	 *
+	 * @return array<TKey, TValue>
+	 */
+	public static function sortByOrderConstraints(array $items, array $constraints): array
+	{
+		$graph = self::buildOrderGraph($items, $constraints);
+		$positions = array_flip(array_keys($items));
+		$available = array_keys(array_filter($graph['indegrees'], static fn (int $degree): bool => 0 === $degree));
+		$sorted = array();
+
+		while ($available)
+		{
+			usort($available, static fn ($a, $b): int => $positions[$a] <=> $positions[$b]);
+			$key = array_shift($available);
+			$sorted[$key] = $items[$key];
+
+			foreach ($graph['edges'][$key] as $target)
+			{
+				if (0 === --$graph['indegrees'][$target])
+				{
+					$available[] = $target;
+				}
+			}
+		}
+
+		if (\count($sorted) !== \count($items))
+		{
+			$cyclic = array_keys(array_filter($graph['indegrees']));
+
+			throw new \LogicException(\sprintf('Cyclic array ordering constraints involving "%s".', implode('", "', $cyclic)));
+		}
+
+		return $sorted;
+	}
+
+	/**
+	 * @param array<array-key, mixed>                                                  $items
+	 * @param array<array-key, array{before?: array-key|null, after?: array-key|null}> $constraints
+	 *
+	 * @return array{edges: array<array-key, list<array-key>>, indegrees: array<array-key, int>}
+	 */
+	private static function buildOrderGraph(array $items, array $constraints): array
+	{
+		$graph = array(
+			'edges' => array_fill_keys(array_keys($items), array()),
+			'indegrees' => array_fill_keys(array_keys($items), 0),
+		);
+
+		foreach ($constraints as $key=>$constraint)
+		{
+			if (!\array_key_exists($key, $items))
+			{
+				continue;
+			}
+
+			if (isset($constraint['before']) && \array_key_exists($constraint['before'], $items))
+			{
+				self::addOrderEdge($graph, $key, $constraint['before']);
+			}
+
+			if (isset($constraint['after']) && \array_key_exists($constraint['after'], $items))
+			{
+				self::addOrderEdge($graph, $constraint['after'], $key);
+			}
+		}
+
+		self::addStableOrderEdges($graph, $items, $constraints);
+
+		return $graph;
+	}
+
+	/**
+	 * @param array{edges: array<array-key, list<array-key>>, indegrees: array<array-key, int>} $graph
+	 * @param array<array-key, mixed>                                                           $items
+	 * @param array<array-key, array{before?: array-key|null, after?: array-key|null}>          $constraints
+	 */
+	private static function addStableOrderEdges(array &$graph, array $items, array $constraints): void
+	{
+		$previous = null;
+
+		foreach (array_keys($items) as $key)
+		{
+			$constraint = $constraints[$key] ?? array();
+			$hasBefore = isset($constraint['before']) && \array_key_exists($constraint['before'], $items);
+			$hasAfter = isset($constraint['after']) && \array_key_exists($constraint['after'], $items);
+
+			if ($hasBefore || $hasAfter)
+			{
+				continue;
+			}
+
+			if (null !== $previous)
+			{
+				self::addStableOrderEdge($graph, $previous, $key);
+			}
+
+			$previous = $key;
+		}
+	}
+
+	/**
+	 * @param array{edges: array<array-key, list<array-key>>, indegrees: array<array-key, int>} $graph
+	 */
+	private static function addStableOrderEdge(array &$graph, int|string $source, int|string $target): void
+	{
+		if (self::hasOrderPath($graph['edges'], $target, $source))
+		{
+			return;
+		}
+
+		self::addOrderEdge($graph, $source, $target);
+	}
+
+	/**
+	 * @param array<array-key, list<array-key>> $edges
+	 */
+	private static function hasOrderPath(array $edges, int|string $source, int|string $target): bool
+	{
+		$pending = array($source);
+		$visited = array();
+
+		while ($pending)
+		{
+			$key = array_pop($pending);
+
+			if ($key === $target)
+			{
+				return true;
+			}
+
+			if (!isset($visited[$key]))
+			{
+				$visited[$key] = true;
+				array_push($pending, ...$edges[$key]);
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param array{edges: array<array-key, list<array-key>>, indegrees: array<array-key, int>} $graph
+	 */
+	private static function addOrderEdge(array &$graph, int|string $source, int|string $target): void
+	{
+		if (\in_array($target, $graph['edges'][$source], true))
+		{
+			return;
+		}
+
+		$graph['edges'][$source][] = $target;
+		++$graph['indegrees'][$target];
+	}
+
+	/**
 	 * Return true if an array is associative
 	 *
 	 * @param mixed $arrArray

--- a/core-bundle/contao/templates/component/_html_tag.html.twig
+++ b/core-bundle/contao/templates/component/_html_tag.html.twig
@@ -1,0 +1,45 @@
+{# Raw string tags are trusted markup; HtmlTag content is escaped unless explicitly marked as raw. #}
+{%- if tag.name is defined -%}
+    {%- set attributes = tag.attributes -%}
+
+    {%- if debug|default(false) and identifier is not null -%}
+        {%- do attributes.set('data-contao-tag', identifier) -%}
+    {%- endif -%}
+
+    {%- if tag.isInlineScript() and attributes.nonce is not defined -%}
+        {%- do attributes.setIfExists('nonce', csp_nonce('script-src')) -%}
+    {%- elseif tag.isInlineStyle() and attributes.nonce is not defined -%}
+        {%- do attributes.setIfExists('nonce', csp_nonce('style-src')) -%}
+    {%- endif -%}
+
+    {%- set void_elements = [
+        'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+        'link', 'meta', 'source', 'track', 'wbr',
+    ] -%}
+
+    <{{ tag.name }}{{ attributes }}>
+    {%- if tag.name not in void_elements -%}
+        {%- if tag.escapesContent() -%}
+            {{- tag.content -}}
+        {%- else -%}
+            {{- tag.content|raw -}}
+        {%- endif -%}
+        </{{ tag.name }}>
+    {%- endif -%}
+{%- else -%}
+    {%- if debug|default(false) and identifier is not null -%}
+        {%- set debug_identifier = identifier -%}
+
+        {%- for prefix in ['contao.twig.head.', 'contao.twig.stylesheets.'] -%}
+            {%- if debug_identifier starts with prefix -%}
+                {%- set debug_identifier = debug_identifier|slice(prefix|length) -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {# Hyphens are URL-encoded explicitly because url_encode() considers them URL-safe, while "--" is invalid in HTML comments. #}
+        {%- set debug_identifier = debug_identifier|url_encode|replace({'-': '%2D'}) -%}
+        <!-- contao-tag (URL-encoded): {{ debug_identifier }} -->
+    {%- endif -%}
+
+    {{- tag|raw -}}
+{%- endif -%}

--- a/core-bundle/contao/templates/moo_tablesort.html.twig
+++ b/core-bundle/contao/templates/moo_tablesort.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'contao_default' %}
 {% use '@Contao/component/_stylesheet.html.twig' %}
 
-{% add 'moo_mediabox' to stylesheets %}
+{% add 'moo_tablesort' to stylesheets %}
     {% with {file: 'assets/tablesort/css/tablesort.min.css'} %}{{ block('stylesheet_component') }}{% endwith %}
 {% endadd %}
 

--- a/core-bundle/contao/templates/page/layout.html.twig
+++ b/core-bundle/contao/templates/page/layout.html.twig
@@ -20,9 +20,19 @@
         {% block head_tags %}
             {% for identifier, head_tag in response_context.head.all(app.request) %}
                 {% if identifier == 'contao.title' %}
-                    {% block title %}{{ head_tag|contao_html_tag(identifier) }}{% endblock %}
+                    {% block title %}
+                        {{ include('@Contao/component/_html_tag.html.twig', {
+                            tag: head_tag,
+                            identifier,
+                            debug: app.debug|default(false),
+                        }, false) }}
+                    {% endblock %}
                 {% else %}
-                    {{ head_tag|contao_html_tag(identifier) }}
+                    {{ include('@Contao/component/_html_tag.html.twig', {
+                        tag: head_tag,
+                        identifier,
+                        debug: app.debug|default(false),
+                    }, false) }}
                 {% endif %}
             {% endfor %}
         {% endblock %}
@@ -65,7 +75,11 @@
     {% defer %}
         {% block end_of_body %}
             {% for identifier, element in response_context.body|default %}
-                {{ element|contao_html_tag(identifier) }}
+                {{ include('@Contao/component/_html_tag.html.twig', {
+                    tag: element,
+                    identifier,
+                    debug: app.debug|default(false),
+                }, false) }}
             {% endfor %}
 
             {# @deprecated Deprecated since Contao 6.1, to be removed in Contao 7. #}

--- a/core-bundle/contao/templates/page/layout.html.twig
+++ b/core-bundle/contao/templates/page/layout.html.twig
@@ -15,31 +15,19 @@
         <meta name="viewport" content="width=device-width,initial-scale=1.0,shrink-to-fit=no">
     {% endblock %}
 
-    {# Defer accessing the response context, so that elements coming after it can still affect it. #}
     {% defer %}
-        {% block title %}
-            {% set title = response_context.head.title|default %}
-            {% if title and contao.page.rootPageTitle|default %}
-                {% set title = title ~ ' - ' ~ contao.page.rootPageTitle %}
-            {% endif %}
-             <title>{{ title }}</title>
+        {# Resolve dynamic head tags after rendering all elements so their additions are included. #}
+        {% block head_tags %}
+            {% for identifier, head_tag in response_context.head.all(app.request) %}
+                {% if identifier == 'contao.title' %}
+                    {% block title %}{{ head_tag|contao_html_tag(identifier) }}{% endblock %}
+                {% else %}
+                    {{ head_tag|contao_html_tag(identifier) }}
+                {% endif %}
+            {% endfor %}
         {% endblock %}
 
-        {% if response_context.head %}
-            <meta name="robots" content="{{ response_context.head.metaRobots }}">
-            <meta name="description" content="{{ response_context.head.metaDescription|u.truncate(320, '…') }}">
-            {% for meta_tag in response_context.head.metaTags %}
-                <meta{{ meta_tag }}>
-            {% endfor %}
-
-            {% if page['enableCanonical'] %}
-                <link rel="canonical" href="{{ response_context.head.canonicalUriForRequest(app.request)|default }}">
-            {% endif %}
-            {% for link_tag in response_context.head.linkTags %}
-                <link{{ link_tag }}>
-            {% endfor %}
-        {% endif %}
-
+        {# @deprecated Deprecated since Contao 6.1, to be removed in Contao 7. #}
         {% block end_of_head %}
             {% for element in response_context.end_of_head|default %}
                 {{ element|raw }}
@@ -76,6 +64,11 @@
     {# Access the response context inside a "defer" block, so that elements coming after it can still affect it. #}
     {% defer %}
         {% block end_of_body %}
+            {% for identifier, element in response_context.body|default %}
+                {{ element|contao_html_tag(identifier) }}
+            {% endfor %}
+
+            {# @deprecated Deprecated since Contao 6.1, to be removed in Contao 7. #}
             {% for element in response_context.end_of_body|default %}
                 {{ element|raw }}
             {% endfor %}

--- a/core-bundle/src/ContentComposition/ContentCompositionBuilder.php
+++ b/core-bundle/src/ContentComposition/ContentCompositionBuilder.php
@@ -12,6 +12,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Image\PictureFactory;
 use Contao\CoreBundle\Image\Preview\PreviewFactory;
 use Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Routing\ResponseContext\JsonLd\JsonLdManager;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
@@ -41,6 +42,8 @@ class ContentCompositionBuilder
     private string|null $layoutTemplate = null;
 
     private string|null $defaultImageDensities = null;
+
+    private bool $legacyDocumentContentDeprecationTriggered = false;
 
     /**
      * Renderer used for the main layout template.
@@ -291,43 +294,51 @@ class ContentCompositionBuilder
 
     private function addResponseContextToTemplate(LayoutTemplate $template, ResponseContext $responseContext): void
     {
+        if (!$responseContext->has(HtmlBodyBag::class)) {
+            $responseContext->add(new HtmlBodyBag());
+        }
+
+        if (!$responseContext->has(HtmlHeadBag::class)) {
+            $responseContext->add(new HtmlHeadBag());
+        }
+
+        $htmlBodyBag = $responseContext->get(HtmlBodyBag::class);
+        $htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
+        $htmlHeadBag->setCanonicalEnabled((bool) ($this->page->enableCanonical ?? false));
+
         $responseContextData = [
-            'head' => $responseContext->has(HtmlHeadBag::class) ? $responseContext->get(HtmlHeadBag::class) : null,
-            'end_of_head' => fn () => [
-                ...array_map(
-                    function (string $url): string {
-                        $options = StringUtil::resolveFlaggedUrl($url);
-
-                        if (!Path::isAbsolute($url) && $staticUrl = $this->assetsContext->getStaticUrl()) {
-                            $url = Path::join($staticUrl, $url);
-                        }
-
-                        return Template::generateStyleTag($url, $options->media, $options->mtime);
-                    },
-                    array_unique($GLOBALS['TL_CSS'] ?? []),
-                ),
-                ...array_map(
-                    function (string $url): string {
-                        $options = StringUtil::resolveFlaggedUrl($url);
-
-                        if (!Path::isAbsolute($url) && $staticUrl = $this->assetsContext->getStaticUrl()) {
-                            $url = Path::join($staticUrl, $url);
-                        }
-
-                        return Template::generateScriptTag($url, $options->async, $options->mtime, defer: $options->defer);
-                    },
-                    array_unique($GLOBALS['TL_JAVASCRIPT'] ?? []),
-                ),
-                ...$GLOBALS['TL_STYLE_SHEETS'] ?? [],
-                ...$GLOBALS['TL_HEAD'] ?? [],
-            ],
-            'end_of_body' => static fn () => $GLOBALS['TL_BODY'] ?? [],
+            'head' => fn () => $this->finalizePageTitle($htmlHeadBag),
+            'body' => $htmlBodyBag,
+            // @deprecated Deprecated since Contao 6.1, to be removed in Contao 7.
+            'end_of_head' => $this->getLegacyHeadElements(...),
+            // @deprecated Deprecated since Contao 6.1, to be removed in Contao 7.
+            'end_of_body' => $this->getLegacyBodyElements(...),
             'json_ld_scripts' => static fn () => $responseContext->isInitialized(JsonLdManager::class)
                 ? $responseContext->get(JsonLdManager::class)->collectFinalScriptFromGraphs()
                 : null,
         ];
 
-        $template->set('response_context', new class($responseContextData) {
+        $template->set('response_context', $this->createTemplateResponseContext($responseContextData));
+    }
+
+    private function finalizePageTitle(HtmlHeadBag $htmlHeadBag): HtmlHeadBag
+    {
+        $title = $htmlHeadBag->getTitle();
+        $rootPageTitle = (string) ($this->page->rootPageTitle ?? '');
+
+        if ($title && $rootPageTitle) {
+            $title .= ' - ';
+        }
+
+        return $htmlHeadBag->setTitle($title.$rootPageTitle);
+    }
+
+    /**
+     * @param array<string, \Closure(): mixed|mixed> $data
+     */
+    private function createTemplateResponseContext(array $data): object
+    {
+        return new class($data) {
             /**
              * @param array<string, \Closure(): mixed|mixed> $data
              */
@@ -369,7 +380,88 @@ class ContentCompositionBuilder
                     yield $key => $this->__get($key);
                 }
             }
-        });
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getLegacyHeadElements(): array
+    {
+        $elements = $this->collectLegacyHeadElements();
+
+        if ($elements) {
+            $this->triggerLegacyDocumentContentDeprecation();
+        }
+
+        return $elements;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectLegacyHeadElements(): array
+    {
+        return [
+            ...array_map($this->generateGlobalStyleTag(...), array_unique($GLOBALS['TL_CSS'] ?? [])),
+            ...array_map($this->generateGlobalScriptTag(...), array_unique($GLOBALS['TL_JAVASCRIPT'] ?? [])),
+            ...$GLOBALS['TL_STYLE_SHEETS'] ?? [],
+            ...$GLOBALS['TL_HEAD'] ?? [],
+        ];
+    }
+
+    /**
+     * @return array<array-key, string>
+     */
+    private function getLegacyBodyElements(): array
+    {
+        $elements = $GLOBALS['TL_BODY'] ?? [];
+
+        if ($elements) {
+            $this->triggerLegacyDocumentContentDeprecation();
+        }
+
+        return $elements;
+    }
+
+    private function triggerLegacyDocumentContentDeprecation(): void
+    {
+        if ($this->legacyDocumentContentDeprecationTriggered) {
+            return;
+        }
+
+        $this->legacyDocumentContentDeprecationTriggered = true;
+
+        trigger_deprecation(
+            'contao/core-bundle',
+            '6.1',
+            'Using legacy document content globals is deprecated and will no longer work in Contao 7. Use HtmlHeadBag, HtmlBodyBag or the Twig "add" tag instead.',
+        );
+    }
+
+    private function generateGlobalStyleTag(string $url): string
+    {
+        $options = StringUtil::resolveFlaggedUrl($url);
+        $url = $this->prefixStaticUrl($url);
+
+        return Template::generateStyleTag($url, $options->media, $options->mtime);
+    }
+
+    private function generateGlobalScriptTag(string $url): string
+    {
+        $options = StringUtil::resolveFlaggedUrl($url);
+        $url = $this->prefixStaticUrl($url);
+
+        return Template::generateScriptTag($url, $options->async, $options->mtime, defer: $options->defer);
+    }
+
+    private function prefixStaticUrl(string $url): string
+    {
+        if (!Path::isAbsolute($url) && $staticUrl = $this->assetsContext->getStaticUrl()) {
+            return Path::join($staticUrl, $url);
+        }
+
+        return $url;
     }
 
     private function addCompositedContentToTemplate(LayoutTemplate $template, array $elementReferencesBySlot): void

--- a/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
@@ -60,6 +60,7 @@ class CoreResponseContextFactory
     {
         $context = $this->createResponseContext();
         $context->add($this->eventDispatcher);
+        $context->addLazy(HtmlBodyBag::class);
         $context->addLazy(HtmlHeadBag::class);
 
         $context->addLazy(

--- a/core-bundle/src/Routing/ResponseContext/HtmlBodyBag.php
+++ b/core-bundle/src/Routing/ResponseContext/HtmlBodyBag.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Routing\ResponseContext;
+
+use Contao\ArrayUtil;
+
+/**
+ * @implements \IteratorAggregate<array-key, HtmlTag|string>
+ */
+final class HtmlBodyBag implements \IteratorAggregate
+{
+    /**
+     * @var array<array-key, HtmlTag|string>
+     */
+    private array $content = [];
+
+    /**
+     * @var array<array-key, array{before?: HtmlTag|array-key, after?: HtmlTag|array-key}>
+     */
+    private array $constraints = [];
+
+    /**
+     * Adds trusted markup to the end of the HTML body. Structured tags use their
+     * suggested identifier if no explicit identifier is given.
+     */
+    public function add(HtmlTag|string $content, string|null $identifier = null): self
+    {
+        $identifier ??= $content instanceof HtmlTag ? $content->getSuggestedIdentifier() : null;
+
+        if (null === $identifier) {
+            $this->content[] = $content;
+        } else {
+            $this->content[$identifier] = $content;
+            unset($this->constraints[$identifier]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * The reference can be an explicit identifier or a semantically matching tag.
+     */
+    public function addBefore(HtmlTag|string $content, HtmlTag|string $reference, string|null $identifier = null): self
+    {
+        $identifier = $this->getIdentifier($content, $identifier);
+        $this->content[$identifier] = $content;
+        $this->constraints[$identifier] = ['before' => $reference];
+
+        return $this;
+    }
+
+    /**
+     * The reference can be an explicit identifier or a semantically matching tag.
+     */
+    public function addAfter(HtmlTag|string $content, HtmlTag|string $reference, string|null $identifier = null): self
+    {
+        $identifier = $this->getIdentifier($content, $identifier);
+        $this->content[$identifier] = $content;
+        $this->constraints[$identifier] = ['after' => $reference];
+
+        return $this;
+    }
+
+    /**
+     * Overrides the ordering constraint of existing content.
+     */
+    public function orderBefore(int|string $identifier, HtmlTag|int|string $reference): self
+    {
+        $this->constraints[$identifier] = ['before' => $reference];
+
+        return $this;
+    }
+
+    /**
+     * Overrides the ordering constraint of existing content.
+     */
+    public function orderAfter(int|string $identifier, HtmlTag|int|string $reference): self
+    {
+        $this->constraints[$identifier] = ['after' => $reference];
+
+        return $this;
+    }
+
+    /**
+     * @return array<array-key, HtmlTag|string>
+     */
+    public function all(): array
+    {
+        return ArrayUtil::sortByOrderConstraints($this->content, $this->resolveConstraints());
+    }
+
+    /**
+     * @return \ArrayIterator<array-key, HtmlTag|string>
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->all());
+    }
+
+    private function getIdentifier(HtmlTag|string $content, string|null $identifier): string
+    {
+        if (null !== $identifier) {
+            return $identifier;
+        }
+
+        if ($content instanceof HtmlTag) {
+            return $content->getSuggestedIdentifier();
+        }
+
+        throw new \InvalidArgumentException('An identifier is required to order raw HTML body content.');
+    }
+
+    /**
+     * @return array<array-key, array{before?: array-key, after?: array-key}>
+     */
+    private function resolveConstraints(): array
+    {
+        $aliases = [];
+        $constraints = $this->constraints;
+
+        foreach ($this->content as $identifier => $content) {
+            if ($content instanceof HtmlTag) {
+                $aliases[$content->getSuggestedIdentifier()][] = $identifier;
+            }
+        }
+
+        foreach ($constraints as $identifier => $constraint) {
+            foreach (['before', 'after'] as $position) {
+                if (isset($constraint[$position])) {
+                    $constraints[$identifier][$position] = $this->resolveReference($constraint[$position], $aliases);
+                }
+            }
+        }
+
+        return $constraints;
+    }
+
+    /**
+     * @param array<string, list<array-key>> $aliases
+     */
+    private function resolveReference(HtmlTag|int|string $reference, array $aliases): int|string
+    {
+        if (!$reference instanceof HtmlTag && \array_key_exists($reference, $this->content)) {
+            return $reference;
+        }
+
+        $reference = $reference instanceof HtmlTag ? $reference->getSuggestedIdentifier() : $reference;
+
+        $matches = $aliases[$reference] ?? [];
+
+        if (1 < \count($matches)) {
+            throw new \LogicException(\sprintf('The HTML tag reference "%s" is ambiguous.', $reference));
+        }
+
+        return $matches[0] ?? $reference;
+    }
+}

--- a/core-bundle/src/Routing/ResponseContext/HtmlHeadBag/HtmlHeadBag.php
+++ b/core-bundle/src/Routing/ResponseContext/HtmlHeadBag/HtmlHeadBag.php
@@ -12,11 +12,26 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag;
 
+use Contao\ArrayUtil;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlTag;
 use Contao\CoreBundle\String\HtmlAttributes;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\String\UnicodeString;
 
 final class HtmlHeadBag
 {
+    public const TAG_TITLE = 'contao.title';
+
+    public const TAG_ROBOTS = 'contao.meta.robots';
+
+    public const TAG_DESCRIPTION = 'contao.meta.description';
+
+    public const TAG_CANONICAL = 'contao.canonical';
+
+    private const RAW_HEAD_PREFIX = 'contao.twig.head';
+
+    private const RAW_STYLESHEET_PREFIX = 'contao.twig.stylesheets';
+
     private string $name = '';
 
     private string $title = '';
@@ -38,6 +53,33 @@ final class HtmlHeadBag
      * @var list<HtmlAttributes>
      */
     private array $linkTags = [];
+
+    /**
+     * @var array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}>
+     */
+    private array $tags = [];
+
+    /**
+     * @var array<string, array{tag: string, before: HtmlTag|string|null, after: HtmlTag|string|null}>
+     */
+    private array $rawHeadTags = [];
+
+    /**
+     * @var array<string, array{tag: string, before: HtmlTag|string|null, after: HtmlTag|string|null}>
+     */
+    private array $rawStyleSheetTags = [];
+
+    /**
+     * @var array<string, array{before?: HtmlTag|string, after?: HtmlTag|string}>
+     */
+    private array $ordering = [];
+
+    /**
+     * @var array<string, true>
+     */
+    private array $removedTags = [];
+
+    private bool $canonicalEnabled = false;
 
     public function getName(): string
     {
@@ -146,6 +188,16 @@ final class HtmlHeadBag
         return $request->getUri();
     }
 
+    /**
+     * @internal
+     */
+    public function setCanonicalEnabled(bool $canonicalEnabled): self
+    {
+        $this->canonicalEnabled = $canonicalEnabled;
+
+        return $this;
+    }
+
     public function getMetaTags(): array
     {
         return $this->metaTags;
@@ -196,5 +248,396 @@ final class HtmlHeadBag
         $this->linkTags = array_filter($this->linkTags, static fn (HtmlAttributes $linkTag): bool => ($linkTag[$key] ?? null) !== $value);
 
         return $this;
+    }
+
+    /**
+     * Uses the tag's suggested identifier if no explicit identifier is given.
+     */
+    public function add(HtmlTag $tag, string|null $identifier = null): self
+    {
+        $this->setEntry($identifier ?? $tag->getSuggestedIdentifier(), $tag, []);
+
+        return $this;
+    }
+
+    /**
+     * The reference can be an explicit identifier or a semantically matching tag.
+     */
+    public function addBefore(HtmlTag $tag, HtmlTag|string $reference, string|null $identifier = null): self
+    {
+        $this->setEntry(
+            $identifier ?? $tag->getSuggestedIdentifier(),
+            $tag,
+            ['before' => $reference],
+        );
+
+        return $this;
+    }
+
+    /**
+     * The reference can be an explicit identifier or a semantically matching tag.
+     */
+    public function addAfter(HtmlTag $tag, HtmlTag|string $reference, string|null $identifier = null): self
+    {
+        $this->setEntry(
+            $identifier ?? $tag->getSuggestedIdentifier(),
+            $tag,
+            ['after' => $reference],
+        );
+
+        return $this;
+    }
+
+    /**
+     * Adds trusted markup that cannot be represented by a single HtmlTag.
+     */
+    public function addRaw(string $identifier, string $markup): self
+    {
+        $this->setEntry($identifier, $markup, []);
+
+        return $this;
+    }
+
+    /**
+     * @internal
+     *
+     * @param array{before?: HtmlTag|string, after?: HtmlTag|string} $position
+     */
+    public function addRawToHead(string $identifier, string $markup, array $position = []): self
+    {
+        if ('' === $identifier) {
+            throw new \InvalidArgumentException('The HTML head tag identifier must not be empty.');
+        }
+
+        $this->rawHeadTags[$identifier] = $this->createEntry($markup, $position);
+        unset($this->removedTags[self::RAW_HEAD_PREFIX.'.'.$identifier]);
+
+        return $this;
+    }
+
+    /**
+     * @internal
+     *
+     * @param array{before?: HtmlTag|string, after?: HtmlTag|string} $position
+     */
+    public function addRawToStylesheets(string $identifier, string $markup, array $position = []): self
+    {
+        if ('' === $identifier) {
+            throw new \InvalidArgumentException('The HTML head tag identifier must not be empty.');
+        }
+
+        $this->rawStyleSheetTags[$identifier] = $this->createEntry($markup, $position);
+        unset($this->removedTags[self::RAW_STYLESHEET_PREFIX.'.'.$identifier]);
+
+        return $this;
+    }
+
+    /**
+     * Adds trusted markup before another tag.
+     */
+    public function addRawBefore(string $identifier, string $markup, HtmlTag|string $reference): self
+    {
+        $this->setEntry($identifier, $markup, ['before' => $reference]);
+
+        return $this;
+    }
+
+    /**
+     * Adds trusted markup after another tag.
+     */
+    public function addRawAfter(string $identifier, string $markup, HtmlTag|string $reference): self
+    {
+        $this->setEntry($identifier, $markup, ['after' => $reference]);
+
+        return $this;
+    }
+
+    /**
+     * Overrides the ordering constraint of an existing tag.
+     */
+    public function orderBefore(string $identifier, HtmlTag|string $reference): self
+    {
+        $this->ordering[$identifier] = ['before' => $reference];
+
+        return $this;
+    }
+
+    /**
+     * Overrides the ordering constraint of an existing tag.
+     */
+    public function orderAfter(string $identifier, HtmlTag|string $reference): self
+    {
+        $this->ordering[$identifier] = ['after' => $reference];
+
+        return $this;
+    }
+
+    public function remove(string $identifier): self
+    {
+        $entries = $this->collectEntries(null);
+        $resolvedIdentifier = $this->resolveStoredIdentifier($identifier, $entries);
+
+        unset($this->tags[$resolvedIdentifier], $this->ordering[$identifier], $this->ordering[$resolvedIdentifier]);
+
+        $this->removedTags[$resolvedIdentifier] = true;
+
+        return $this;
+    }
+
+    public function has(string $identifier, Request|null $request = null): bool
+    {
+        $entries = $this->collectEntries($request);
+
+        return isset($entries[$this->resolveStoredIdentifier($identifier, $entries)]);
+    }
+
+    /**
+     * Returns the tags in rendering order. References to tags that do not exist
+     * are ignored.
+     *
+     * @return array<string, HtmlTag|string>
+     */
+    public function all(Request|null $request = null): array
+    {
+        $entries = $this->collectEntries($request);
+        $constraints = $this->resolveConstraints($entries);
+        $tags = [];
+
+        foreach (ArrayUtil::sortByOrderConstraints($entries, $constraints) as $identifier => $entry) {
+            $tags[$identifier] = $entry['tag'];
+        }
+
+        return $tags;
+    }
+
+    /**
+     * @param array{before?: HtmlTag|string, after?: HtmlTag|string} $position
+     */
+    private function setEntry(string $identifier, HtmlTag|string $tag, array $position): void
+    {
+        if ('' === $identifier) {
+            throw new \InvalidArgumentException('The HTML head tag identifier must not be empty.');
+        }
+
+        $this->tags[$identifier] = $this->createEntry($tag, $position);
+
+        unset($this->removedTags[$identifier]);
+    }
+
+    /**
+     * @return array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}>
+     */
+    private function collectEntries(Request|null $request): array
+    {
+        $entries = $this->getCoreEntries($request);
+
+        foreach ($this->tags as $identifier => $entry) {
+            $entries[$identifier] = $entry;
+        }
+
+        $this->addRawEntries($entries, $this->rawStyleSheetTags, self::RAW_STYLESHEET_PREFIX);
+        $this->addRawEntries($entries, $this->rawHeadTags, self::RAW_HEAD_PREFIX);
+
+        foreach (array_keys($this->removedTags) as $identifier) {
+            unset($entries[$identifier]);
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @return array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}>
+     */
+    private function getCoreEntries(Request|null $request): array
+    {
+        $entries = [
+            self::TAG_TITLE => $this->createEntry(HtmlTag::title($this->title)),
+            self::TAG_ROBOTS => $this->createEntry(HtmlTag::meta(['name' => 'robots', 'content' => $this->metaRobots])),
+            self::TAG_DESCRIPTION => $this->createEntry(HtmlTag::meta(['name' => 'description', 'content' => new UnicodeString($this->metaDescription)->truncate(320, '…')])),
+        ];
+
+        $this->addAdditionalMetaEntries($entries);
+        $this->addCanonicalEntry($entries, $request);
+        $this->addAdditionalLinkEntries($entries);
+
+        return $entries;
+    }
+
+    /**
+     * @param array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}> $entries
+     */
+    private function addAdditionalMetaEntries(array &$entries): void
+    {
+        foreach ($this->metaTags as $key => $attributes) {
+            $entries["contao.meta.additional.$key"] = $this->createEntry(HtmlTag::meta($attributes));
+        }
+    }
+
+    /**
+     * @param array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}> $entries
+     */
+    private function addCanonicalEntry(array &$entries, Request|null $request): void
+    {
+        if (!$this->canonicalEnabled || !$request) {
+            return;
+        }
+
+        $entries[self::TAG_CANONICAL] = $this->createEntry(HtmlTag::link([
+            'rel' => 'canonical',
+            'href' => $this->getCanonicalUriForRequest($request),
+        ]));
+    }
+
+    /**
+     * @param array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}> $entries
+     */
+    private function addAdditionalLinkEntries(array &$entries): void
+    {
+        foreach ($this->linkTags as $key => $attributes) {
+            $entries["contao.link.additional.$key"] = $this->createEntry(HtmlTag::link($attributes));
+        }
+    }
+
+    /**
+     * @param array{before?: HtmlTag|string, after?: HtmlTag|string} $position
+     *
+     * @return array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}
+     */
+    private function createEntry(HtmlTag|string $tag, array $position = []): array
+    {
+        return [
+            'tag' => $tag,
+            'before' => $position['before'] ?? null,
+            'after' => $position['after'] ?? null,
+        ];
+    }
+
+    /**
+     * @param array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}> $entries
+     * @param array<string, array{tag: string, before: HtmlTag|string|null, after: HtmlTag|string|null}>         $rawEntries
+     */
+    private function addRawEntries(array &$entries, array $rawEntries, string $prefix): void
+    {
+        foreach ($rawEntries as $identifier => $entry) {
+            $entries["$prefix.$identifier"] = $entry;
+        }
+    }
+
+    /**
+     * @param array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}> $entries
+     *
+     * @return array<string, array{before: string|null, after: string|null}>
+     */
+    private function resolveConstraints(array $entries): array
+    {
+        $identifierMap = $this->collectIdentifierMap($entries);
+        $constraints = [];
+
+        foreach ($entries as $identifier => $entry) {
+            $constraints[$identifier] = [
+                'before' => $this->resolveReference($entry['before'], $entries, $identifierMap),
+                'after' => $this->resolveReference($entry['after'], $entries, $identifierMap),
+            ];
+        }
+
+        foreach ($this->ordering as $identifier => $ordering) {
+            $identifier = $this->resolveReference($identifier, $entries, $identifierMap);
+
+            if (null === $identifier || !isset($entries[$identifier])) {
+                continue;
+            }
+
+            $constraints[$identifier] = [
+                'before' => $this->resolveReference($ordering['before'] ?? null, $entries, $identifierMap),
+                'after' => $this->resolveReference($ordering['after'] ?? null, $entries, $identifierMap),
+            ];
+        }
+
+        return $constraints;
+    }
+
+    /**
+     * @param array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}> $entries
+     *
+     * @return array<string, list<string>>
+     */
+    private function collectIdentifierMap(array $entries): array
+    {
+        $identifierMap = [];
+
+        $this->addRawIdentifiers($identifierMap, $this->rawStyleSheetTags, self::RAW_STYLESHEET_PREFIX);
+        $this->addRawIdentifiers($identifierMap, $this->rawHeadTags, self::RAW_HEAD_PREFIX);
+
+        foreach ($entries as $identifier => $entry) {
+            if ($entry['tag'] instanceof HtmlTag) {
+                $identifierMap[$entry['tag']->getSuggestedIdentifier()][] = $identifier;
+            }
+        }
+
+        return $identifierMap;
+    }
+
+    /**
+     * @param array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}> $entries
+     */
+    private function resolveStoredIdentifier(string $identifier, array $entries): string
+    {
+        if (isset($entries[$identifier])) {
+            return $identifier;
+        }
+
+        $matches = array_filter(
+            [
+                self::RAW_HEAD_PREFIX.'.'.$identifier,
+                self::RAW_STYLESHEET_PREFIX.'.'.$identifier,
+            ],
+            static fn (string $match): bool => isset($entries[$match]),
+        );
+
+        if (1 < \count($matches)) {
+            throw new \LogicException(\sprintf('The HTML tag identifier "%s" is ambiguous.', $identifier));
+        }
+
+        return $matches ? array_values($matches)[0] : $identifier;
+    }
+
+    /**
+     * @param array<string, list<string>>                                                                $identifierMap
+     * @param array<string, array{tag: string, before: HtmlTag|string|null, after: HtmlTag|string|null}> $rawEntries
+     */
+    private function addRawIdentifiers(array &$identifierMap, array $rawEntries, string $prefix): void
+    {
+        foreach (array_keys($rawEntries) as $identifier) {
+            $internalIdentifier = "$prefix.$identifier";
+
+            if (!isset($this->removedTags[$internalIdentifier])) {
+                $identifierMap[$identifier][] = $internalIdentifier;
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array{tag: HtmlTag|string, before: HtmlTag|string|null, after: HtmlTag|string|null}> $entries
+     * @param array<string, list<string>>                                                                        $identifierMap
+     */
+    private function resolveReference(HtmlTag|string|null $reference, array $entries, array $identifierMap): string|null
+    {
+        if (null === $reference) {
+            return $reference;
+        }
+
+        if (\is_string($reference) && isset($entries[$reference])) {
+            return $reference;
+        }
+
+        $reference = $reference instanceof HtmlTag ? $reference->getSuggestedIdentifier() : $reference;
+
+        $matches = $identifierMap[$reference] ?? [];
+
+        if (1 < \count($matches)) {
+            throw new \LogicException(\sprintf('The HTML tag reference "%s" is ambiguous.', $reference));
+        }
+
+        return $matches[0] ?? $reference;
     }
 }

--- a/core-bundle/src/Routing/ResponseContext/HtmlTag.php
+++ b/core-bundle/src/Routing/ResponseContext/HtmlTag.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Routing\ResponseContext;
+
+use Contao\CoreBundle\String\HtmlAttributes;
+
+final class HtmlTag
+{
+    private const VOID_ELEMENTS = [
+        'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+        'link', 'meta', 'source', 'track', 'wbr',
+    ];
+
+    private HtmlAttributes $attributes;
+
+    private function __construct(
+        private readonly string $name,
+        private string|null $content = null,
+        private bool $escapeContent = true,
+    ) {
+        if (!preg_match('/^[a-z][a-z0-9:-]*$/i', $name)) {
+            throw new \InvalidArgumentException(\sprintf('Invalid HTML tag name "%s".', $name));
+        }
+
+        $this->attributes = new HtmlAttributes();
+    }
+
+    public function __clone()
+    {
+        $this->attributes = clone $this->attributes;
+    }
+
+    /**
+     * @param HtmlAttributes|iterable<string, \Stringable|bool|float|int|string|null>|string|null $attributes
+     */
+    public static function create(string $name, string|null $content = null, HtmlAttributes|iterable|string|null $attributes = null): self
+    {
+        return new self(strtolower($name), $content)->withAttributes($attributes);
+    }
+
+    /**
+     * @param HtmlAttributes|iterable<string, \Stringable|bool|float|int|string|null>|string|null $attributes
+     */
+    public static function title(string $title, HtmlAttributes|iterable|string|null $attributes = null): self
+    {
+        return new self('title', $title)->withAttributes($attributes);
+    }
+
+    /**
+     * @param HtmlAttributes|iterable<string, \Stringable|bool|float|int|string|null>|string|null $attributes
+     */
+    public static function meta(HtmlAttributes|iterable|string|null $attributes = null): self
+    {
+        return new self('meta')->withAttributes($attributes);
+    }
+
+    /**
+     * @param HtmlAttributes|iterable<string, \Stringable|bool|float|int|string|null>|string|null $attributes
+     */
+    public static function link(HtmlAttributes|iterable|string|null $attributes = null): self
+    {
+        return new self('link')->withAttributes($attributes);
+    }
+
+    /**
+     * @param HtmlAttributes|iterable<string, \Stringable|bool|float|int|string|null>|string|null $attributes
+     */
+    public static function stylesheet(string $href, HtmlAttributes|iterable|string|null $attributes = null): self
+    {
+        return self::link(['rel' => 'stylesheet', 'href' => $href])
+            ->withAttributes($attributes)
+            ->withAttribute('rel', 'stylesheet')
+            ->withAttribute('href', $href)
+        ;
+    }
+
+    /**
+     * @param HtmlAttributes|iterable<string, \Stringable|bool|float|int|string|null>|string|null $attributes
+     */
+    public static function script(string $src, HtmlAttributes|iterable|string|null $attributes = null): self
+    {
+        return new self('script', escapeContent: false)
+            ->withAttribute('src', $src)
+            ->withAttributes($attributes)
+            ->withAttribute('src', $src)
+        ;
+    }
+
+    /**
+     * Only pass trusted JavaScript to this method.
+     *
+     * @param HtmlAttributes|iterable<string, \Stringable|bool|float|int|string|null>|string|null $attributes
+     */
+    public static function inlineScript(string $content, HtmlAttributes|iterable|string|null $attributes = null): self
+    {
+        return new self('script', $content, false)->withAttributes($attributes);
+    }
+
+    /**
+     * Only pass trusted CSS to this method.
+     *
+     * @param HtmlAttributes|iterable<string, \Stringable|bool|float|int|string|null>|string|null $attributes
+     */
+    public static function inlineStyle(string $content, HtmlAttributes|iterable|string|null $attributes = null): self
+    {
+        return new self('style', $content, false)->withAttributes($attributes);
+    }
+
+    public function withAttribute(string $name, \Stringable|bool|float|int|string|null $value = true): self
+    {
+        $clone = clone $this;
+        $clone->attributes->set($name, $value);
+
+        return $clone;
+    }
+
+    /**
+     * @param HtmlAttributes|iterable<string, \Stringable|bool|float|int|string|null>|string|null $attributes
+     */
+    public function withAttributes(HtmlAttributes|iterable|string|null $attributes): self
+    {
+        $clone = clone $this;
+        $clone->attributes->mergeWith($attributes);
+
+        return $clone;
+    }
+
+    public function withContent(string $content): self
+    {
+        $clone = clone $this;
+        $clone->content = $content;
+        $clone->escapeContent = true;
+
+        return $clone;
+    }
+
+    /**
+     * Only pass trusted HTML, CSS or JavaScript to this method.
+     */
+    public function withRawContent(string $content): self
+    {
+        $clone = clone $this;
+        $clone->content = $content;
+        $clone->escapeContent = false;
+
+        return $clone;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getAttributes(): HtmlAttributes
+    {
+        return clone $this->attributes;
+    }
+
+    public function getContent(): string|null
+    {
+        return $this->content;
+    }
+
+    public function escapesContent(): bool
+    {
+        return $this->escapeContent;
+    }
+
+    public function isInlineScript(): bool
+    {
+        return 'script' === $this->name && null !== $this->content && !isset($this->attributes['src']);
+    }
+
+    public function isInlineStyle(): bool
+    {
+        return 'style' === $this->name && null !== $this->content;
+    }
+
+    /**
+     * Returns a deterministic semantic identifier suitable for ordering tags.
+     */
+    public function getSuggestedIdentifier(): string
+    {
+        if ('script' === $this->name && $identifier = $this->getAttributeIdentifier('src')) {
+            return $identifier;
+        }
+
+        if ('link' === $this->name && $identifier = $this->getAttributeIdentifier('rel', 'href')) {
+            return $identifier;
+        }
+
+        if ('meta' === $this->name) {
+            foreach (['charset', 'name', 'property', 'http-equiv', 'itemprop'] as $attribute) {
+                if ($identifier = $this->getAttributeIdentifier($attribute)) {
+                    return $identifier;
+                }
+            }
+        }
+
+        if ('title' === $this->name) {
+            return 'title';
+        }
+
+        return "{$this->name}[".hash('xxh3', $this->toHtml()).']';
+    }
+
+    /**
+     * @internal
+     */
+    public function toHtml(): string
+    {
+        if (\in_array($this->name, self::VOID_ELEMENTS, true)) {
+            return "<{$this->name}{$this->attributes}>";
+        }
+
+        $content = $this->content ?? '';
+
+        if ($this->escapeContent) {
+            $content = htmlspecialchars($content, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }
+
+        return "<{$this->name}{$this->attributes}>$content</{$this->name}>";
+    }
+
+    private function getAttributeIdentifier(string ...$attributes): string|null
+    {
+        $identifier = $this->name;
+
+        foreach ($attributes as $attribute) {
+            if (!isset($this->attributes[$attribute])) {
+                return null;
+            }
+
+            $value = json_encode((string) $this->attributes[$attribute], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+            $identifier .= "[$attribute=$value]";
+        }
+
+        return $identifier;
+    }
+}

--- a/core-bundle/src/Routing/ResponseContext/HtmlTag.php
+++ b/core-bundle/src/Routing/ResponseContext/HtmlTag.php
@@ -16,11 +16,6 @@ use Contao\CoreBundle\String\HtmlAttributes;
 
 final class HtmlTag
 {
-    private const VOID_ELEMENTS = [
-        'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
-        'link', 'meta', 'source', 'track', 'wbr',
-    ];
-
     private HtmlAttributes $attributes;
 
     private function __construct(
@@ -211,25 +206,12 @@ final class HtmlTag
             return 'title';
         }
 
-        return "{$this->name}[".hash('xxh3', $this->toHtml()).']';
-    }
+        $payload = json_encode(
+            [$this->name, $this->attributes, $this->content, $this->escapeContent],
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+        );
 
-    /**
-     * @internal
-     */
-    public function toHtml(): string
-    {
-        if (\in_array($this->name, self::VOID_ELEMENTS, true)) {
-            return "<{$this->name}{$this->attributes}>";
-        }
-
-        $content = $this->content ?? '';
-
-        if ($this->escapeContent) {
-            $content = htmlspecialchars($content, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-        }
-
-        return "<{$this->name}{$this->attributes}>$content</{$this->name}>";
+        return "{$this->name}[".hash('xxh3', $payload).']';
     }
 
     private function getAttributeIdentifier(string ...$attributes): string|null

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -23,7 +23,6 @@ use Contao\CoreBundle\Twig\Inheritance\DynamicUseTokenParser;
 use Contao\CoreBundle\Twig\Inspector\InspectorNodeVisitor;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
-use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
 use Contao\CoreBundle\Twig\Runtime\AutolinkRuntime;
 use Contao\CoreBundle\Twig\Runtime\BackendHelperRuntime;
 use Contao\CoreBundle\Twig\Runtime\ContentUrlRuntime;
@@ -33,6 +32,7 @@ use Contao\CoreBundle\Twig\Runtime\FormatterRuntime;
 use Contao\CoreBundle\Twig\Runtime\FragmentRuntime;
 use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
 use Contao\CoreBundle\Twig\Runtime\HighlightResult;
+use Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\CoreBundle\Twig\Runtime\LegacyTemplateFunctionsRuntime;
 use Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime;
@@ -97,7 +97,7 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
             new DynamicIncludeTokenParser($this->filesystemLoader),
             new DynamicUseTokenParser($this->filesystemLoader),
             // Add a parser for the Contao specific "add" tag
-            new AddTokenParser(self::class),
+            new AddTokenParser(),
             // Add a parser for the Contao specific "slot" tag
             new SlotTokenParser(),
             // Add a parser for the Contao specific "defer" tag
@@ -302,6 +302,11 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
                 [AutolinkRuntime::class, 'linkUrls'],
                 ['pre_escape' => 'html', 'is_safe' => ['html']],
             ),
+            new TwigFilter(
+                'contao_html_tag',
+                [HtmlDocumentRuntime::class, 'renderHtmlTag'],
+                ['is_safe' => ['html']],
+            ),
         ];
     }
 
@@ -311,36 +316,6 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
     public function getCurrentThemeSlug(): string|null
     {
         return $this->filesystemLoader->getCurrentThemeSlug();
-    }
-
-    /**
-     * @see AddNode
-     * @see AddTokenParser
-     *
-     * @internal
-     */
-    public function addDocumentContent(string|null $identifier, string $content, DocumentLocation $location): void
-    {
-        // TODO: This should make use of the response context in the future.
-        if (DocumentLocation::head === $location) {
-            if (null !== $identifier) {
-                $GLOBALS['TL_HEAD'][$identifier] = $content;
-            } else {
-                $GLOBALS['TL_HEAD'][] = $content;
-            }
-        } elseif (DocumentLocation::endOfBody === $location) {
-            if (null !== $identifier) {
-                $GLOBALS['TL_BODY'][$identifier] = $content;
-            } else {
-                $GLOBALS['TL_BODY'][] = $content;
-            }
-        } elseif (DocumentLocation::stylesheets === $location) {
-            if (null !== $identifier) {
-                $GLOBALS['TL_STYLE_SHEETS'][$identifier] = $content;
-            } else {
-                $GLOBALS['TL_STYLE_SHEETS'][] = $content;
-            }
-        }
     }
 
     private function getTwigIncludeFunction(): TwigFunction

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -32,7 +32,6 @@ use Contao\CoreBundle\Twig\Runtime\FormatterRuntime;
 use Contao\CoreBundle\Twig\Runtime\FragmentRuntime;
 use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
 use Contao\CoreBundle\Twig\Runtime\HighlightResult;
-use Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\CoreBundle\Twig\Runtime\LegacyTemplateFunctionsRuntime;
 use Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime;
@@ -301,11 +300,6 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
                 'autolink_url',
                 [AutolinkRuntime::class, 'linkUrls'],
                 ['pre_escape' => 'html', 'is_safe' => ['html']],
-            ),
-            new TwigFilter(
-                'contao_html_tag',
-                [HtmlDocumentRuntime::class, 'renderHtmlTag'],
-                ['is_safe' => ['html']],
             ),
         ];
     }

--- a/core-bundle/src/Twig/ResponseContext/AddNode.php
+++ b/core-bundle/src/Twig/ResponseContext/AddNode.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\ResponseContext;
 
+use Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime;
 use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Node\Node;
@@ -23,17 +24,16 @@ use Twig\Node\NodeCaptureInterface;
 #[YieldReady]
 final class AddNode extends Node implements NodeCaptureInterface
 {
-    public function __construct(string $extensionName, Node $body, string|null $identifier, DocumentLocation $location, int $lineno)
+    /**
+     * @param array{identifier: string|null, location: DocumentLocation, position: string|null, reference: string|null} $attributes
+     */
+    public function __construct(Node $body, array $attributes, int $lineno)
     {
         parent::__construct(
             [
                 'body' => $body,
             ],
-            [
-                'extension_name' => $extensionName,
-                'identifier' => $identifier,
-                'location' => $location,
-            ],
+            $attributes,
             $lineno,
         );
     }
@@ -62,16 +62,39 @@ final class AddNode extends Node implements NodeCaptureInterface
             ->write('}'."\n")
             ->outdent()
             ->write('} finally { ob_end_clean(); }'."\n")
-            ->write('$this->extensions[')
-            ->repr($this->getAttribute('extension_name'))
-            ->raw(']->addDocumentContent('."\n")
+            ->write('$this->env->getRuntime(')
+            ->repr(HtmlDocumentRuntime::class)
+            ->raw(')->add('."\n")
             ->indent()
-            ->write('')
-            ->repr($this->getAttribute('identifier'))
-            ->raw(', $__contao_document_content, ')
-            ->raw(\sprintf('\\%s::%s', DocumentLocation::class, $this->getAttribute('location')->name)."\n")
+            ->write('$__contao_document_content, ')
+            ->raw(\sprintf('\\%s::%s, ', DocumentLocation::class, $this->getAttribute('location')->name))
+            ->repr($this->getOptions())
+            ->raw("\n")
             ->outdent()
             ->write(');'."\n")
         ;
+    }
+
+    /**
+     * @return array{identifier?: string, before?: string, after?: string}
+     */
+    private function getOptions(): array
+    {
+        $options = [];
+
+        if (null !== $identifier = $this->getAttribute('identifier')) {
+            $options['identifier'] = $identifier;
+        }
+
+        $position = $this->getAttribute('position');
+        $reference = $this->getAttribute('reference');
+
+        if ('before' === $position && null !== $reference) {
+            $options['before'] = $reference;
+        } elseif ('after' === $position && null !== $reference) {
+            $options['after'] = $reference;
+        }
+
+        return $options;
     }
 }

--- a/core-bundle/src/Twig/ResponseContext/AddTokenParser.php
+++ b/core-bundle/src/Twig/ResponseContext/AddTokenParser.php
@@ -16,21 +16,18 @@ use Twig\Error\SyntaxError;
 use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
+use Twig\TokenStream;
 
 /**
  * @internal
  */
 final class AddTokenParser extends AbstractTokenParser
 {
-    public function __construct(private readonly string $extensionName)
-    {
-    }
-
     public function parse(Token $token): Node
     {
         $stream = $this->parser->getStream();
 
-        // Parse opening tag: {% add to body %} or {% add 'foo' to body %}
+        // Parse opening tag: {% add to body %} or {% add 'foo' to body after 'bar' %}
         $identifier = null;
 
         if ($stream->test(Token::STRING_TYPE)) {
@@ -38,18 +35,8 @@ final class AddTokenParser extends AbstractTokenParser
             $stream->next();
         }
 
-        $stream->expect(Token::NAME_TYPE, 'to');
-        $locationToken = $stream->expect(Token::NAME_TYPE, null, '');
-        $locationString = $locationToken->getValue();
-
-        if (!$location = DocumentLocation::tryFrom($locationString)) {
-            $validLocations = array_map(
-                static fn (DocumentLocation $location): string => $location->value,
-                DocumentLocation::cases(),
-            );
-
-            throw new SyntaxError(\sprintf('The parameter "%s" is not a valid location for the "add" tag, use "%s" instead.', $locationString, implode('" or "', $validLocations)));
-        }
+        $location = $this->parseLocation($stream);
+        [$position, $reference] = $this->parsePosition($stream, $identifier, $token);
 
         $stream->expect(Token::BLOCK_END_TYPE);
 
@@ -57,7 +44,16 @@ final class AddTokenParser extends AbstractTokenParser
         $body = $this->parser->subparse($this->decideAddEnd(...), true);
         $stream->expect(Token::BLOCK_END_TYPE);
 
-        return new AddNode($this->extensionName, $body, $identifier, $location, $token->getLine());
+        return new AddNode(
+            $body,
+            [
+                'identifier' => $identifier,
+                'location' => $location,
+                'position' => $position,
+                'reference' => $reference,
+            ],
+            $token->getLine(),
+        );
     }
 
     /**
@@ -74,5 +70,42 @@ final class AddTokenParser extends AbstractTokenParser
     public function getTag(): string
     {
         return 'add';
+    }
+
+    private function parseLocation(TokenStream $stream): DocumentLocation
+    {
+        $stream->expect(Token::NAME_TYPE, 'to');
+        $locationToken = $stream->expect(Token::NAME_TYPE, null, '');
+        $locationString = $locationToken->getValue();
+
+        if ($location = DocumentLocation::tryFrom($locationString)) {
+            return $location;
+        }
+
+        $validLocations = array_map(
+            static fn (DocumentLocation $location): string => $location->value,
+            DocumentLocation::cases(),
+        );
+
+        throw new SyntaxError(\sprintf('The parameter "%s" is not a valid location for the "add" tag, use "%s" instead.', $locationString, implode('" or "', $validLocations)));
+    }
+
+    /**
+     * @return array{string|null, string|null}
+     */
+    private function parsePosition(TokenStream $stream, string|null $identifier, Token $token): array
+    {
+        if (!$stream->test(Token::NAME_TYPE, ['before', 'after'])) {
+            return [null, null];
+        }
+
+        $position = $stream->getCurrent()->getValue();
+        $stream->next();
+
+        if (null === $identifier) {
+            throw new SyntaxError('An identifier is required when ordering content with the "add" tag.', $token->getLine(), $stream->getSourceContext());
+        }
+
+        return [$position, $stream->expect(Token::STRING_TYPE)->getValue()];
     }
 }

--- a/core-bundle/src/Twig/Runtime/HtmlDocumentRuntime.php
+++ b/core-bundle/src/Twig/Runtime/HtmlDocumentRuntime.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Runtime;
+
+use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlTag;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
+use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class HtmlDocumentRuntime implements RuntimeExtensionInterface
+{
+    private int $unnamedTagCounter = 0;
+
+    public function __construct(
+        private readonly ResponseContextAccessor $responseContextAccessor,
+        private readonly bool $debug = false,
+    ) {
+    }
+
+    public function renderHtmlTag(HtmlTag|string $tag, int|string|null $identifier = null): string
+    {
+        if (\is_string($tag)) {
+            if ($this->debug && null !== $identifier) {
+                return $this->addDebugIdentifierComment($tag, $identifier);
+            }
+
+            return $tag;
+        }
+
+        if ($this->debug && null !== $identifier) {
+            $tag = $tag->withAttribute('data-contao-tag', (string) $identifier);
+        }
+
+        return $this->addCspNonce($tag)->toHtml();
+    }
+
+    /**
+     * @internal
+     *
+     * @param array{identifier?: string, before?: string, after?: string} $options
+     */
+    public function add(string $content, DocumentLocation $location, array $options = []): void
+    {
+        $responseContext = $this->responseContextAccessor->getResponseContext();
+
+        if ($responseContext && DocumentLocation::endOfBody === $location) {
+            if ($this->addToBody($responseContext, $content, $options)) {
+                return;
+            }
+        }
+
+        if ($responseContext && DocumentLocation::endOfBody !== $location && $responseContext->has(HtmlHeadBag::class)) {
+            $head = $responseContext->get(HtmlHeadBag::class);
+            $identifier = $options['identifier'] ?? (string) ++$this->unnamedTagCounter;
+            $position = match (true) {
+                isset($options['before']) => ['before' => $options['before']],
+                isset($options['after']) => ['after' => $options['after']],
+                default => [],
+            };
+
+            if (DocumentLocation::head === $location) {
+                $head->addRawToHead($identifier, $content, $position);
+            } else {
+                $head->addRawToStylesheets($identifier, $content, $position);
+            }
+
+            return;
+        }
+
+        $this->addLegacyContent($options['identifier'] ?? null, $content, $location);
+    }
+
+    private function addDebugIdentifierComment(string $markup, int|string $identifier): string
+    {
+        $identifier = $this->normalizeDebugIdentifier((string) $identifier);
+        $identifier = trim(str_replace(['--', "\r", "\n"], ['- -', ' ', ' '], $identifier));
+
+        return "<!-- contao-tag: $identifier -->$markup";
+    }
+
+    private function normalizeDebugIdentifier(string $identifier): string
+    {
+        foreach (['contao.twig.head.', 'contao.twig.stylesheets.'] as $prefix) {
+            if (str_starts_with($identifier, $prefix)) {
+                return substr($identifier, \strlen($prefix));
+            }
+        }
+
+        return $identifier;
+    }
+
+    /**
+     * @param array{identifier?: string, before?: string, after?: string} $options
+     */
+    private function addToBody(ResponseContext $responseContext, string $content, array $options): bool
+    {
+        if (!$responseContext->has(HtmlBodyBag::class)) {
+            return false;
+        }
+
+        $body = $responseContext->get(HtmlBodyBag::class);
+        $identifier = $options['identifier'] ?? null;
+
+        if (isset($options['before'])) {
+            $body->addBefore($content, $options['before'], $identifier);
+        } elseif (isset($options['after'])) {
+            $body->addAfter($content, $options['after'], $identifier);
+        } else {
+            $body->add($content, $identifier);
+        }
+
+        return true;
+    }
+
+    private function addLegacyContent(string|null $identifier, string $content, DocumentLocation $location): void
+    {
+        trigger_deprecation(
+            'contao/core-bundle',
+            '6.1',
+            'Using the Twig "add" tag without the corresponding response context bag is deprecated and will no longer work in Contao 7.',
+        );
+
+        $global = match ($location) {
+            DocumentLocation::head => 'TL_HEAD',
+            DocumentLocation::stylesheets => 'TL_STYLE_SHEETS',
+            DocumentLocation::endOfBody => 'TL_BODY',
+        };
+
+        if (null !== $identifier) {
+            $GLOBALS[$global][$identifier] = $content;
+        } else {
+            $GLOBALS[$global][] = $content;
+        }
+    }
+
+    private function addCspNonce(HtmlTag $tag): HtmlTag
+    {
+        if (isset($tag->getAttributes()['nonce']) || (!$tag->isInlineScript() && !$tag->isInlineStyle())) {
+            return $tag;
+        }
+
+        $responseContext = $this->responseContextAccessor->getResponseContext();
+
+        if (!$responseContext?->has(CspHandler::class)) {
+            return $tag;
+        }
+
+        $directive = $tag->isInlineScript() ? 'script-src' : 'style-src';
+
+        if ($nonce = $responseContext->get(CspHandler::class)->getNonce($directive)) {
+            return $tag->withAttribute('nonce', $nonce);
+        }
+
+        return $tag;
+    }
+}

--- a/core-bundle/src/Twig/Runtime/HtmlDocumentRuntime.php
+++ b/core-bundle/src/Twig/Runtime/HtmlDocumentRuntime.php
@@ -12,10 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\Runtime;
 
-use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
-use Contao\CoreBundle\Routing\ResponseContext\HtmlTag;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
 use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
@@ -25,27 +23,8 @@ final class HtmlDocumentRuntime implements RuntimeExtensionInterface
 {
     private int $unnamedTagCounter = 0;
 
-    public function __construct(
-        private readonly ResponseContextAccessor $responseContextAccessor,
-        private readonly bool $debug = false,
-    ) {
-    }
-
-    public function renderHtmlTag(HtmlTag|string $tag, int|string|null $identifier = null): string
+    public function __construct(private readonly ResponseContextAccessor $responseContextAccessor)
     {
-        if (\is_string($tag)) {
-            if ($this->debug && null !== $identifier) {
-                return $this->addDebugIdentifierComment($tag, $identifier);
-            }
-
-            return $tag;
-        }
-
-        if ($this->debug && null !== $identifier) {
-            $tag = $tag->withAttribute('data-contao-tag', (string) $identifier);
-        }
-
-        return $this->addCspNonce($tag)->toHtml();
     }
 
     /**
@@ -82,25 +61,6 @@ final class HtmlDocumentRuntime implements RuntimeExtensionInterface
         }
 
         $this->addLegacyContent($options['identifier'] ?? null, $content, $location);
-    }
-
-    private function addDebugIdentifierComment(string $markup, int|string $identifier): string
-    {
-        $identifier = $this->normalizeDebugIdentifier((string) $identifier);
-        $identifier = trim(str_replace(['--', "\r", "\n"], ['- -', ' ', ' '], $identifier));
-
-        return "<!-- contao-tag: $identifier -->$markup";
-    }
-
-    private function normalizeDebugIdentifier(string $identifier): string
-    {
-        foreach (['contao.twig.head.', 'contao.twig.stylesheets.'] as $prefix) {
-            if (str_starts_with($identifier, $prefix)) {
-                return substr($identifier, \strlen($prefix));
-            }
-        }
-
-        return $identifier;
     }
 
     /**
@@ -145,26 +105,5 @@ final class HtmlDocumentRuntime implements RuntimeExtensionInterface
         } else {
             $GLOBALS[$global][] = $content;
         }
-    }
-
-    private function addCspNonce(HtmlTag $tag): HtmlTag
-    {
-        if (isset($tag->getAttributes()['nonce']) || (!$tag->isInlineScript() && !$tag->isInlineStyle())) {
-            return $tag;
-        }
-
-        $responseContext = $this->responseContextAccessor->getResponseContext();
-
-        if (!$responseContext?->has(CspHandler::class)) {
-            return $tag;
-        }
-
-        $directive = $tag->isInlineScript() ? 'script-src' : 'style-src';
-
-        if ($nonce = $responseContext->get(CspHandler::class)->getNonce($directive)) {
-            return $tag->withAttribute('nonce', $nonce);
-        }
-
-        return $tag;
     }
 }

--- a/core-bundle/tests/Contao/ArrayUtilTest.php
+++ b/core-bundle/tests/Contao/ArrayUtilTest.php
@@ -39,6 +39,65 @@ class ArrayUtilTest extends TestCase
         ];
     }
 
+    public function testSortsByOrderConstraints(): void
+    {
+        $items = [
+            'first' => 1,
+            'second' => 2,
+            'third' => 3,
+            'fourth' => 4,
+        ];
+
+        $this->assertSame(
+            [
+                'third' => 3,
+                'first' => 1,
+                'second' => 2,
+                'fourth' => 4,
+            ],
+            ArrayUtil::sortByOrderConstraints($items, [
+                'third' => ['before' => 'first'],
+                'fourth' => ['after' => 'first'],
+                'second' => ['after' => 'missing'],
+            ]),
+        );
+    }
+
+    public function testRejectsCyclicOrderConstraints(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cyclic array ordering constraints');
+
+        ArrayUtil::sortByOrderConstraints(
+            ['first' => 1, 'second' => 2],
+            [
+                'first' => ['after' => 'second'],
+                'second' => ['after' => 'first'],
+            ],
+        );
+    }
+
+    public function testDoesNotCreateCyclesWhenStabilizingTheOrder(): void
+    {
+        $this->assertSame(
+            [
+                'b' => 2,
+                'x' => 3,
+                'a' => 1,
+            ],
+            ArrayUtil::sortByOrderConstraints(
+                [
+                    'a' => 1,
+                    'b' => 2,
+                    'x' => 3,
+                ],
+                [
+                    'x' => ['after' => 'b', 'before' => 'a'],
+                ],
+            ),
+        );
+    }
+
     #[DataProvider('sortByOrderFieldProvider')]
     public function testSortsByOrderField(array $items, array $order, array $expected): void
     {

--- a/core-bundle/tests/ContentComposition/ContentCompositionBuilderTest.php
+++ b/core-bundle/tests/ContentComposition/ContentCompositionBuilderTest.php
@@ -12,6 +12,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Image\PictureFactory;
 use Contao\CoreBundle\Image\Preview\PreviewFactory;
 use Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Routing\ResponseContext\JsonLd\JsonLdManager;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
@@ -22,6 +23,7 @@ use Contao\LayoutModel;
 use Contao\PageModel;
 use Contao\System;
 use Contao\ThemeModel;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\LoggerInterface;
 use Spatie\SchemaOrg\Graph;
 use Symfony\Component\HttpFoundation\Request;
@@ -185,6 +187,7 @@ class ContentCompositionBuilderTest extends TestCase
     public function testAddsResponseContextDataToTemplate(): void
     {
         $responseContext = new ResponseContext();
+        $responseContext->add(new HtmlBodyBag()->add('<script>/* response context script */</script>'));
         $responseContext->add($htmlHeadBag = new HtmlHeadBag());
         $responseContext->add($jsonLdManager = new JsonLdManager($responseContext));
 
@@ -206,12 +209,6 @@ class ContentCompositionBuilderTest extends TestCase
             ->set($jsonLdManager->createSchemaOrgTypeFromArray(['@type' => 'ImageObject', 'name' => 'Name']), Graph::IDENTIFIER_DEFAULT)
         ;
 
-        $GLOBALS['TL_HEAD'][] = '<meta content="additional-tag">';
-        $GLOBALS['TL_BODY'][] = '<script>/* additional script */</script>';
-        $GLOBALS['TL_STYLE_SHEETS'][] = '<link rel="stylesheet" href="additional_stylesheet.css">';
-        $GLOBALS['TL_CSS'][] = 'additional_stylesheet_filename.css|123';
-        $GLOBALS['TL_JAVASCRIPT'][] = 'additional_javascript_filename.js|123|async|defer';
-
         $parameters = $this
             ->getContentCompositionBuilder(
                 responseContextAccessor: $responseContextAccessor,
@@ -223,15 +220,9 @@ class ContentCompositionBuilderTest extends TestCase
 
         $expectedResponseContextData = [
             'head' => $htmlHeadBag,
-            'end_of_head' => [
-                '<link rel="stylesheet" href="https://static-url/additional_stylesheet_filename.css?v=202cb962">',
-                '<script src="https://static-url/additional_javascript_filename.js?v=202cb962" async defer></script>',
-                '<link rel="stylesheet" href="additional_stylesheet.css">',
-                '<meta content="additional-tag">',
-            ],
-            'end_of_body' => [
-                '<script>/* additional script */</script>',
-            ],
+            'body' => $responseContext->get(HtmlBodyBag::class),
+            'end_of_head' => [],
+            'end_of_body' => [],
             'json_ld_scripts' => <<<'EOF'
                 <script type="application/ld+json">
                 {
@@ -249,6 +240,114 @@ class ContentCompositionBuilderTest extends TestCase
 
         $this->assertArrayHasKey('response_context', $parameters);
         $this->assertSame($expectedResponseContextData, iterator_to_array($parameters['response_context']->all()));
+        $this->assertSame(
+            ['<script>/* response context script */</script>'],
+            $parameters['response_context']->body->all(),
+        );
+    }
+
+    #[DataProvider('providePageTitles')]
+    public function testStoresTheFinalPageTitleInTheHeadBag(string $title, string $rootPageTitle, string $expected): void
+    {
+        $responseContext = new ResponseContext()->add($head = new HtmlHeadBag()->setTitle($title));
+        $responseContextAccessor = $this->createStub(ResponseContextAccessor::class);
+        $responseContextAccessor
+            ->method('getResponseContext')
+            ->willReturn($responseContext)
+        ;
+        $page = $this->createClassWithPropertiesStub(PageModel::class, [
+            'layout' => 1,
+            'language' => 'en',
+            'rootPageTitle' => $rootPageTitle,
+        ]);
+
+        $template = $this->getContentCompositionBuilder($this->mockFramework(), $page, responseContextAccessor: $responseContextAccessor)
+            ->buildLayoutTemplate()
+        ;
+
+        $this->assertSame($title, $head->getTitle());
+        $this->assertSame($head, $template->getData()['response_context']->head);
+        $this->assertSame($expected, $head->getTitle());
+        $this->assertSame($expected, $head->all()[HtmlHeadBag::TAG_TITLE]->getContent());
+    }
+
+    public function testFinalizesThePageTitleAfterContentRendering(): void
+    {
+        $responseContext = new ResponseContext()->add($head = new HtmlHeadBag()->setTitle('Page title'));
+        $responseContextAccessor = $this->createStub(ResponseContextAccessor::class);
+        $responseContextAccessor
+            ->method('getResponseContext')
+            ->willReturn($responseContext)
+        ;
+        $page = $this->createClassWithPropertiesStub(PageModel::class, [
+            'layout' => 1,
+            'language' => 'en',
+            'rootPageTitle' => 'Root title',
+        ]);
+
+        $template = $this->getContentCompositionBuilder($this->mockFramework(), $page, responseContextAccessor: $responseContextAccessor)
+            ->buildLayoutTemplate()
+        ;
+
+        // Simulate a reader module overwriting the title while its content is rendered.
+        $head->setTitle('Reader title');
+
+        $this->assertSame($head, $template->getData()['response_context']->head);
+        $this->assertSame('Reader title - Root title', $head->getTitle());
+        $this->assertSame('Reader title - Root title', $head->all()[HtmlHeadBag::TAG_TITLE]->getContent());
+    }
+
+    public static function providePageTitles(): iterable
+    {
+        yield 'page and root title' => ['Page title', 'Root title', 'Page title - Root title'];
+        yield 'root title only' => ['', 'Root title', 'Root title'];
+        yield 'page title only' => ['Page title', '', 'Page title'];
+    }
+
+    public function testSupportsAndDeprecatesLegacyDocumentContentGlobals(): void
+    {
+        $responseContext = new ResponseContext()
+            ->add(new HtmlBodyBag())
+            ->add(new HtmlHeadBag())
+        ;
+        $responseContextAccessor = $this->createStub(ResponseContextAccessor::class);
+        $responseContextAccessor
+            ->method('getResponseContext')
+            ->willReturn($responseContext)
+        ;
+        $responseContextFactory = $this->createMock(CoreResponseContextFactory::class);
+        $responseContextFactory
+            ->expects($this->never())
+            ->method('createContaoWebpageResponseContext')
+        ;
+
+        $parameters = $this
+            ->getContentCompositionBuilder(
+                responseContextAccessor: $responseContextAccessor,
+                responseContextFactory: $responseContextFactory,
+            )
+            ->buildLayoutTemplate()
+            ->getData()
+        ;
+
+        $GLOBALS['TL_HEAD'][] = '<meta data-legacy>';
+        $GLOBALS['TL_BODY'][] = '<script data-legacy></script>';
+        $GLOBALS['TL_STYLE_SHEETS'][] = '<link rel="stylesheet" href="legacy.css">';
+        $GLOBALS['TL_CSS'][] = 'legacy.css|123';
+        $GLOBALS['TL_JAVASCRIPT'][] = 'legacy.js|123|async|defer';
+
+        $this->expectUserDeprecationMessageMatches('/Using legacy document content globals is deprecated/');
+
+        $this->assertSame(
+            [
+                '<link rel="stylesheet" href="https://static-url/legacy.css?v=202cb962">',
+                '<script src="https://static-url/legacy.js?v=202cb962" async defer></script>',
+                '<link rel="stylesheet" href="legacy.css">',
+                '<meta data-legacy>',
+            ],
+            $parameters['response_context']->end_of_head,
+        );
+        $this->assertSame(['<script data-legacy></script>'], $parameters['response_context']->end_of_body);
     }
 
     public function testAddsCompositedContentToTemplate(): void

--- a/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
@@ -35,6 +35,9 @@ use Contao\CoreBundle\InsertTag\ChunkedText;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\CoreBundle\Routing\PageFinder;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
@@ -55,6 +58,7 @@ use Contao\CoreBundle\Twig\Runtime\CspRuntime;
 use Contao\CoreBundle\Twig\Runtime\FormatterRuntime;
 use Contao\CoreBundle\Twig\Runtime\FragmentRuntime;
 use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
+use Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime;
 use Contao\CoreBundle\Twig\Runtime\StringRuntime;
@@ -114,6 +118,10 @@ abstract class ContentElementTestCase extends TestCase
     final public const ARTICLE2 = 456;
 
     final public const PAGE1 = 5;
+
+    private HtmlBodyBag|null $htmlBodyBag = null;
+
+    private HtmlHeadBag|null $htmlHeadBag = null;
 
     protected function tearDown(): void
     {
@@ -242,14 +250,12 @@ abstract class ContentElementTestCase extends TestCase
 
         // Record response context data
         $responseContextData = array_filter([
-            DocumentLocation::head->value => $GLOBALS['TL_HEAD'] ?? [],
-            DocumentLocation::stylesheets->value => $GLOBALS['TL_STYLE_SHEETS'] ?? [],
-            DocumentLocation::endOfBody->value => $GLOBALS['TL_BODY'] ?? [],
+            DocumentLocation::head->value => $this->getAddedHeadContent(DocumentLocation::head),
+            DocumentLocation::stylesheets->value => $this->getAddedHeadContent(DocumentLocation::stylesheets),
+            DocumentLocation::endOfBody->value => $this->htmlBodyBag?->all() ?? [],
         ]);
 
         // Reset state
-        unset($GLOBALS['TL_HEAD'], $GLOBALS['TL_STYLE_SHEETS'], $GLOBALS['TL_BODY']);
-
         $this->resetStaticProperties([Highlighter::class]);
 
         return $response;
@@ -343,14 +349,21 @@ abstract class ContentElementTestCase extends TestCase
         $environment->addExtension(new AssetExtension($packages));
         $environment->addExtension(new RoutingExtension($this->createStub(UrlGeneratorInterface::class)));
 
-        $environment->addExtension(
-            new ContaoExtension(
-                $environment,
-                $contaoFilesystemLoader,
-                $this->createStub(ContaoVariable::class),
-                new InspectorNodeVisitor($this->createStub(Storage::class), $environment),
-            ),
+        $responseContextAccessor = $this->createStub(ResponseContextAccessor::class);
+        $responseContextAccessor
+            ->method('getResponseContext')
+            ->willReturn(new ResponseContext()
+                ->add($this->htmlBodyBag = new HtmlBodyBag())
+                ->add($this->htmlHeadBag = new HtmlHeadBag()))
+        ;
+        $extension = new ContaoExtension(
+            $environment,
+            $contaoFilesystemLoader,
+            $this->createStub(ContaoVariable::class),
+            new InspectorNodeVisitor($this->createStub(Storage::class), $environment),
         );
+
+        $environment->addExtension($extension);
 
         $sanitizers = new ContainerBuilder();
         $sanitizers->set('html', new HtmlSanitizer(new HtmlSanitizerConfig()));
@@ -360,11 +373,11 @@ abstract class ContentElementTestCase extends TestCase
 
         // Runtime loaders
         $insertTagParser = $this->getDefaultInsertTagParser();
-        $responseContextAccessor = $this->createStub(ResponseContextAccessor::class);
 
         $environment->addRuntimeLoader(
             new FactoryRuntimeLoader([
                 FragmentRuntime::class => static fn () => new FragmentRuntime($framework),
+                HtmlDocumentRuntime::class => static fn () => new HtmlDocumentRuntime($responseContextAccessor),
                 InsertTagRuntime::class => static fn () => new InsertTagRuntime($insertTagParser),
                 HighlighterRuntime::class => static fn () => new HighlighterRuntime(),
                 SchemaOrgRuntime::class => static fn () => new SchemaOrgRuntime($responseContextAccessor),
@@ -614,6 +627,23 @@ abstract class ContentElementTestCase extends TestCase
             Controller::class => $controllerAdapter,
             StringUtil::class => $stringUtil,
         ]);
+    }
+
+    /**
+     * @return array<array-key, string>
+     */
+    private function getAddedHeadContent(DocumentLocation $location): array
+    {
+        $prefix = "contao.twig.{$location->value}.";
+        $content = [];
+
+        foreach ($this->htmlHeadBag?->all() ?? [] as $identifier => $tag) {
+            if (\is_string($tag) && str_starts_with($identifier, $prefix)) {
+                $content[substr($identifier, \strlen($prefix))] = $tag;
+            }
+        }
+
+        return $content;
     }
 
     private function setDefaultSanitizerConfig(): void

--- a/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
@@ -24,6 +24,7 @@ use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory;
 use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
 use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandlerFactory;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Routing\ResponseContext\JsonLd\ContaoPageSchema;
 use Contao\CoreBundle\Routing\ResponseContext\JsonLd\JsonLdManager;
@@ -98,6 +99,7 @@ class CoreResponseContextFactoryTest extends TestCase
 
         $responseContext = $factory->createWebpageResponseContext();
 
+        $this->assertInstanceOf(HtmlBodyBag::class, $responseContext->get(HtmlBodyBag::class));
         $this->assertInstanceOf(HtmlHeadBag::class, $responseContext->get(HtmlHeadBag::class));
         $this->assertTrue($responseContext->has(JsonLdManager::class));
         $this->assertFalse($responseContext->isInitialized(JsonLdManager::class));

--- a/core-bundle/tests/Routing/ResponseContext/HtmlBodyBagTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/HtmlBodyBagTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Routing\ResponseContext;
+
+use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlTag;
+use PHPUnit\Framework\TestCase;
+
+class HtmlBodyBagTest extends TestCase
+{
+    public function testAddsAndReplacesContent(): void
+    {
+        $bag = new HtmlBodyBag();
+        $bag
+            ->add('<script src="/first.js"></script>')
+            ->add('<script src="/old.js"></script>', 'app')
+            ->add('<script src="/app.js"></script>', 'app')
+        ;
+
+        $this->assertSame(
+            [
+                '<script src="/first.js"></script>',
+                'app' => '<script src="/app.js"></script>',
+            ],
+            $bag->all(),
+        );
+        $this->assertSame($bag->all(), iterator_to_array($bag));
+    }
+
+    public function testOrdersContentBySemanticTagReference(): void
+    {
+        $bag = new HtmlBodyBag();
+        $bag
+            ->addAfter(HtmlTag::script('/app.js'), HtmlTag::script('/vendor.js'))
+            ->add(HtmlTag::script('/analytics.js'), 'analytics')
+            ->addBefore(HtmlTag::script('/polyfill.js'), HtmlTag::script('/vendor.js'))
+            ->add(HtmlTag::script('/vendor.js'), 'vendor')
+        ;
+
+        $expectedIdentifiers = [
+            'analytics',
+            'script[src="/polyfill.js"]',
+            'vendor',
+            'script[src="/app.js"]',
+        ];
+
+        $this->assertSame($expectedIdentifiers, array_keys($bag->all()));
+        $this->assertSame($expectedIdentifiers, array_keys(iterator_to_array($bag)));
+        $this->assertSame('/app.js', $bag->all()['script[src="/app.js"]']->getAttributes()['src']);
+    }
+
+    public function testOrdersContentByStringIdentifierReference(): void
+    {
+        $bag = new HtmlBodyBag();
+        $bag
+            ->addAfter(HtmlTag::script('/app.js'), 'vendor', 'app')
+            ->addBefore(HtmlTag::script('/polyfill.js'), 'vendor', 'polyfill')
+            ->add(HtmlTag::script('/vendor.js'), 'vendor')
+        ;
+
+        $this->assertSame(
+            ['polyfill', 'vendor', 'app'],
+            array_keys($bag->all()),
+        );
+    }
+
+    public function testClearsTheOrderConstraintWhenReplacingContent(): void
+    {
+        $bag = new HtmlBodyBag();
+        $bag
+            ->addAfter('<script src="/old.js"></script>', 'vendor', 'app')
+            ->add('<script src="/app.js"></script>', 'app')
+            ->add('<script src="/vendor.js"></script>', 'vendor')
+        ;
+
+        $this->assertSame(
+            [
+                'app' => '<script src="/app.js"></script>',
+                'vendor' => '<script src="/vendor.js"></script>',
+            ],
+            $bag->all(),
+        );
+    }
+
+    public function testOverridesTheOrderingOfExistingContent(): void
+    {
+        $bag = new HtmlBodyBag();
+        $bag
+            ->addAfter('<script src="/app.js"></script>', 'vendor', 'app')
+            ->add('<script src="/vendor.js"></script>', 'vendor')
+            ->orderBefore('app', 'vendor')
+        ;
+
+        $this->assertSame(['app', 'vendor'], array_keys($bag->all()));
+
+        $bag->orderAfter('app', 'vendor');
+
+        $this->assertSame(['vendor', 'app'], array_keys($bag->all()));
+    }
+
+    public function testRequiresAnIdentifierToOrderRawContent(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An identifier is required');
+
+        new HtmlBodyBag()->addAfter('<script></script>', 'vendor');
+    }
+
+    public function testRejectsAmbiguousSemanticReferences(): void
+    {
+        $bag = new HtmlBodyBag();
+        $bag
+            ->add(HtmlTag::script('/vendor.js'), 'first.vendor')
+            ->add(HtmlTag::script('/vendor.js'), 'second.vendor')
+            ->addAfter(HtmlTag::script('/app.js'), HtmlTag::script('/vendor.js'))
+        ;
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('is ambiguous');
+
+        $bag->all();
+    }
+}

--- a/core-bundle/tests/Routing/ResponseContext/HtmlHeadBag/HtmlHeadBagTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/HtmlHeadBag/HtmlHeadBagTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Routing\ResponseContext\HtmlHeadBag;
 
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlTag;
 use Contao\CoreBundle\String\HtmlAttributes;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -92,9 +93,235 @@ class HtmlHeadBagTest extends TestCase
 
         $this->assertCount(1, $manager->getMetaTags());
         $this->assertSame(' name="foo" content="bar"', implode('', $manager->getMetaTags()));
+        $this->assertArrayHasKey('contao.meta.additional.1', $manager->all());
 
         $manager->setMetaTags([]);
 
         $this->assertSame([], $manager->getMetaTags());
+    }
+
+    public function testCollectsAllHeadTags(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->setTitle('Page title - Root title')
+            ->setMetaDescription('Description')
+            ->setCanonicalEnabled(true)
+            ->addMetaTag(new HtmlAttributes(['property' => 'og:title', 'content' => 'Open Graph title']))
+            ->addLinkTag(new HtmlAttributes(['rel' => 'alternate', 'href' => '/feed.xml']))
+            ->add(HtmlTag::script('/app.js'), 'app.script')
+        ;
+
+        $tags = $manager->all(Request::create('https://example.com/page'));
+
+        $this->assertSame(
+            [
+                HtmlHeadBag::TAG_TITLE,
+                HtmlHeadBag::TAG_ROBOTS,
+                HtmlHeadBag::TAG_DESCRIPTION,
+                'contao.meta.additional.0',
+                HtmlHeadBag::TAG_CANONICAL,
+                'contao.link.additional.0',
+                'app.script',
+            ],
+            array_keys($tags),
+        );
+
+        $this->assertSame('Page title - Root title', $tags[HtmlHeadBag::TAG_TITLE]->getContent());
+        $this->assertSame('https://example.com/page', $tags[HtmlHeadBag::TAG_CANONICAL]->getAttributes()['href']);
+    }
+
+    public function testOrdersAndReplacesTagsByIdentifier(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->addBefore(HtmlTag::meta(['name' => 'first']), HtmlHeadBag::TAG_TITLE, 'before.title')
+            ->addAfter(HtmlTag::script('/after.js'), HtmlHeadBag::TAG_DESCRIPTION, 'after.description')
+            ->add(HtmlTag::script('/old.js'), 'replace.me')
+            ->add(HtmlTag::script('/new.js'), 'replace.me')
+            ->addRaw('raw', '<meta data-raw>')
+        ;
+
+        $tags = $manager->all();
+        $identifiers = array_keys($tags);
+
+        $this->assertSame('before.title', $identifiers[0]);
+        $this->assertSame(HtmlHeadBag::TAG_TITLE, $identifiers[1]);
+        $this->assertSame(HtmlHeadBag::TAG_DESCRIPTION, $identifiers[3]);
+        $this->assertSame('after.description', $identifiers[4]);
+        $this->assertSame('/new.js', $tags['replace.me']->getAttributes()['src']);
+        $this->assertSame('<meta data-raw>', $tags['raw']);
+        $this->assertCount(1, array_filter($identifiers, static fn (string $identifier): bool => 'replace.me' === $identifier));
+    }
+
+    public function testOrdersRawTagsByIdentifier(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->addRawAfter('third', '<meta data-third>', 'second')
+            ->addRaw('second', '<meta data-second>')
+            ->addRawBefore('first', '<meta data-first>', 'second')
+        ;
+
+        $tags = $manager->all();
+        $identifiers = array_keys($tags);
+
+        $this->assertLessThan(array_search('second', $identifiers, true), array_search('first', $identifiers, true));
+        $this->assertLessThan(array_search('third', $identifiers, true), array_search('second', $identifiers, true));
+    }
+
+    public function testOverridesTheOrderingOfExistingAndCoreTags(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->addAfter(HtmlTag::script('/app.js'), HtmlHeadBag::TAG_TITLE, 'app.script')
+            ->orderBefore('app.script', HtmlHeadBag::TAG_TITLE)
+            ->orderAfter(HtmlHeadBag::TAG_TITLE, HtmlHeadBag::TAG_DESCRIPTION)
+        ;
+
+        $identifiers = array_keys($manager->all());
+
+        $this->assertLessThan(array_search(HtmlHeadBag::TAG_TITLE, $identifiers, true), array_search('app.script', $identifiers, true));
+        $this->assertLessThan(array_search(HtmlHeadBag::TAG_TITLE, $identifiers, true), array_search(HtmlHeadBag::TAG_DESCRIPTION, $identifiers, true));
+    }
+
+    public function testOrdersCategorizedTagsByIdentifier(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->addRawToHead('app', '<script src="/app.js"></script>')
+            ->addRawToHead('vendor', '<script src="/vendor.js"></script>')
+            ->orderAfter('app', 'vendor')
+            ->orderBefore('app', 'vendor')
+        ;
+
+        $identifiers = array_keys($manager->all());
+
+        $this->assertLessThan(array_search('contao.twig.head.vendor', $identifiers, true), array_search('contao.twig.head.app', $identifiers, true));
+    }
+
+    public function testChecksAndRemovesCategorizedTagsByIdentifier(): void
+    {
+        $manager = new HtmlHeadBag()
+            ->addRawToHead('module', '<script src="/module.js"></script>')
+            ->addRawToStylesheets('theme', '<link rel="stylesheet" href="/theme.css">')
+        ;
+
+        $this->assertTrue($manager->has('module'));
+        $this->assertTrue($manager->has('theme'));
+
+        $manager
+            ->remove('module')
+            ->remove('theme')
+        ;
+
+        $this->assertFalse($manager->has('module'));
+        $this->assertFalse($manager->has('theme'));
+        $this->assertArrayNotHasKey('contao.twig.head.module', $manager->all());
+        $this->assertArrayNotHasKey('contao.twig.stylesheets.theme', $manager->all());
+    }
+
+    public function testKeepsEqualIdentifiersInSeparateCategories(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->addRawToHead('shared', '<meta data-shared>')
+            ->addRawToStylesheets('shared', '<link rel="stylesheet" href="/shared.css">')
+        ;
+
+        $tags = $manager->all();
+
+        $this->assertSame('<meta data-shared>', $tags['contao.twig.head.shared']);
+        $this->assertSame('<link rel="stylesheet" href="/shared.css">', $tags['contao.twig.stylesheets.shared']);
+    }
+
+    public function testRemovesDynamicCoreTags(): void
+    {
+        $manager = new HtmlHeadBag()->remove(HtmlHeadBag::TAG_ROBOTS);
+
+        $this->assertFalse($manager->has(HtmlHeadBag::TAG_ROBOTS));
+    }
+
+    public function testChecksRequestDependentCanonicalTag(): void
+    {
+        $manager = new HtmlHeadBag()->setCanonicalEnabled(true);
+
+        $this->assertFalse($manager->has(HtmlHeadBag::TAG_CANONICAL));
+        $this->assertTrue($manager->has(HtmlHeadBag::TAG_CANONICAL, Request::create('https://example.com/')));
+    }
+
+    public function testDetectsOrderingCycles(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->addAfter(HtmlTag::meta(), 'second', 'first')
+            ->addAfter(HtmlTag::meta(), 'first', 'second')
+        ;
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cyclic array ordering constraints');
+
+        $manager->all();
+    }
+
+    public function testAcceptsEquivalentOrderingConstraints(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->addBefore(HtmlTag::meta(), 'second', 'first')
+            ->addAfter(HtmlTag::meta(), 'first', 'second')
+        ;
+
+        $identifiers = array_keys($manager->all());
+
+        $this->assertLessThan(array_search('second', $identifiers, true), array_search('first', $identifiers, true));
+    }
+
+    public function testOrdersNonTreeConstraints(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->addBefore(HtmlTag::meta(), 'second', 'first')
+            ->addAfter(HtmlTag::meta(), 'third', 'second')
+            ->addBefore(HtmlTag::meta(), 'first', 'third')
+        ;
+
+        $identifiers = array_keys($manager->all());
+
+        $this->assertLessThan(array_search('first', $identifiers, true), array_search('third', $identifiers, true));
+        $this->assertLessThan(array_search('second', $identifiers, true), array_search('first', $identifiers, true));
+    }
+
+    public function testDerivesIdentifiersAndResolvesSemanticReferences(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->addAfter(HtmlTag::script('/app.js'), HtmlTag::script('/vendor.js'))
+            ->add(HtmlTag::script('/vendor.js', ['defer' => true]), 'vendor.script')
+        ;
+
+        $tags = $manager->all();
+
+        $this->assertArrayHasKey('script[src="/app.js"]', $tags);
+        $this->assertLessThan(
+            array_search('script[src="/app.js"]', array_keys($tags), true),
+            array_search('vendor.script', array_keys($tags), true),
+        );
+    }
+
+    public function testRejectsAmbiguousSemanticReferences(): void
+    {
+        $manager = new HtmlHeadBag();
+        $manager
+            ->add(HtmlTag::script('/vendor.js'), 'first.vendor')
+            ->add(HtmlTag::script('/vendor.js'), 'second.vendor')
+            ->addAfter(HtmlTag::script('/app.js'), HtmlTag::script('/vendor.js'))
+        ;
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The HTML tag reference "script[src=');
+        $this->expectExceptionMessage('is ambiguous');
+
+        $manager->all();
     }
 }

--- a/core-bundle/tests/Routing/ResponseContext/HtmlTagTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/HtmlTagTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Routing\ResponseContext;
+
+use Contao\CoreBundle\Routing\ResponseContext\HtmlTag;
+use Contao\CoreBundle\String\HtmlAttributes;
+use PHPUnit\Framework\TestCase;
+
+class HtmlTagTest extends TestCase
+{
+    public function testCreatesAndConfiguresTagsWithoutMutatingThem(): void
+    {
+        $script = HtmlTag::script('/app.js');
+        $deferredScript = $script->withAttribute('defer');
+
+        $this->assertSame('script', $script->getName());
+        $this->assertSame('/app.js', $script->getAttributes()['src']);
+        $this->assertFalse(isset($script->getAttributes()['defer']));
+        $this->assertTrue(isset($deferredScript->getAttributes()['defer']));
+        $this->assertNull($script->getContent());
+        $this->assertFalse($script->escapesContent());
+
+        $this->assertSame('stylesheet', HtmlTag::stylesheet('/app.css')->getAttributes()['rel']);
+        $this->assertTrue(HtmlTag::inlineScript('alert(1)')->isInlineScript());
+        $this->assertTrue(HtmlTag::inlineStyle('body {}')->isInlineStyle());
+        $this->assertTrue(HtmlTag::title('<Title>')->escapesContent());
+        $this->assertTrue(HtmlTag::create('noscript')->withContent('<p>Fallback</p>')->escapesContent());
+        $this->assertFalse(HtmlTag::create('noscript')->withRawContent('<p>Fallback</p>')->escapesContent());
+    }
+
+    public function testRejectsInvalidTagNames(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid HTML tag name');
+
+        HtmlTag::create('meta><script');
+    }
+
+    public function testAcceptsAttributesInEveryFactory(): void
+    {
+        $attributes = new HtmlAttributes(['data-factory' => 'create']);
+
+        $this->assertSame('create', HtmlTag::create('base', attributes: $attributes)->getAttributes()['data-factory']);
+        $this->assertSame('title', HtmlTag::title('Title', ['data-factory' => 'title'])->getAttributes()['data-factory']);
+        $this->assertSame('meta', HtmlTag::meta(['data-factory' => 'meta'])->getAttributes()['data-factory']);
+        $this->assertSame('link', HtmlTag::link(['data-factory' => 'link'])->getAttributes()['data-factory']);
+        $this->assertSame('print', HtmlTag::stylesheet('/app.css', ['media' => 'print'])->getAttributes()['media']);
+        $this->assertTrue(isset(HtmlTag::script('/app.js', ['defer' => true])->getAttributes()['defer']));
+        $this->assertSame('module', HtmlTag::inlineScript('alert(1)', ['type' => 'module'])->getAttributes()['type']);
+        $this->assertSame('screen', HtmlTag::inlineStyle('body {}', ['media' => 'screen'])->getAttributes()['media']);
+
+        $this->assertSame('/app.js', HtmlTag::script('/app.js', ['src' => '/other.js'])->getAttributes()['src']);
+        $this->assertSame('/app.css', HtmlTag::stylesheet('/app.css', ['href' => '/other.css'])->getAttributes()['href']);
+        HtmlTag::create('base', attributes: $attributes)->withAttribute('mutated');
+        $this->assertFalse(isset($attributes['mutated']));
+    }
+
+    public function testSerializesVoidAndNormalElements(): void
+    {
+        $this->assertSame('<meta name="robots" content="noindex">', HtmlTag::meta(['name' => 'robots', 'content' => 'noindex'])->toHtml());
+        $this->assertSame('<script src="/app.js"></script>', HtmlTag::script('/app.js')->toHtml());
+        $this->assertSame('<title>&lt;Title&gt;</title>', HtmlTag::title('<Title>')->toHtml());
+    }
+
+    public function testSuggestsSemanticIdentifiers(): void
+    {
+        $this->assertSame('script[src="/app.js"]', HtmlTag::script('/app.js', ['defer' => true])->getSuggestedIdentifier());
+        $this->assertSame('link[rel="stylesheet"][href="/app.css"]', HtmlTag::stylesheet('/app.css')->getSuggestedIdentifier());
+        $this->assertSame('meta[property="og:title"]', HtmlTag::meta(['property' => 'og:title', 'content' => 'Title'])->getSuggestedIdentifier());
+        $this->assertSame('title', HtmlTag::title('Page title')->getSuggestedIdentifier());
+        $this->assertMatchesRegularExpression('/^script\[[a-f0-9]+\]$/', HtmlTag::inlineScript('alert(1)')->getSuggestedIdentifier());
+    }
+}

--- a/core-bundle/tests/Routing/ResponseContext/HtmlTagTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/HtmlTagTest.php
@@ -65,13 +65,6 @@ class HtmlTagTest extends TestCase
         $this->assertFalse(isset($attributes['mutated']));
     }
 
-    public function testSerializesVoidAndNormalElements(): void
-    {
-        $this->assertSame('<meta name="robots" content="noindex">', HtmlTag::meta(['name' => 'robots', 'content' => 'noindex'])->toHtml());
-        $this->assertSame('<script src="/app.js"></script>', HtmlTag::script('/app.js')->toHtml());
-        $this->assertSame('<title>&lt;Title&gt;</title>', HtmlTag::title('<Title>')->toHtml());
-    }
-
     public function testSuggestsSemanticIdentifiers(): void
     {
         $this->assertSame('script[src="/app.js"]', HtmlTag::script('/app.js', ['defer' => true])->getSuggestedIdentifier());

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -149,7 +149,6 @@ class ContaoExtensionTest extends TestCase
             'html_to_plain_text',
             'deserialize',
             'autolink_url',
-            'contao_html_tag',
         ];
 
         $this->assertCount(\count($expectedFilters), $filters);

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -149,6 +149,7 @@ class ContaoExtensionTest extends TestCase
             'html_to_plain_text',
             'deserialize',
             'autolink_url',
+            'contao_html_tag',
         ];
 
         $this->assertCount(\count($expectedFilters), $filters);

--- a/core-bundle/tests/Twig/ResponseContext/AddNodeTest.php
+++ b/core-bundle/tests/Twig/ResponseContext/AddNodeTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Twig\ResponseContext;
 
 use Contao\CoreBundle\Tests\TestCase;
-use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\ResponseContext\AddNode;
 use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
 use Twig\Compiler;
@@ -26,10 +25,13 @@ class AddNodeTest extends TestCase
     public function testCompilesAddNode(): void
     {
         $addNode = new AddNode(
-            ContaoExtension::class,
             new PrintNode(new ConstantExpression('foobar', 42), 42),
-            'identifier',
-            DocumentLocation::endOfBody,
+            [
+                'identifier' => 'identifier',
+                'location' => DocumentLocation::endOfBody,
+                'position' => 'after',
+                'reference' => 'vendor',
+            ],
             1,
         );
 
@@ -49,8 +51,8 @@ class AddNodeTest extends TestCase
                     ob_clean();
                 }
             } finally { ob_end_clean(); }
-            $this->extensions["Contao\\CoreBundle\\Twig\\Extension\\ContaoExtension"]->addDocumentContent(
-                "identifier", $__contao_document_content, \Contao\CoreBundle\Twig\ResponseContext\DocumentLocation::endOfBody
+            $this->env->getRuntime("Contao\\CoreBundle\\Twig\\Runtime\\HtmlDocumentRuntime")->add(
+                $__contao_document_content, \Contao\CoreBundle\Twig\ResponseContext\DocumentLocation::endOfBody, ["identifier" => "identifier", "after" => "vendor"]
             );
 
             SOURCE;

--- a/core-bundle/tests/Twig/ResponseContext/AddTokenParserTest.php
+++ b/core-bundle/tests/Twig/ResponseContext/AddTokenParserTest.php
@@ -12,6 +12,10 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Twig\ResponseContext;
 
+use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Global\ContaoVariable;
@@ -19,6 +23,8 @@ use Contao\CoreBundle\Twig\Inspector\InspectorNodeVisitor;
 use Contao\CoreBundle\Twig\Inspector\Storage;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
+use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
+use Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Twig\Environment;
 use Twig\Error\SyntaxError;
@@ -26,13 +32,21 @@ use Twig\Lexer;
 use Twig\Loader\ArrayLoader;
 use Twig\Loader\LoaderInterface;
 use Twig\Parser;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
 use Twig\Source;
 
 class AddTokenParserTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_HEAD'], $GLOBALS['TL_STYLE_SHEETS'], $GLOBALS['TL_BODY']);
+
+        parent::tearDown();
+    }
+
     public function testGetTag(): void
     {
-        $tokenParser = new AddTokenParser(ContaoExtension::class);
+        $tokenParser = new AddTokenParser();
 
         $this->assertSame('add', $tokenParser->getTag());
     }
@@ -45,25 +59,39 @@ class AddTokenParserTest extends TestCase
     public function testAddsContent(string $code, array $expectedHeadContent, array $expectedStyleSheetContent, array $expectedBodyContent): void
     {
         $environment = new Environment($this->createStub(LoaderInterface::class));
+        $responseContext = new ResponseContext()
+            ->add($body = new HtmlBodyBag())
+            ->add($head = new HtmlHeadBag())
+        ;
+        $accessor = $this->createStub(ResponseContextAccessor::class);
+        $accessor
+            ->method('getResponseContext')
+            ->willReturn($responseContext)
+        ;
+        $environment->addRuntimeLoader(new FactoryRuntimeLoader([
+            HtmlDocumentRuntime::class => static fn () => new HtmlDocumentRuntime($accessor),
+        ]));
 
-        $environment->addExtension(
-            new ContaoExtension(
-                $environment,
-                $this->createStub(ContaoFilesystemLoader::class),
-                $this->createStub(ContaoVariable::class),
-                new InspectorNodeVisitor($this->createStub(Storage::class), $environment),
-            ),
+        $extension = new ContaoExtension(
+            $environment,
+            $this->createStub(ContaoFilesystemLoader::class),
+            $this->createStub(ContaoVariable::class),
+            new InspectorNodeVisitor($this->createStub(Storage::class), $environment),
         );
 
-        $environment->addTokenParser(new AddTokenParser(ContaoExtension::class));
+        $environment->addExtension($extension);
+
+        $environment->addTokenParser(new AddTokenParser());
         $environment->setLoader(new ArrayLoader(['template.html.twig' => $code]));
         $this->assertSame('', $environment->render('template.html.twig'));
 
-        $this->assertSame($expectedHeadContent, $GLOBALS['TL_HEAD'] ?? []);
-        $this->assertSame($expectedStyleSheetContent, $GLOBALS['TL_STYLE_SHEETS'] ?? []);
-        $this->assertSame($expectedBodyContent, $GLOBALS['TL_BODY'] ?? []);
+        $this->assertSame($expectedHeadContent, $this->getAddedHeadContent($head, DocumentLocation::head));
+        $this->assertSame($expectedStyleSheetContent, $this->getAddedHeadContent($head, DocumentLocation::stylesheets));
+        $this->assertSame($expectedBodyContent, $body->all());
 
-        unset($GLOBALS['TL_HEAD'], $GLOBALS['TL_STYLE_SHEETS'], $GLOBALS['TL_BODY']);
+        $this->assertArrayNotHasKey('TL_HEAD', $GLOBALS);
+        $this->assertArrayNotHasKey('TL_STYLE_SHEETS', $GLOBALS);
+        $this->assertArrayNotHasKey('TL_BODY', $GLOBALS);
     }
 
     public static function provideSources(): iterable
@@ -144,13 +172,53 @@ class AddTokenParserTest extends TestCase
             [],
             ['foo bar'],
         ];
+
+        yield 'add after to head' => [
+            "{% add 'second' to head after 'first' %}second{% endadd %}\n".
+            "{% add 'first' to head %}first{% endadd %}",
+            ['first' => 'first', 'second' => 'second'],
+            [],
+            [],
+        ];
+
+        yield 'add before to stylesheets' => [
+            "{% add 'second' to stylesheets %}second{% endadd %}\n".
+            "{% add 'first' to stylesheets before 'second' %}first{% endadd %}",
+            [],
+            ['first' => 'first', 'second' => 'second'],
+            [],
+        ];
+
+        yield 'add after to body' => [
+            "{% add 'second' to body after 'first' %}second{% endadd %}\n".
+            "{% add 'first' to body %}first{% endadd %}",
+            [],
+            [],
+            ['first' => 'first', 'second' => 'second'],
+        ];
+    }
+
+    public function testFallsBackToLegacyGlobalsWithoutAResponseContext(): void
+    {
+        $environment = new Environment(new ArrayLoader([
+            'template.html.twig' => '{% add "legacy" to head %}<meta data-legacy>{% endadd %}',
+        ]));
+        $environment->addRuntimeLoader(new FactoryRuntimeLoader([
+            HtmlDocumentRuntime::class => fn () => new HtmlDocumentRuntime($this->createStub(ResponseContextAccessor::class)),
+        ]));
+        $environment->addTokenParser(new AddTokenParser());
+
+        $this->expectUserDeprecationMessageMatches('/Using the Twig "add" tag without the corresponding response context bag is deprecated/');
+
+        $this->assertSame('', $environment->render('template.html.twig'));
+        $this->assertSame(['legacy' => '<meta data-legacy>'], $GLOBALS['TL_HEAD']);
     }
 
     #[DataProvider('provideInvalidSources')]
     public function testValidatesSource(string $code, string $expectedException): void
     {
         $environment = new Environment($this->createStub(LoaderInterface::class));
-        $environment->addTokenParser(new AddTokenParser(ContaoExtension::class));
+        $environment->addTokenParser(new AddTokenParser());
 
         $parser = new Parser($environment);
         $source = new Source($code, 'template.html.twig');
@@ -183,5 +251,35 @@ class AddTokenParserTest extends TestCase
             '{% add to body "foo" %}bar{% endadd %}',
             'Unexpected token "string" of value "foo" ("end of statement block" expected) in "template.html.twig"',
         ];
+
+        yield 'ordering without an identifier' => [
+            "{% add to body after 'foo' %}bar{% endadd %}",
+            'An identifier is required when ordering content with the "add" tag in "template.html.twig"',
+        ];
+
+        yield 'ordering without a reference' => [
+            "{% add 'foo' to body after %}bar{% endadd %}",
+            'Unexpected token "end of statement block" ("string" expected) in "template.html.twig"',
+        ];
+    }
+
+    /**
+     * @return array<array-key, string>
+     */
+    private function getAddedHeadContent(HtmlHeadBag $head, DocumentLocation $location): array
+    {
+        $prefix = "contao.twig.{$location->value}.";
+        $content = [];
+        $hasNamedContent = false;
+
+        foreach ($head->all() as $identifier => $tag) {
+            if (\is_string($tag) && str_starts_with($identifier, $prefix)) {
+                $key = substr($identifier, \strlen($prefix));
+                $hasNamedContent = $hasNamedContent || !ctype_digit($key);
+                $content[$key] = $tag;
+            }
+        }
+
+        return $hasNamedContent ? $content : array_values($content);
     }
 }

--- a/core-bundle/tests/Twig/Runtime/HtmlDocumentRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/HtmlDocumentRuntimeTest.php
@@ -12,16 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Twig\Runtime;
 
-use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
-use Contao\CoreBundle\Routing\ResponseContext\HtmlTag;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
 use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
 use Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime;
-use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
-use Nelmio\SecurityBundle\ContentSecurityPolicy\PolicyManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -30,70 +26,6 @@ class HtmlDocumentRuntimeTest extends TestCase
     protected function tearDown(): void
     {
         unset($GLOBALS['TL_HEAD'], $GLOBALS['TL_STYLE_SHEETS'], $GLOBALS['TL_BODY']);
-    }
-
-    public function testRendersStructuredAndRawHeadTags(): void
-    {
-        $runtime = new HtmlDocumentRuntime($this->createStub(ResponseContextAccessor::class));
-
-        $this->assertSame(
-            '<meta name="theme-color" content="&quot;dark&quot;">',
-            $runtime->renderHtmlTag(HtmlTag::meta(['name' => 'theme-color', 'content' => '"dark"'])),
-        );
-        $this->assertSame('<title>&lt;Title&#039;s&gt;</title>', $runtime->renderHtmlTag(HtmlTag::title("<Title's>")));
-        $this->assertSame('<script src="/app.js" defer></script>', $runtime->renderHtmlTag(HtmlTag::script('/app.js', ['defer' => true]), 'app.script'));
-        $this->assertSame('<meta data-legacy>', $runtime->renderHtmlTag('<meta data-legacy>'));
-    }
-
-    public function testAddsIdentifiersAsDataAttributesInDebugMode(): void
-    {
-        $runtime = new HtmlDocumentRuntime($this->createStub(ResponseContextAccessor::class), true);
-
-        $this->assertSame(
-            '<script src="/app.js" data-contao-tag="script[src=&quot;/app.js&quot;]"></script>',
-            $runtime->renderHtmlTag(HtmlTag::script('/app.js'), 'script[src="/app.js"]'),
-        );
-        $this->assertSame(
-            '<!-- contao-tag: raw --><script data-raw></script>',
-            $runtime->renderHtmlTag('<script data-raw></script>', 'raw'),
-        );
-        $this->assertSame(
-            '<!-- contao-tag: theme --><link rel="stylesheet">',
-            $runtime->renderHtmlTag('<link rel="stylesheet">', 'contao.twig.stylesheets.theme'),
-        );
-        $this->assertSame(
-            '<!-- contao-tag: replacement --><script data-contao-tag="existing"></script>',
-            $runtime->renderHtmlTag('<script data-contao-tag="existing"></script>', 'replacement'),
-        );
-        $this->assertSame(
-            '<!-- contao-tag: price- -break --><meta>',
-            $runtime->renderHtmlTag('<meta>', "price--break\n"),
-        );
-    }
-
-    public function testAddsCspNoncesToInlineScriptsAndStyles(): void
-    {
-        $directives = new DirectiveSet(new PolicyManager());
-        $directives->setDirective('script-src', "'self'");
-        $directives->setDirective('style-src', "'self'");
-
-        $responseContext = new ResponseContext()->add(new CspHandler($directives));
-        $runtime = new HtmlDocumentRuntime($this->createAccessor($responseContext));
-        $script = HtmlTag::inlineScript('alert(1)');
-
-        $this->assertMatchesRegularExpression(
-            '/^<script nonce="[^"]+">alert\(1\)<\/script>$/',
-            $runtime->renderHtmlTag($script),
-        );
-        $this->assertFalse(isset($script->getAttributes()['nonce']));
-        $this->assertMatchesRegularExpression(
-            '/^<style nonce="[^"]+">body \{\}<\/style>$/',
-            $runtime->renderHtmlTag(HtmlTag::inlineStyle('body {}')),
-        );
-        $this->assertSame(
-            '<script nonce="manual">alert(1)</script>',
-            $runtime->renderHtmlTag($script->withAttribute('nonce', 'manual')),
-        );
     }
 
     public function testAddsTwigContentToTheResponseContext(): void

--- a/core-bundle/tests/Twig/Runtime/HtmlDocumentRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/HtmlDocumentRuntimeTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\Runtime;
+
+use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlTag;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
+use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
+use Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\PolicyManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class HtmlDocumentRuntimeTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_HEAD'], $GLOBALS['TL_STYLE_SHEETS'], $GLOBALS['TL_BODY']);
+    }
+
+    public function testRendersStructuredAndRawHeadTags(): void
+    {
+        $runtime = new HtmlDocumentRuntime($this->createStub(ResponseContextAccessor::class));
+
+        $this->assertSame(
+            '<meta name="theme-color" content="&quot;dark&quot;">',
+            $runtime->renderHtmlTag(HtmlTag::meta(['name' => 'theme-color', 'content' => '"dark"'])),
+        );
+        $this->assertSame('<title>&lt;Title&#039;s&gt;</title>', $runtime->renderHtmlTag(HtmlTag::title("<Title's>")));
+        $this->assertSame('<script src="/app.js" defer></script>', $runtime->renderHtmlTag(HtmlTag::script('/app.js', ['defer' => true]), 'app.script'));
+        $this->assertSame('<meta data-legacy>', $runtime->renderHtmlTag('<meta data-legacy>'));
+    }
+
+    public function testAddsIdentifiersAsDataAttributesInDebugMode(): void
+    {
+        $runtime = new HtmlDocumentRuntime($this->createStub(ResponseContextAccessor::class), true);
+
+        $this->assertSame(
+            '<script src="/app.js" data-contao-tag="script[src=&quot;/app.js&quot;]"></script>',
+            $runtime->renderHtmlTag(HtmlTag::script('/app.js'), 'script[src="/app.js"]'),
+        );
+        $this->assertSame(
+            '<!-- contao-tag: raw --><script data-raw></script>',
+            $runtime->renderHtmlTag('<script data-raw></script>', 'raw'),
+        );
+        $this->assertSame(
+            '<!-- contao-tag: theme --><link rel="stylesheet">',
+            $runtime->renderHtmlTag('<link rel="stylesheet">', 'contao.twig.stylesheets.theme'),
+        );
+        $this->assertSame(
+            '<!-- contao-tag: replacement --><script data-contao-tag="existing"></script>',
+            $runtime->renderHtmlTag('<script data-contao-tag="existing"></script>', 'replacement'),
+        );
+        $this->assertSame(
+            '<!-- contao-tag: price- -break --><meta>',
+            $runtime->renderHtmlTag('<meta>', "price--break\n"),
+        );
+    }
+
+    public function testAddsCspNoncesToInlineScriptsAndStyles(): void
+    {
+        $directives = new DirectiveSet(new PolicyManager());
+        $directives->setDirective('script-src', "'self'");
+        $directives->setDirective('style-src', "'self'");
+
+        $responseContext = new ResponseContext()->add(new CspHandler($directives));
+        $runtime = new HtmlDocumentRuntime($this->createAccessor($responseContext));
+        $script = HtmlTag::inlineScript('alert(1)');
+
+        $this->assertMatchesRegularExpression(
+            '/^<script nonce="[^"]+">alert\(1\)<\/script>$/',
+            $runtime->renderHtmlTag($script),
+        );
+        $this->assertFalse(isset($script->getAttributes()['nonce']));
+        $this->assertMatchesRegularExpression(
+            '/^<style nonce="[^"]+">body \{\}<\/style>$/',
+            $runtime->renderHtmlTag(HtmlTag::inlineStyle('body {}')),
+        );
+        $this->assertSame(
+            '<script nonce="manual">alert(1)</script>',
+            $runtime->renderHtmlTag($script->withAttribute('nonce', 'manual')),
+        );
+    }
+
+    public function testAddsTwigContentToTheResponseContext(): void
+    {
+        $responseContext = new ResponseContext()
+            ->add($body = new HtmlBodyBag())
+            ->add($head = new HtmlHeadBag())
+        ;
+        $runtime = new HtmlDocumentRuntime($this->createAccessor($responseContext));
+
+        $runtime->add('<meta data-first>', DocumentLocation::head);
+        $runtime->add('<style>first</style>', DocumentLocation::stylesheets, ['identifier' => 'theme']);
+        $runtime->add('<style>replacement</style>', DocumentLocation::stylesheets, ['identifier' => 'theme']);
+        $runtime->add('<script src="/footer.js"></script>', DocumentLocation::endOfBody, ['identifier' => 'footer']);
+
+        $tags = $head->all();
+
+        $this->assertSame('<meta data-first>', $tags['contao.twig.head.1']);
+        $this->assertSame('<style>replacement</style>', $tags['contao.twig.stylesheets.theme']);
+        $this->assertSame(['footer' => '<script src="/footer.js"></script>'], $body->all());
+        $this->assertArrayNotHasKey('TL_HEAD', $GLOBALS);
+        $this->assertArrayNotHasKey('TL_STYLE_SHEETS', $GLOBALS);
+        $this->assertArrayNotHasKey('TL_BODY', $GLOBALS);
+    }
+
+    /**
+     * @param array{
+     *     identifier: string|null,
+     *     content: string,
+     *     location: DocumentLocation,
+     *     global: string,
+     *     expected: array<array-key, string>,
+     * } $data
+     */
+    #[DataProvider('provideLegacyContent')]
+    public function testFallsBackToLegacyGlobalsWithoutResponseContextBags(array $data): void
+    {
+        $this->expectUserDeprecationMessageMatches('/Using the Twig "add" tag without the corresponding response context bag is deprecated/');
+
+        $runtime = new HtmlDocumentRuntime($this->createStub(ResponseContextAccessor::class));
+        $options = null === $data['identifier'] ? [] : ['identifier' => $data['identifier']];
+        $runtime->add($data['content'], $data['location'], $options);
+
+        $this->assertSame($data['expected'], $GLOBALS[$data['global']]);
+    }
+
+    public static function provideLegacyContent(): iterable
+    {
+        yield 'head' => [[
+            'identifier' => 'head',
+            'content' => '<meta data-head>',
+            'location' => DocumentLocation::head,
+            'global' => 'TL_HEAD',
+            'expected' => ['head' => '<meta data-head>'],
+        ]];
+
+        yield 'stylesheets' => [[
+            'identifier' => null,
+            'content' => '<style></style>',
+            'location' => DocumentLocation::stylesheets,
+            'global' => 'TL_STYLE_SHEETS',
+            'expected' => ['<style></style>'],
+        ]];
+
+        yield 'body' => [[
+            'identifier' => 'body',
+            'content' => '<script></script>',
+            'location' => DocumentLocation::endOfBody,
+            'global' => 'TL_BODY',
+            'expected' => ['body' => '<script></script>'],
+        ]];
+    }
+
+    private function createAccessor(ResponseContext $responseContext): ResponseContextAccessor
+    {
+        $accessor = $this->createStub(ResponseContextAccessor::class);
+        $accessor
+            ->method('getResponseContext')
+            ->willReturn($responseContext)
+        ;
+
+        return $accessor;
+    }
+}

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Twig;
 
 use Contao\Config;
+use Contao\CoreBundle\Csp\WysiwygStyleProcessor;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlTag;
@@ -30,12 +32,15 @@ use Contao\CoreBundle\Twig\Inspector\Storage;
 use Contao\CoreBundle\Twig\Interop\ContextFactory;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\Renderer\DeferredRenderer;
+use Contao\CoreBundle\Twig\Runtime\CspRuntime;
 use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
 use Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\FormText;
 use Contao\System;
 use Highlight\Highlighter;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
+use Nelmio\SecurityBundle\ContentSecurityPolicy\PolicyManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
@@ -166,7 +171,10 @@ class TwigIntegrationTest extends TestCase
     public function testRendersHtmlTags(): void
     {
         $environment = $this->createHeadEnvironment([
-            'test.html.twig' => '{{ tag|contao_html_tag }}{{ raw_tag|contao_html_tag }}',
+            'test.html.twig' => <<<'TWIG'
+                {{ include('@Contao/component/_html_tag.html.twig', {tag, identifier: null, debug: false}, false) }}
+                {{- include('@Contao/component/_html_tag.html.twig', {tag: raw_tag, identifier: null, debug: false}, false) }}
+                TWIG,
         ]);
 
         $this->assertSame(
@@ -176,6 +184,65 @@ class TwigIntegrationTest extends TestCase
                 'raw_tag' => '<meta data-legacy>',
             ]),
         );
+    }
+
+    public function testCanCustomizeTheHtmlTagComponent(): void
+    {
+        $environment = $this->createHeadEnvironment([
+            'test.html.twig' => "{{ include('@Contao/component/_html_tag.html.twig', {tag, identifier: null, debug: false}, false) }}",
+            'component/_html_tag.html.twig' => '<custom-tag data-name="{{ tag.name }}">{{ tag.content }}</custom-tag>',
+        ]);
+
+        $this->assertSame(
+            '<custom-tag data-name="title">Page title</custom-tag>',
+            $environment->render('test.html.twig', ['tag' => HtmlTag::title('Page title')]),
+        );
+    }
+
+    public function testRendersDebugIdentifiersAndCspNoncesInTheHtmlTagComponent(): void
+    {
+        $directives = new DirectiveSet(new PolicyManager());
+        $directives->setDirective('script-src', "'self'");
+        $directives->setDirective('style-src', "'self'");
+
+        $responseContext = new ResponseContext()->add(new CspHandler($directives));
+        $request = Request::create('https://example.com/');
+        $accessor = new ResponseContextAccessor(new RequestStack([$request]));
+        $accessor->setResponseContext($responseContext);
+
+        $environment = $this->createHeadEnvironment(
+            [
+                'test.html.twig' => <<<'TWIG'
+                    {{ include('@Contao/component/_html_tag.html.twig', {tag: external_script, identifier: external_identifier, debug: true}, false) }}
+                    {{- include('@Contao/component/_html_tag.html.twig', {tag: raw_tag, identifier: raw_identifier, debug: true}, false) }}
+                    {{- include('@Contao/component/_html_tag.html.twig', {tag: inline_script, identifier: null, debug: false}, false) }}
+                    {{- include('@Contao/component/_html_tag.html.twig', {tag: inline_style, identifier: null, debug: false}, false) }}
+                    {{- include('@Contao/component/_html_tag.html.twig', {tag: manual_script, identifier: null, debug: false}, false) }}
+                    TWIG,
+            ],
+            $accessor,
+        );
+        $inlineScript = HtmlTag::inlineScript('alert(1)');
+
+        $output = $environment->render('test.html.twig', [
+            'external_script' => HtmlTag::script('/app.js'),
+            'external_identifier' => 'script[src="/app.js"]',
+            'raw_tag' => '<meta data-raw>',
+            'raw_identifier' => "contao.twig.head.price--break\n",
+            'inline_script' => $inlineScript,
+            'inline_style' => HtmlTag::inlineStyle('body {}'),
+            'manual_script' => $inlineScript->withAttribute('nonce', 'manual'),
+        ]);
+
+        $this->assertMatchesRegularExpression(
+            '/^<script src="\/app\.js" data-contao-tag="script\[src=&quot;\/app\.js&quot;\]"><\/script>/',
+            $output,
+        );
+        $this->assertStringContainsString('<!-- contao-tag (URL-encoded): price%2D%2Dbreak%0A --><meta data-raw>', $output);
+        $this->assertMatchesRegularExpression('/<script nonce="[^"]+">alert\(1\)<\/script>/', $output);
+        $this->assertMatchesRegularExpression('/<style nonce="[^"]+">body \{\}<\/style>/', $output);
+        $this->assertStringContainsString('<script nonce="manual">alert(1)</script>', $output);
+        $this->assertFalse(isset($inlineScript->getAttributes()['nonce']));
     }
 
     public function testRendersAndOverridesHeadTagBlocksWhenDeferred(): void
@@ -240,7 +307,6 @@ class TwigIntegrationTest extends TestCase
                     TWIG,
             ],
             $accessor,
-            true,
         );
 
         $output = new DeferredRenderer($environment)->render('child.html.twig', [
@@ -251,25 +317,25 @@ class TwigIntegrationTest extends TestCase
                 'body' => $body,
                 'end_of_body' => ['<script data-legacy-body></script>'],
             ],
-            'app' => ['request' => $request],
+            'app' => ['request' => $request, 'debug' => true],
         ]);
 
         $this->assertStringContainsString('<meta charset="UTF-8">', $output);
         $this->assertStringContainsString('<meta name="generator" content="Contao Open Source CMS">', $output);
         $this->assertStringContainsString('width=device-width,initial-scale=1.0,shrink-to-fit=no', $output);
         $this->assertMatchesRegularExpression(
-            '/<!-- contao-tag: module --><script src="\/module\.js"><\/script>\s*<!-- contao-tag: vendor --><script src="\/vendor\.js"><\/script>/',
+            '/<!-- contao-tag \(URL-encoded\): module --><script src="\/module\.js"><\/script>\s*<!-- contao-tag \(URL-encoded\): vendor --><script src="\/vendor\.js"><\/script>/',
             $output,
         );
         $this->assertMatchesRegularExpression(
-            '/<!-- contao-tag: footer --><script src="\/footer\.js"><\/script>\s*<script src="\/structured\.js" data-contao-tag="script\[src=&quot;\/structured\.js&quot;\]"><\/script>/',
+            '/<!-- contao-tag \(URL-encoded\): footer --><script src="\/footer\.js"><\/script>\s*<script src="\/structured\.js" data-contao-tag="script\[src=&quot;\/structured\.js&quot;\]"><\/script>/',
             $output,
         );
         $this->assertMatchesRegularExpression(
             '/<script src="\/structured\.js"[^>]*><\/script>\s*<script data-legacy-body><\/script>/',
             $output,
         );
-        $this->assertStringContainsString('<!-- contao-tag: theme --><link rel="stylesheet" href="/theme.css">', $output);
+        $this->assertStringContainsString('<!-- contao-tag (URL-encoded): theme --><link rel="stylesheet" href="/theme.css">', $output);
         $this->assertArrayNotHasKey('TL_HEAD', $GLOBALS);
         $this->assertArrayNotHasKey('TL_STYLE_SHEETS', $GLOBALS);
         $this->assertArrayNotHasKey('TL_BODY', $GLOBALS);
@@ -488,19 +554,25 @@ class TwigIntegrationTest extends TestCase
     /**
      * @param array<string, string> $templates
      */
-    private function createHeadEnvironment(array $templates, ResponseContextAccessor|null $accessor = null, bool $debug = false): Environment
+    private function createHeadEnvironment(array $templates, ResponseContextAccessor|null $accessor = null): Environment
     {
         $accessor ??= $this->createStub(ResponseContextAccessor::class);
+        $filesystemLoader = $this->createStub(ContaoFilesystemLoader::class);
+        $filesystemLoader
+            ->method('getAllFirstByThemeSlug')
+            ->willReturnCallback(static fn (string $name): array => ['' => $name])
+        ;
         $environment = new Environment(new ChainLoader([
             new ArrayLoader($templates),
             new FilesystemLoader(__DIR__.'/../../contao/templates'),
         ]));
         $environment->addRuntimeLoader(new FactoryRuntimeLoader([
-            HtmlDocumentRuntime::class => static fn () => new HtmlDocumentRuntime($accessor, $debug),
+            CspRuntime::class => static fn () => new CspRuntime($accessor, new WysiwygStyleProcessor([])),
+            HtmlDocumentRuntime::class => static fn () => new HtmlDocumentRuntime($accessor),
         ]));
         $extension = new ContaoExtension(
             $environment,
-            $this->createStub(ContaoFilesystemLoader::class),
+            $filesystemLoader,
             $this->createStub(ContaoVariable::class),
             new InspectorNodeVisitor($this->createStub(Storage::class), $environment),
         );

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -15,15 +15,23 @@ namespace Contao\CoreBundle\Tests\Twig;
 use Contao\Config;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlBodyBag;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlTag;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Defer\DeferTokenParser;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Global\ContaoVariable;
 use Contao\CoreBundle\Twig\Inspector\InspectorNodeVisitor;
 use Contao\CoreBundle\Twig\Inspector\Storage;
 use Contao\CoreBundle\Twig\Interop\ContextFactory;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
+use Contao\CoreBundle\Twig\Renderer\DeferredRenderer;
 use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
+use Contao\CoreBundle\Twig\Runtime\HtmlDocumentRuntime;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\FormText;
 use Contao\System;
@@ -35,6 +43,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
+use Twig\Loader\ChainLoader;
+use Twig\Loader\FilesystemLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
 class TwigIntegrationTest extends TestCase
@@ -61,7 +71,7 @@ class TwigIntegrationTest extends TestCase
 
         unset($GLOBALS['TL_LANG'], $GLOBALS['TL_FFL'], $GLOBALS['TL_MIME']);
 
-        $this->resetStaticProperties([ContaoFramework::class, System::class, Config::class]);
+        $this->resetStaticProperties([ContaoFramework::class, DeferTokenParser::class, System::class, Config::class]);
 
         parent::tearDown();
     }
@@ -151,6 +161,118 @@ class TwigIntegrationTest extends TestCase
         ]);
 
         $this->assertSame($expectedOutput, $output);
+    }
+
+    public function testRendersHtmlTags(): void
+    {
+        $environment = $this->createHeadEnvironment([
+            'test.html.twig' => '{{ tag|contao_html_tag }}{{ raw_tag|contao_html_tag }}',
+        ]);
+
+        $this->assertSame(
+            '<title>&lt;Title&gt;</title><meta data-legacy>',
+            $environment->render('test.html.twig', [
+                'tag' => HtmlTag::title('<Title>'),
+                'raw_tag' => '<meta data-legacy>',
+            ]),
+        );
+    }
+
+    public function testRendersAndOverridesHeadTagBlocksWhenDeferred(): void
+    {
+        $environment = $this->createHeadEnvironment([
+            'child.html.twig' => <<<'TWIG'
+                {% extends 'page/layout.html.twig' %}
+                {% block viewport %}<meta name="viewport" content="custom">{% endblock %}
+                {% block title %}<title data-custom>{{ head_tag.content }}</title>{% endblock %}
+                {% block end_of_head %}{{ parent() }}<meta data-after-legacy>{% endblock %}
+                {% block body %}{% endblock %}
+                TWIG,
+        ]);
+
+        $head = new HtmlHeadBag()
+            ->setTitle('Page title')
+            ->addAfter(HtmlTag::script('/app.js', ['defer' => true]), HtmlHeadBag::TAG_DESCRIPTION, 'app.script')
+        ;
+
+        $output = new DeferredRenderer($environment)->render('child.html.twig', [
+            'locale' => 'en',
+            'rtl' => false,
+            'response_context' => ['head' => $head, 'end_of_head' => ['<meta data-legacy>']],
+            'app' => ['request' => Request::create('https://example.com/')],
+        ]);
+
+        $this->assertStringContainsString('<meta name="viewport" content="custom">', $output);
+        $this->assertStringNotContainsString('width=device-width', $output);
+        $this->assertStringContainsString('<title data-custom>Page title</title>', $output);
+        $this->assertMatchesRegularExpression('/<meta name="description" content>\s*<script src="\/app\.js" defer><\/script>/', $output);
+        $this->assertMatchesRegularExpression('/<meta data-legacy>\s*<meta data-after-legacy>/', $output);
+    }
+
+    public function testAddTwigTagAddsAndReordersContentInTheDeferredDocument(): void
+    {
+        $request = Request::create('https://example.com/');
+        $accessor = new ResponseContextAccessor(new RequestStack([$request]));
+        $responseContext = new ResponseContext()
+            ->add($body = new HtmlBodyBag())
+            ->add($head = new HtmlHeadBag())
+        ;
+        $body->add(HtmlTag::script('/structured.js'));
+        $accessor->setResponseContext($responseContext);
+        $environment = $this->createHeadEnvironment(
+            [
+                'child.html.twig' => <<<'TWIG'
+                    {% extends 'page/layout.html.twig' %}
+                    {% block body_content %}
+                        {% add 'theme' to stylesheets %}<link rel="stylesheet" href="/theme.css">{% endadd %}
+                        {% add 'module' to head after 'vendor' %}<script src="/module.js"></script>{% endadd %}
+                        {% add 'vendor' to head %}<script src="/vendor.js"></script>{% endadd %}
+                        {% add 'footer' to body after 'script[src="/structured.js"]' %}<script src="/footer.js"></script>{% endadd %}
+                    {% endblock %}
+                    {% block head_tags %}
+                        {% do response_context.head.orderBefore('module', 'vendor') %}
+                        {{ parent() }}
+                    {% endblock %}
+                    {% block end_of_body %}
+                        {% do response_context.body.orderBefore('footer', 'script[src="/structured.js"]') %}
+                        {{ parent() }}
+                    {% endblock %}
+                    TWIG,
+            ],
+            $accessor,
+            true,
+        );
+
+        $output = new DeferredRenderer($environment)->render('child.html.twig', [
+            'locale' => 'en',
+            'rtl' => false,
+            'response_context' => [
+                'head' => $head,
+                'body' => $body,
+                'end_of_body' => ['<script data-legacy-body></script>'],
+            ],
+            'app' => ['request' => $request],
+        ]);
+
+        $this->assertStringContainsString('<meta charset="UTF-8">', $output);
+        $this->assertStringContainsString('<meta name="generator" content="Contao Open Source CMS">', $output);
+        $this->assertStringContainsString('width=device-width,initial-scale=1.0,shrink-to-fit=no', $output);
+        $this->assertMatchesRegularExpression(
+            '/<!-- contao-tag: module --><script src="\/module\.js"><\/script>\s*<!-- contao-tag: vendor --><script src="\/vendor\.js"><\/script>/',
+            $output,
+        );
+        $this->assertMatchesRegularExpression(
+            '/<!-- contao-tag: footer --><script src="\/footer\.js"><\/script>\s*<script src="\/structured\.js" data-contao-tag="script\[src=&quot;\/structured\.js&quot;\]"><\/script>/',
+            $output,
+        );
+        $this->assertMatchesRegularExpression(
+            '/<script src="\/structured\.js"[^>]*><\/script>\s*<script data-legacy-body><\/script>/',
+            $output,
+        );
+        $this->assertStringContainsString('<!-- contao-tag: theme --><link rel="stylesheet" href="/theme.css">', $output);
+        $this->assertArrayNotHasKey('TL_HEAD', $GLOBALS);
+        $this->assertArrayNotHasKey('TL_STYLE_SHEETS', $GLOBALS);
+        $this->assertArrayNotHasKey('TL_BODY', $GLOBALS);
     }
 
     public function testHighlightsCode(): void
@@ -361,5 +483,30 @@ class TwigIntegrationTest extends TestCase
                 </ul>
                 HTML,
         ];
+    }
+
+    /**
+     * @param array<string, string> $templates
+     */
+    private function createHeadEnvironment(array $templates, ResponseContextAccessor|null $accessor = null, bool $debug = false): Environment
+    {
+        $accessor ??= $this->createStub(ResponseContextAccessor::class);
+        $environment = new Environment(new ChainLoader([
+            new ArrayLoader($templates),
+            new FilesystemLoader(__DIR__.'/../../contao/templates'),
+        ]));
+        $environment->addRuntimeLoader(new FactoryRuntimeLoader([
+            HtmlDocumentRuntime::class => static fn () => new HtmlDocumentRuntime($accessor, $debug),
+        ]));
+        $extension = new ContaoExtension(
+            $environment,
+            $this->createStub(ContaoFilesystemLoader::class),
+            $this->createStub(ContaoVariable::class),
+            new InspectorNodeVisitor($this->createStub(Storage::class), $environment),
+        );
+
+        $environment->addExtension($extension);
+
+        return $environment;
     }
 }


### PR DESCRIPTION
This makes the response context the source of truth for dynamic HTML head and end-of-body content 🥳 

Frontend templates can now render the collected tags without having to know where they originated, while extensions and template designers can add, replace, remove and order (!) tags through a structured API.

### A word on backwards compatibility

The existing head bag properties for the page title, meta description, robots directive, canonical URL and legacy meta/link tags remain supported.

Content added through `$GLOBALS['TL_CSS']`, `$GLOBALS['TL_JAVASCRIPT']`, `$GLOBALS['TL_STYLE_SHEETS']`, `$GLOBALS['TL_HEAD']` and `$GLOBALS['TL_BODY']` is still collected, but now triggers a deprecation.

I also tried to keep all of the rest BC so if you are reviewing and you wonder about a piece of code, think of BC first - maybe it explains it then 😊 

### Usage

In PHP you can now do this:

```php
$head = $responseContext->get(HtmlHeadBag::class);

$head->add(HtmlTag::stylesheet('/assets/application.css'));

$head->addAfter(
    HtmlTag::script('/assets/application.js', ['defer' => true]),
    'link[rel="stylesheet"][href="/assets/application.css"]',
);
```

Content can be ordered after another named entry. Both in PHP and here in Twig:

```twig
{% add 'application.script' to body after 'vendor.script' %}
    <script src="/assets/application.js" defer></script>
{% endadd %}
```

Or before another entry:

```twig
{% add 'critical.stylesheet' to stylesheets before 'theme.stylesheet' %}
    <link rel="stylesheet" href="/assets/critical.css">
{% endadd %}
```

Because not all tags will provide an identifier by default as it is optional, there is an identifier derived by default so you can do this:

```twig
{% add 'application.script' to body after 'script[src="/assets/vendor.js"]' %}
    <script src="/assets/application.js"></script>
{% endadd %}
```

Because it's hard to know the identifier or guess it - you can just look at the source code in the `dev` environment. You will find either a `data-contao-tag` attribute or a `<!-- contao-tag: foobar -->` HTML comment.

Finally, in the page layout, all you need to do is:

```twig
{% for identifier, tag in response_context.head.all(app.request) %}
    {{ tag|contao_html_tag(identifier) }}
{% endfor %}
```

And here's the real magic: we now support ordering on the bags both via PHP and Twig! So you can already order your data before or after some other entry when adding but you can also adjust the ordering in the final layout output giving you new super powers 😎: 

```twig
{% block head_tags %}
    {% do response_context.head.orderBefore(
        'application.script',
        'vendor.script',
    ) %}

    {{ parent() }}
{% endblock %}
```

```twig
{% block end_of_body %}
    {% do response_context.end_of_body.orderAfter(
        'application.script',
        'vendor.script',
    ) %}

    {{ parent() }}
{% endblock %}
```

This should also lay the foundation for other contributions such as native support for `og:image` tags and whatever else the community comes up with 😊 
