### PR TITLE
Use a shared app cache for cron and web worker

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -23,15 +23,6 @@ services:
             - staticFiles
             - '%kernel.debug%'
 
-    contao.cache.shared:
-        class: Symfony\Component\Cache\Adapter\FilesystemAdapter
-        arguments:
-            - contao
-            - 0
-            - '%kernel.project_dir%/var/cache/shared'
-        tags:
-            - cache.pool
-
     contao.cache.clearer:
         class: Contao\CoreBundle\Cache\ContaoCacheClearer
         public: true
@@ -45,6 +36,15 @@ services:
             - '@doctrine.orm.default_entity_manager'
             - '@?fos_http_cache.http.symfony_response_tagger'
             - '@?fos_http_cache.cache_manager'
+
+    contao.cache.shared:
+        class: Symfony\Component\Cache\Adapter\FilesystemAdapter
+        arguments:
+            - contao
+            - 0
+            - '%kernel.project_dir%/var/cache/shared'
+        tags:
+            - { name: cache.pool, namespace: 'contao' }
 
     contao.cache.warmer:
         class: Contao\CoreBundle\Cache\ContaoCacheWarmer

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -44,7 +44,7 @@ services:
             - 0
             - '%kernel.project_dir%/var/cache/shared'
         tags:
-            - { name: cache.pool, namespace: 'contao' }
+            - { name: cache.pool, namespace: contao }
 
     contao.cache.warmer:
         class: Contao\CoreBundle\Cache\ContaoCacheWarmer

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -23,6 +23,15 @@ services:
             - staticFiles
             - '%kernel.debug%'
 
+    contao.cache.shared:
+        class: Symfony\Component\Cache\Adapter\FilesystemAdapter
+        arguments:
+            - contao
+            - 0
+            - '%kernel.project_dir%/var/cache/shared'
+        tags:
+            - cache.pool
+
     contao.cache.clearer:
         class: Contao\CoreBundle\Cache\ContaoCacheClearer
         public: true
@@ -93,7 +102,7 @@ services:
         arguments:
             - !service_closure '@contao.repository.cron_job'
             - !service_closure '@doctrine.orm.entity_manager'
-            - '@cache.app'
+            - '@contao.cache.shared'
             - '@?logger'
 
     contao.cron.purge_expired_data:
@@ -583,7 +592,7 @@ services:
     contao.messenger.web_worker:
         class: Contao\CoreBundle\Messenger\WebWorker
         arguments:
-            - '@cache.app'
+            - '@contao.cache.shared'
             - '@console.command.messenger_consume_messages'
             - '@contao.routing.scope_matcher'
 


### PR DESCRIPTION
As noticed by @Toflar in Slack, our cache items to detect CLI processes for the cron and messenger are currently specific to the environment. So if your CLI processes are running in `prod`, but you enabled the `dev` mode via the Contao back end for example, then your web processes (for your specific `dev` mode) will think that no CLI processes are running.

This PR fixes that by introducing a shared app cache (`contao.cache.shared`) which lives in `var/cache/shared` and is shared across all environments.

_Note:_ Symfony would normally automatically add a prefix seed for all `cache.pool` caches depending on the environment for each cache item. So even if the cache points to the same directory for all environments, the cache items would still be separated by the environment. But this can be circumvented by providing a `namespace` on the `cache.pool` tag.