### PR TITLE
Replace the `BackendUser::navigation()` method and deprecate the `getUserNavigation` hook

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -530,6 +530,9 @@ services:
         class: Contao\CoreBundle\EventListener\Menu\BackendMainListener
         arguments:
             - '@security.helper'
+            - '@request_stack'
+            - '@router'
+            - '@translator'
 
     contao.listener.menu.backend_preview:
         class: Contao\CoreBundle\EventListener\Menu\BackendPreviewListener

--- a/core-bundle/contao/classes/BackendUser.php
+++ b/core-bundle/contao/classes/BackendUser.php
@@ -336,9 +336,13 @@ class BackendUser extends User
 	 * @param boolean $blnShowAll
 	 *
 	 * @return array
+	 *
+	 * @deprecated Deprecated since Contao 6.1, to be removed in Contao 7.
 	 */
 	public function navigation($blnShowAll=false)
 	{
+		trigger_deprecation('contao/core-bundle', '6.1', 'Using "%s()" is deprecated and will no longer work in Contao 7.', __METHOD__);
+
 		$arrModules = array();
 		$arrStatus = System::getContainer()->get('request_stack')->getSession()->getBag('contao_backend')->get('backend_modules');
 		$router = System::getContainer()->get('router');

--- a/core-bundle/src/EventListener/Menu/BackendMainListener.php
+++ b/core-bundle/src/EventListener/Menu/BackendMainListener.php
@@ -12,10 +12,17 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\Menu;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\Event\MenuEvent;
+use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\System;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Make sure this listener comes before the other ones adding to its tree.
@@ -25,18 +32,16 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 #[AsEventListener(priority: 10)]
 class BackendMainListener
 {
-    public function __construct(private readonly Security $security)
-    {
+    public function __construct(
+        private readonly Security $security,
+        private readonly RequestStack $requestStack,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly TranslatorInterface&TranslatorBagInterface $translator,
+    ) {
     }
 
     public function __invoke(MenuEvent $event): void
     {
-        $user = $this->security->getUser();
-
-        if (!$user instanceof BackendUser) {
-            return;
-        }
-
         $name = $event->getTree()->getName();
 
         if ('mainMenu' !== $name) {
@@ -45,7 +50,9 @@ class BackendMainListener
 
         $factory = $event->getFactory();
         $tree = $event->getTree();
-        $modules = $user->navigation();
+        $request = $this->requestStack->getCurrentRequest();
+        $modules = $this->getBackendModules($request);
+        $collapsed = $this->getCollapsedNodes();
 
         foreach ($modules as $categoryName => $categoryData) {
             $categoryNode = $tree->getChild($categoryName);
@@ -55,8 +62,8 @@ class BackendMainListener
                     ->createItem($categoryName)
                     ->setLabel($categoryData['label'])
                     ->setUri($categoryData['href'])
-                    ->setLinkAttribute('class', $this->getClassFromAttributes($categoryData))
-                    ->setLinkAttribute('title', $categoryData['title'])
+                    ->setLinkAttribute('class', $categoryData['class'])
+                    ->setLinkAttribute('title', $this->translator->trans('MSC.collapseNode', [], 'contao_default'))
                     ->setLinkAttribute('data-action', 'contao--toggle-navigation#toggle:prevent')
                     ->setLinkAttribute('data-contao--toggle-navigation-category-param', $categoryName)
                     ->setLinkAttribute('data-contao--tooltips-target', 'tooltip')
@@ -66,7 +73,8 @@ class BackendMainListener
                     ->setExtra('translation_domain', false)
                 ;
 
-                if (isset($categoryData['class']) && preg_match('/\bnode-collapsed\b/', (string) $categoryData['class'])) {
+                if ($collapsed[$categoryName] ?? false) {
+                    $categoryNode->setLinkAttribute('title', $this->translator->trans('MSC.expandNode', [], 'contao_default'));
                     $categoryNode->setAttribute('class', 'collapsed');
                     $categoryNode->setLinkAttribute('aria-expanded', 'false');
                 } else {
@@ -82,28 +90,90 @@ class BackendMainListener
                     ->createItem($nodeName)
                     ->setLabel($nodeData['label'])
                     ->setUri($nodeData['href'])
-                    ->setLinkAttribute('class', $this->getClassFromAttributes($nodeData))
+                    ->setLinkAttribute('class', $nodeData['class'])
                     ->setLinkAttribute('title', $nodeData['title'])
                     ->setLinkAttribute('data-contao--tooltips-target', 'tooltip')
-                    ->setCurrent((bool) $nodeData['isActive'])
                     ->setExtra('translation_domain', false)
                 ;
+
+                if ($request?->query->get('do') === $nodeName) {
+                    $categoryNode->setLinkAttribute('class', $categoryNode->getLinkAttribute('class').' trail');
+                    $moduleNode->setCurrent(true);
+                }
 
                 $categoryNode->addChild($moduleNode);
             }
         }
     }
 
-    private function getClassFromAttributes(array $attributes): string
+    /**
+     * We have to keep this logic from BackendUser::navigation() until the
+     * "getUserNavigation" hook is removed.
+     */
+    private function getBackendModules(Request|null $request): array
     {
-        $classes = [];
+        $arrModules = [];
 
-        // Remove the default CSS classes and keep potentially existing custom ones (see #1357)
-        if (isset($attributes['class'])) {
-            $classes = array_flip(array_filter(explode(' ', (string) $attributes['class'])));
-            unset($classes['node-expanded'], $classes['node-collapsed'], $classes['trail']);
+        foreach ($GLOBALS['BE_MOD'] as $strGroupName => $arrGroupModules) {
+            if (!empty($arrGroupModules) && ('system' === $strGroupName || $this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, array_keys($arrGroupModules)))) {
+                $arrModules[$strGroupName]['class'] = 'group-'.$strGroupName;
+                $arrModules[$strGroupName]['title'] = $this->translator->trans('MSC.collapseNode', [], 'contao_default');
+                $arrModules[$strGroupName]['label'] = $this->translateModule($strGroupName);
+                $arrModules[$strGroupName]['href'] = $this->urlGenerator->generate('contao_backend', ['do' => $request?->query->get('do'), 'mtg' => $strGroupName]);
+                $arrModules[$strGroupName]['ajaxUrl'] = $this->urlGenerator->generate('contao_backend');
+
+                foreach ($arrGroupModules as $strModuleName => $arrModuleConfig) {
+                    // Check access
+                    $blnAccess = (isset($arrModuleConfig['disablePermissionChecks']) && true === $arrModuleConfig['disablePermissionChecks']) || $this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, $strModuleName);
+                    $blnHide = isset($arrModuleConfig['hideInNavigation']) && true === $arrModuleConfig['hideInNavigation'];
+
+                    if ($blnAccess && !$blnHide) {
+                        $arrModules[$strGroupName]['modules'][$strModuleName] = $arrModuleConfig;
+                        $arrModules[$strGroupName]['modules'][$strModuleName]['title'] = $this->translator->getCatalogue()->has("MOD.$strModuleName.1", 'contao_default') ? $this->translator->trans("MOD.$strModuleName.1", [], 'contao_default') : '';
+                        $arrModules[$strGroupName]['modules'][$strModuleName]['label'] = $this->translateModule($strModuleName);
+                        $arrModules[$strGroupName]['modules'][$strModuleName]['class'] = 'navigation '.$strModuleName;
+                        $arrModules[$strGroupName]['modules'][$strModuleName]['href'] = $this->urlGenerator->generate('contao_backend', ['do' => $strModuleName]);
+                    }
+                }
+            }
         }
 
-        return implode(' ', array_keys($classes));
+        // HOOK: add custom logic
+        if (isset($GLOBALS['TL_HOOKS']['getUserNavigation']) && \is_array($GLOBALS['TL_HOOKS']['getUserNavigation'])) {
+            trigger_deprecation('contao/core-bundle', '6.1', 'The "getUserNavigation" hook is deprecated and will be removed in Contao 7. Use the "%s" event instead', MenuEvent::class);
+
+            foreach ($GLOBALS['TL_HOOKS']['getUserNavigation'] as $callback) {
+                $arrModules = System::importStatic($callback[0])->{$callback[1]}($arrModules, true);
+            }
+        }
+
+        return $arrModules;
+    }
+
+    private function getCollapsedNodes(): array
+    {
+        $sessionBag = $this->requestStack->getSession()->getBag('contao_backend');
+
+        if (!$sessionBag instanceof AttributeBagInterface) {
+            return [];
+        }
+
+        return array_map(
+            static fn ($v) => !$v,
+            (array) $sessionBag->get('backend_modules'),
+        );
+    }
+
+    private function translateModule(string $name): string
+    {
+        if ($this->translator->getCatalogue()->has("MOD.$name.0", 'contao_default')) {
+            return $this->translator->trans("MOD.$name.0", [], 'contao_default');
+        }
+
+        if ($this->translator->getCatalogue()->has("MOD.$name", 'contao_default')) {
+            return $this->translator->trans("MOD.$name", [], 'contao_default');
+        }
+
+        return $name;
     }
 }

--- a/core-bundle/tests/EventListener/Menu/BackendMainListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendMainListenerTest.php
@@ -12,35 +12,81 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener\Menu;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\Event\MenuEvent;
 use Contao\CoreBundle\EventListener\Menu\BackendMainListener;
 use Contao\CoreBundle\Tests\TestCase;
 use Knp\Menu\MenuFactory;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Translation\Translator;
 
 class BackendMainListenerTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_MOD']);
+    }
+
     public function testBuildsTheMainMenu(): void
     {
-        $user = $this->createMock(BackendUser::class);
-        $user
-            ->expects($this->once())
-            ->method('navigation')
-            ->willReturn($this->getNavigation())
-        ;
+        $GLOBALS['BE_MOD'] = [
+            'group' => [
+                'module1' => [],
+                'module2' => [],
+            ],
+        ];
 
         $security = $this->createStub(Security::class);
         $security
-            ->method('getUser')
-            ->willReturn($user)
+            ->method('isGranted')
+            ->willReturn(true)
+        ;
+
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator
+            ->method('generate')
+            ->willReturn('__link__')
+        ;
+
+        $messageCatalogue = $this->createStub(MessageCatalogueInterface::class);
+        $messageCatalogue
+            ->method('has')
+            ->willReturn(true)
+        ;
+
+        $translator = $this->createStub(Translator::class);
+        $translator
+            ->method('getCatalogue')
+            ->willReturn($messageCatalogue)
+        ;
+
+        $translator
+            ->method('trans')
+            ->willReturnMap([
+                ['MSC.collapseNode', [], 'contao_default', 'collapse'],
+                ['MSC.expandNode', [], 'contao_default', 'expand'],
+                ['MOD.group.0', [], 'contao_default', 'Group'],
+                ['MOD.group.1', [], 'contao_default', 'Group Title'],
+                ['MOD.module1.0', [], 'contao_default', 'Module 1'],
+                ['MOD.module1.1', [], 'contao_default', 'Module 1 Title'],
+                ['MOD.module2.0', [], 'contao_default', 'Module 2'],
+                ['MOD.module2.1', [], 'contao_default', 'Module 2 Title'],
+            ])
         ;
 
         $nodeFactory = new MenuFactory();
         $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('mainMenu'));
 
-        $listener = new BackendMainListener($security);
+        $listener = new BackendMainListener(
+            $security,
+            $this->createStub(RequestStack::class),
+            $urlGenerator,
+            $translator,
+        );
+
         $listener($event);
 
         $tree = $event->getTree();
@@ -49,98 +95,166 @@ class BackendMainListenerTest extends TestCase
 
         $children = $tree->getChildren();
 
-        $this->assertCount(2, $children);
-        $this->assertSame(['category1', 'category2'], array_keys($children));
+        $this->assertCount(1, $children);
+        $this->assertSame(['group'], array_keys($children));
 
-        // Category 1
-        $this->assertSame('Category 1', $children['category1']->getLabel());
-        $this->assertSame([], $children['category1']->getAttributes());
-        $this->assertSame(['id' => 'category1'], $children['category1']->getChildrenAttributes());
-        $this->assertSame(['translation_domain' => false], $children['category1']->getExtras());
+        $this->assertSame('Group', $children['group']->getLabel());
+        $this->assertSame([], $children['group']->getAttributes());
+        $this->assertSame(['id' => 'group'], $children['group']->getChildrenAttributes());
+        $this->assertSame(['translation_domain' => false], $children['group']->getExtras());
 
         $this->assertSame(
             [
-                'class' => 'group-category1 custom-class',
-                'title' => 'Category 1 Title',
+                'class' => 'group-group',
+                'title' => 'collapse',
                 'data-action' => 'contao--toggle-navigation#toggle:prevent',
-                'data-contao--toggle-navigation-category-param' => 'category1',
+                'data-contao--toggle-navigation-category-param' => 'group',
                 'data-contao--tooltips-target' => 'tooltip',
-                'aria-controls' => 'category1',
+                'aria-controls' => 'group',
                 'data-turbo-prefetch' => 'false',
                 'aria-expanded' => 'true',
             ],
-            $children['category1']->getLinkAttributes(),
+            $children['group']->getLinkAttributes(),
         );
 
-        $grandChildren = $children['category1']->getChildren();
+        $grandChildren = $children['group']->getChildren();
 
         $this->assertCount(2, $grandChildren);
-        $this->assertSame(['node1', 'node2'], array_keys($grandChildren));
+        $this->assertSame(['module1', 'module2'], array_keys($grandChildren));
 
         // Node 1
-        $this->assertSame('Node 1', $grandChildren['node1']->getLabel());
-        $this->assertSame('/node1', $grandChildren['node1']->getUri());
-        $this->assertSame(['class' => 'node1', 'title' => 'Node 1 Title', 'data-contao--tooltips-target' => 'tooltip'], $grandChildren['node1']->getLinkAttributes());
-        $this->assertSame(['translation_domain' => false], $grandChildren['node1']->getExtras());
+        $this->assertSame('Module 1', $grandChildren['module1']->getLabel());
+        $this->assertSame('__link__', $grandChildren['module1']->getUri());
+        $this->assertSame(['class' => 'navigation module1', 'title' => 'Module 1 Title', 'data-contao--tooltips-target' => 'tooltip'], $grandChildren['module1']->getLinkAttributes());
+        $this->assertSame(['translation_domain' => false], $grandChildren['module1']->getExtras());
 
         // Node 1
-        $this->assertSame('Node 2', $grandChildren['node2']->getLabel());
-        $this->assertSame('/node2', $grandChildren['node2']->getUri());
-        $this->assertSame(['class' => 'node2', 'title' => 'Node 2 Title', 'data-contao--tooltips-target' => 'tooltip'], $grandChildren['node2']->getLinkAttributes());
-        $this->assertSame(['translation_domain' => false], $grandChildren['node2']->getExtras());
-
-        // Category 2
-        $this->assertSame('Category 2', $children['category2']->getLabel());
-        $this->assertSame(['class' => 'collapsed'], $children['category2']->getAttributes());
-        $this->assertSame(['id' => 'category2'], $children['category2']->getChildrenAttributes());
-        $this->assertSame(['translation_domain' => false], $children['category2']->getExtras());
-
-        $this->assertSame(
-            [
-                'class' => 'group-category2',
-                'title' => 'Category 2 Title',
-                'data-action' => 'contao--toggle-navigation#toggle:prevent',
-                'data-contao--toggle-navigation-category-param' => 'category2',
-                'data-contao--tooltips-target' => 'tooltip',
-                'aria-controls' => 'category2',
-                'data-turbo-prefetch' => 'false',
-                'aria-expanded' => 'false',
-            ],
-            $children['category2']->getLinkAttributes(),
-        );
+        $this->assertSame('Module 2', $grandChildren['module2']->getLabel());
+        $this->assertSame('__link__', $grandChildren['module2']->getUri());
+        $this->assertSame(['class' => 'navigation module2', 'title' => 'Module 2 Title', 'data-contao--tooltips-target' => 'tooltip'], $grandChildren['module2']->getLinkAttributes());
+        $this->assertSame(['translation_domain' => false], $grandChildren['module2']->getExtras());
     }
 
-    public function testDoesNotBuildTheMainMenuIfNoUserIsGiven(): void
+    public function testDoesNotRenderEmptyModuleGroups(): void
     {
+        $GLOBALS['BE_MOD'] = [
+            'group1' => [
+                'module1' => [],
+                'module2' => [],
+            ],
+            'group2' => [],
+        ];
+
         $security = $this->createStub(Security::class);
         $security
-            ->method('getUser')
-            ->willReturn(null)
-        ;
-
-        $router = $this->createMock(RouterInterface::class);
-        $router
-            ->expects($this->never())
-            ->method('generate')
+            ->method('isGranted')
+            ->willReturn(true)
         ;
 
         $nodeFactory = new MenuFactory();
         $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('mainMenu'));
 
-        $listener = new BackendMainListener($security);
+        $listener = new BackendMainListener(
+            $security,
+            $this->createStub(RequestStack::class),
+            $this->createStub(UrlGeneratorInterface::class),
+            $this->createStub(Translator::class),
+        );
+
         $listener($event);
 
         $tree = $event->getTree();
 
-        $this->assertCount(0, $tree->getChildren());
+        $this->assertSame('mainMenu', $tree->getName());
+
+        $children = $tree->getChildren();
+
+        $this->assertCount(1, $children);
+        $this->assertSame(['group1'], array_keys($children));
+
+        $grandChildren = $children['group1']->getChildren();
+
+        $this->assertCount(2, $grandChildren);
+        $this->assertSame(['module1', 'module2'], array_keys($grandChildren));
+    }
+
+    public function testFallsBackToStringModuleTranslation(): void
+    {
+        $GLOBALS['BE_MOD'] = [
+            'group' => [
+                'module1' => [],
+                'module2' => [],
+            ],
+        ];
+
+        $security = $this->createStub(Security::class);
+        $security
+            ->method('isGranted')
+            ->willReturn(true)
+        ;
+
+        $messageCatalogue = $this->createStub(MessageCatalogueInterface::class);
+        $messageCatalogue
+            ->method('has')
+            ->willReturnCallback(static fn (string $id) => !str_ends_with($id, '.0') && !str_ends_with($id, '.1'))
+        ;
+
+        $translator = $this->createStub(Translator::class);
+        $translator
+            ->method('getCatalogue')
+            ->willReturn($messageCatalogue)
+        ;
+
+        $translator
+            ->method('trans')
+            ->willReturnMap([
+                ['MSC.collapseNode', [], 'contao_default', 'collapse'],
+                ['MSC.expandNode', [], 'contao_default', 'expand'],
+                ['MOD.group', [], 'contao_default', 'Group'],
+                ['MOD.module1', [], 'contao_default', 'Module 1'],
+                ['MOD.module2', [], 'contao_default', 'Module 2'],
+            ])
+        ;
+
+        $nodeFactory = new MenuFactory();
+        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('mainMenu'));
+
+        $listener = new BackendMainListener(
+            $security,
+            $this->createStub(RequestStack::class),
+            $this->createStub(UrlGeneratorInterface::class),
+            $translator,
+        );
+
+        $listener($event);
+
+        $tree = $event->getTree();
+
+        $this->assertSame('mainMenu', $tree->getName());
+
+        $children = $tree->getChildren();
+
+        $this->assertSame('Group', $children['group']->getLabel());
+
+        $grandChildren = $children['group']->getChildren();
+
+        $this->assertSame('Module 1', $grandChildren['module1']->getLabel());
+        $this->assertSame('Module 2', $grandChildren['module2']->getLabel());
     }
 
     public function testDoesNotBuildTheMainMenuIfTheNameDoesNotMatch(): void
     {
-        $security = $this->createStub(Security::class);
+        $GLOBALS['BE_MOD'] = [
+            'group' => [
+                'module1' => [],
+                'module2' => [],
+            ],
+        ];
+
+        $security = $this->createMock(Security::class);
         $security
-            ->method('getUser')
-            ->willReturn(null)
+            ->expects($this->never())
+            ->method('isGranted')
         ;
 
         $router = $this->createMock(RouterInterface::class);
@@ -152,49 +266,17 @@ class BackendMainListenerTest extends TestCase
         $nodeFactory = new MenuFactory();
         $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('root'));
 
-        $listener = new BackendMainListener($security);
+        $listener = new BackendMainListener(
+            $security,
+            $this->createStub(RequestStack::class),
+            $this->createStub(UrlGeneratorInterface::class),
+            $this->createStub(Translator::class),
+        );
+
         $listener($event);
 
         $tree = $event->getTree();
 
         $this->assertCount(0, $tree->getChildren());
-    }
-
-    /**
-     * @return array<string, array<string, array<string, array<string, bool|string>>|string>>
-     */
-    private function getNavigation(): array
-    {
-        return [
-            'category1' => [
-                'label' => 'Category 1',
-                'title' => 'Category 1 Title',
-                'href' => '/',
-                'class' => 'group-category1 node-expanded trail custom-class',
-                'modules' => [
-                    'node1' => [
-                        'label' => 'Node 1',
-                        'title' => 'Node 1 Title',
-                        'href' => '/node1',
-                        'class' => 'node1',
-                        'isActive' => true,
-                    ],
-                    'node2' => [
-                        'label' => 'Node 2',
-                        'title' => 'Node 2 Title',
-                        'href' => '/node2',
-                        'class' => 'node2',
-                        'isActive' => false,
-                    ],
-                ],
-            ],
-            'category2' => [
-                'label' => 'Category 2',
-                'title' => 'Category 2 Title',
-                'href' => '/',
-                'class' => 'group-category2 node-collapsed',
-                'modules' => [],
-            ],
-        ];
     }
 }

--- a/core-bundle/tests/EventListener/Menu/BackendMainListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendMainListenerTest.php
@@ -27,6 +27,8 @@ class BackendMainListenerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         unset($GLOBALS['BE_MOD']);
     }
 


### PR DESCRIPTION
While reviewing #10071 I though maybe we could replace the legacy user object instead of adding yet another helper method. Then I realized our backend navigation still relied on that class, so we should get rid of that.

This still keeps some of the legacy code because we need to support the old `getUserNavigation` hook. Once we get rid of that (I guess we really can in 7.0, since there has been an event for a loong time), we can rewrite the remaining stuff.

Be aware that the tests have been changed significantly, since they tested stuff (result from `User::navigation`) that actually wasn't possible to configure through `$GLOBALS['BE_MOD']`.