### PR TITLE
Remove the obsolete `contao.repository.job` service

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -866,11 +866,6 @@ services:
         arguments:
             - '@doctrine'
 
-    contao.repository.job:
-        class: Contao\CoreBundle\Repository\JobRepository
-        arguments:
-            - '@doctrine'
-
     contao.repository.webauthn_credential:
         class: Contao\CoreBundle\Repository\WebauthnCredentialRepository
         public: true


### PR DESCRIPTION
This was added in https://github.com/contao/contao/pull/8066 by accident.