### PR TITLE
Optimize file counting in the maintenance module

### DIFF
--- a/core-bundle/contao/classes/PurgeData.php
+++ b/core-bundle/contao/classes/PurgeData.php
@@ -113,10 +113,10 @@ class PurgeData extends Backend implements MaintenanceModuleInterface
 					// Do not count the deferred images JSON files
 					if ($key == 'images')
 					{
-						$objFiles->notPath('deferred');
+						$objFiles->exclude('deferred');
 					}
 
-					$total = iterator_count($objFiles);
+					$total = $objFiles->count();
 				}
 
 				$arrJobs[$key]['affected'] .= '<br>' . $folder . ': <span>' . \sprintf($GLOBALS['TL_LANG']['MSC']['files'], $total) . '</span>';


### PR DESCRIPTION
The maintenance module recursively counts files in the purgeable directories.

For the image cache, it previously used `Finder::notPath()` to omit deferred image metadata. However, `notPath()` filters the results only after traversing the directory. Using `exclude()` allows Finder to prune the directory instead.

This also uses Finder's `Countable` API directly instead of passing it to `iterator_count()`. Although both are currently equivalent, calling `count()` makes the intent explicit and allows Finder to provide an optimized counting implementation in the future.