### PR TITLE
Update mcp-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
         "symfony/intl": "^7.4 || ^8.0",
         "symfony/mailer": "^7.4 || ^8.0",
         "symfony/maker-bundle": "^1.1",
-        "symfony/mcp-bundle": "^0.10",
+        "symfony/mcp-bundle": "^0.12",
         "symfony/messenger": "^7.4 || ^8.0",
         "symfony/mime": "^7.4 || ^8.0",
         "symfony/monolog-bridge": "^7.4 || ^8.0",

--- a/mcp-bundle/composer.json
+++ b/mcp-bundle/composer.json
@@ -32,7 +32,7 @@
         "contao/api-bundle": "self.version",
         "contao/core-bundle": "self.version",
         "symfony/http-kernel": "^7.4 || ^8.0",
-        "symfony/mcp-bundle": "^0.10"
+        "symfony/mcp-bundle": "^0.12"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",


### PR DESCRIPTION
Currently, all PRs fail because of Composer blocking security affected packages. We just need to update the mcp-bundle deps, there are no breaks affecting our dev state as far as I could tell.