### PR TITLE
Backport the `BackendHelperRuntime`

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1175,6 +1175,11 @@ services:
             - '@contao.framework'
             - '@contao.resource_finder'
 
+    contao.twig.backend_helper_runtime:
+        class: Contao\CoreBundle\Twig\Runtime\BackendHelperRuntime
+        arguments:
+            - '@contao.framework'
+
     contao.twig.content_url_runtime:
         class: Contao\CoreBundle\Twig\Runtime\ContentUrlRuntime
         arguments:

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -29,6 +29,7 @@ use Contao\CoreBundle\Twig\Interop\PhpTemplateProxyNodeVisitor;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
 use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
+use Contao\CoreBundle\Twig\Runtime\BackendHelperRuntime;
 use Contao\CoreBundle\Twig\Runtime\ContentUrlRuntime;
 use Contao\CoreBundle\Twig\Runtime\CspRuntime;
 use Contao\CoreBundle\Twig\Runtime\FigureRuntime;
@@ -241,6 +242,16 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
             new TwigFunction(
                 'content_url',
                 [ContentUrlRuntime::class, 'generate'],
+            ),
+            new TwigFunction(
+                'backend_icon',
+                [BackendHelperRuntime::class, 'icon'],
+                ['is_safe' => ['html']],
+            ),
+            new TwigFunction(
+                'file_icon',
+                [BackendHelperRuntime::class, 'fileIcon'],
+                ['is_safe' => ['html']],
             ),
         ];
     }

--- a/core-bundle/src/Twig/Runtime/BackendHelperRuntime.php
+++ b/core-bundle/src/Twig/Runtime/BackendHelperRuntime.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Twig\Runtime;
+
+use Contao\CoreBundle\Filesystem\FilesystemItem;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\String\HtmlAttributes;
+use Contao\Image;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class BackendHelperRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @internal
+     */
+    public function __construct(private readonly ContaoFramework $framework)
+    {
+    }
+
+    public function icon(string $src, string $alt = '', HtmlAttributes|null $attributes = null): string
+    {
+        $image = $this->framework->getAdapter(Image::class);
+
+        return $image->getHtml($src, $alt, $attributes instanceof HtmlAttributes ? $attributes : '');
+    }
+
+    /**
+     * Returns a file icon based on the mapping in the TL_MIME superglobal.
+     */
+    public function fileIcon(FilesystemItem $item, string $alt = '', HtmlAttributes|null $attributes = null): string
+    {
+        if (!$mimeType = $item->getMimeType()) {
+            return $this->icon('plain.svg', $alt, $attributes);
+        }
+
+        $this->framework->initialize();
+
+        foreach ($GLOBALS['TL_MIME'] ?? [] as $mimeTypes) {
+            if ($mimeType === $mimeTypes[0]) {
+                return $this->icon($mimeTypes[1], $alt, $attributes);
+            }
+        }
+
+        return $this->icon('plain.svg', $alt, $attributes);
+    }
+}

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -102,6 +102,8 @@ class ContaoExtensionTest extends TestCase
             'csp_source' => [],
             'csp_hash' => [],
             'content_url' => [],
+            'backend_icon' => ['html'],
+            'file_icon' => ['html'],
         ];
 
         $functions = $this->getContaoExtension()->getFunctions();

--- a/core-bundle/tests/Twig/Runtime/BackendHelperRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/BackendHelperRuntimeTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\Runtime;
+
+use Contao\CoreBundle\Filesystem\FilesystemItem;
+use Contao\CoreBundle\String\HtmlAttributes;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Runtime\BackendHelperRuntime;
+use Contao\Image;
+
+class BackendHelperRuntimeTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_MIME']);
+
+        parent::tearDown();
+    }
+
+    public function testDelegatesCallsForIcon(): void
+    {
+        $attributes = (new HtmlAttributes())->set('foo', 'bar');
+
+        $imageAdapter = $this->mockAdapter(['getHtml']);
+        $imageAdapter
+            ->expects($this->once())
+            ->method('getHtml')
+            ->with('icon.svg', 'alt', $attributes)
+            ->willReturn('icon HTML')
+        ;
+
+        $framework = $this->mockContaoFramework([Image::class => $imageAdapter]);
+
+        $runtime = new BackendHelperRuntime($framework);
+
+        $this->assertSame('icon HTML', $runtime->icon('icon.svg', 'alt', $attributes));
+    }
+
+    public function testReturnsDefaultIconForNoMimeType(): void
+    {
+        $attributes = (new HtmlAttributes())->set('foo', 'bar');
+
+        $imageAdapter = $this->mockAdapter(['getHtml']);
+        $imageAdapter
+            ->expects($this->once())
+            ->method('getHtml')
+            ->with('plain.svg', 'alt', $attributes)
+            ->willReturn('icon HTML')
+        ;
+
+        $framework = $this->mockContaoFramework([Image::class => $imageAdapter]);
+
+        $runtime = new BackendHelperRuntime($framework);
+
+        $this->assertSame('icon HTML', $runtime->fileIcon(
+            $this->createStub(FilesystemItem::class),
+            'alt',
+            $attributes,
+        ));
+    }
+
+    public function testReturnsIconForMimeType(): void
+    {
+        $attributes = (new HtmlAttributes())->set('foo', 'bar');
+
+        $imageAdapter = $this->mockAdapter(['getHtml']);
+        $imageAdapter
+            ->expects($this->once())
+            ->method('getHtml')
+            ->with('image.svg', 'alt', $attributes)
+            ->willReturn('icon HTML')
+        ;
+
+        $framework = $this->mockContaoFramework([Image::class => $imageAdapter]);
+
+        $fileitem = $this->createMock(FilesystemItem::class);
+        $fileitem
+            ->expects($this->once())
+            ->method('getMimeType')
+            ->willReturn('image/jpeg')
+        ;
+
+        $GLOBALS['TL_MIME'] = ['jpg' => ['image/jpeg', 'image.svg']];
+
+        $runtime = new BackendHelperRuntime($framework);
+
+        $this->assertSame('icon HTML', $runtime->fileIcon($fileitem, 'alt', $attributes));
+    }
+
+    public function testReturnsDefaultIconForMissingRegisteredMimeType(): void
+    {
+        $attributes = (new HtmlAttributes())->set('foo', 'bar');
+
+        $imageAdapter = $this->mockAdapter(['getHtml']);
+        $imageAdapter
+            ->expects($this->once())
+            ->method('getHtml')
+            ->with('plain.svg', 'alt', $attributes)
+            ->willReturn('icon HTML')
+        ;
+
+        $framework = $this->mockContaoFramework([Image::class => $imageAdapter]);
+
+        $fileitem = $this->createMock(FilesystemItem::class);
+        $fileitem
+            ->expects($this->once())
+            ->method('getMimeType')
+            ->willReturn('image/jpeg')
+        ;
+
+        $runtime = new BackendHelperRuntime($framework);
+
+        $this->assertSame('icon HTML', $runtime->fileIcon($fileitem, 'alt', $attributes));
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]  
> No need to merge upstream, this is already within Contao >= 5.7

### Description

This PR backports the `BackendHelperRuntime`, especially the `backend_icon` twig function.

The `BackendHelperRuntime` has been added in #7587 as a twig equivalent for `Image::getHtml()` and should be used within extensions that do not want to provide their own icons and want to consume them from the core + keep compatibility with Contao ^5.3 and ^6.0.

Using `backend_icon` is the way to get our icons in this case.

I do not think people should need to install `contao/codefog-haste` just for adding ONE backport for that function https://github.com/codefog/contao-haste/pull/236, imho way too much other dependencies for this case that aren't needed.

### Information

We've deprecated backend themes in Contao 5.7 and removed them in Contao 6 which makes consuming the backend icons harder for extensions in Contao 6 since we are moving away from

```css
background-image: url("../../../system/themes/flexible/icons/children.svg");
```

and would now need to determine the new icon path from the `manifest.json`:

```css
background-image: url("/bundles/contaocore/icons/edit.0b1829c8.svg");
```

Using `backend_icon` would be best since these extensions would only need to provide one version to provide the icons instead of running 2 versions for Contao 5.* and Contao 6. That would be the case in widgets like the `m-vo/contao-group-widget`-> See discussion: https://github.com/m-vo/contao-group-widget/pull/86#discussion_r3782281055 and https://github.com/m-vo/contao-group-widget/pull/86#issuecomment-5291430364.

In any case if someone actually wants to consume the backend icons within `CSS` within extensions that need to run in Contao `4.4`, `4.9`, `4.13`, `5.3`, `5.7`, `6.*` and future versions, then they have to use another strategy such as https://github.com/madeyourday/contao-rocksolid-frontend-helper/pull/94/changes/d378c1d3e98ccbf59fc9fdde35bb751ae3261a51 within https://github.com/madeyourday/contao-rocksolid-frontend-helper/pull/94 where extensions can consume it via the `contao.backend.icons` (introduced in #8094) and dynamically get the url path.

