### PR TITLE
Use the same email validation as defined in the HTML specification

### DIFF
--- a/core-bundle/contao/library/Contao/Validator.php
+++ b/core-bundle/contao/library/Contao/Validator.php
@@ -140,7 +140,7 @@ class Validator
 		 *
 		 * @see https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
 		 */
-		return 1 === preg_match('/^[a-zA-Z0-9!#$%&\'*+\/=?^_`{|}~\pL\pN-]+(?:\.[a-zA-Z0-9!#$%&\'*+\/=?^_`{|}~\pL\pN-]+)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/u', Idna::encodeEmail($varValue));
+		return 1 === preg_match('/^[\pL\pN!#$%&\'*+\/=?^_`{|}~-]+(?:\.[\pL\pN!#$%&\'*+\/=?^_`{|}~-]+)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/u', Idna::encodeEmail($varValue));
 	}
 
 	/**

--- a/core-bundle/contao/library/Contao/Validator.php
+++ b/core-bundle/contao/library/Contao/Validator.php
@@ -134,19 +134,12 @@ class Validator
 	public static function isEmail($varValue)
 	{
 		/*
-		 * The regex below is based on a regex by Michael Rushton adjusted by
-		 * Rasmus Lerdorf to only consider routeable addresses as valid. We
-		 * have also added Unicode support for the local part.
+		 * The regex below is based on the HTML standard with the modification
+		 * that we do not allow dotless domains.
 		 *
-		 * Michael's regex carries this copyright:
-		 *
-		 * Copyright © Michael Rushton 2009-10
-		 * http://squiloople.com/
-		 * Feel free to use and redistribute this code. But please keep this copyright notice.
-		 *
-		 * @see https://github.com/php/php-src/blob/master/ext/filter/logical_filters.c#L601
+		 * @see https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
 		 */
-		return 1 === preg_match('/^(?!(?:(?:\x22?\x5C[\x00-\x7E]\x22?)|(?:\x22?[^\x5C\x22]\x22?)){255,})(?!(?:(?:\x22?\x5C[\x00-\x7E]\x22?)|(?:\x22?[^\x5C\x22]\x22?)){65,}@)(?:(?:[\x21\x23-\x27\x2A\x2B\x2D\x2F-\x39\x3D\x3F\x5E-\x7E\pL\pN]+)|(?:\x22(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F\pL\pN]|(?:\x5C[\x00-\x7F]))*\x22))(?:\.(?:(?:[\x21\x23-\x27\x2A\x2B\x2D\x2F-\x39\x3D\x3F\x5E-\x7E\pL\pN]+)|(?:\x22(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F\pL\pN]|(?:\x5C[\x00-\x7F]))*\x22)))*@(?:(?:(?!.*[^.]{64,})(?:(?:(?:xn--)?[a-z0-9]+(?:-+[a-z0-9]+)*\.){1,126}){1,}(?:(?:[a-z][a-z0-9]*)|(?:(?:xn--)[a-z0-9]+))(?:-+[a-z0-9]+)*)|(?:\[(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){7})|(?:(?!(?:.*[a-f0-9][:\]]){7,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?)))|(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){5}:)|(?:(?!(?:.*[a-f0-9]:){5,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3}:)?)))?(?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9]{2})|(?:[1-9]?[0-9]))(?:\.(?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9]{2})|(?:[1-9]?[0-9]))){3}))]))$/iDu', Idna::encodeEmail($varValue));
+		return 1 === preg_match('/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/', Idna::encodeEmail($varValue));
 	}
 
 	/**

--- a/core-bundle/contao/library/Contao/Validator.php
+++ b/core-bundle/contao/library/Contao/Validator.php
@@ -139,7 +139,7 @@ class Validator
 		 *
 		 * @see https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
 		 */
-		return 1 === preg_match('/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~\pL\pN-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/u', Idna::encodeEmail($varValue));
+		return 1 === preg_match('/^[a-zA-Z0-9!#$%&\'*+\/=?^_`{|}~\pL\pN-]+(?:\.[a-zA-Z0-9!#$%&\'*+\/=?^_`{|}~\pL\pN-]+)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/u', Idna::encodeEmail($varValue));
 	}
 
 	/**

--- a/core-bundle/contao/library/Contao/Validator.php
+++ b/core-bundle/contao/library/Contao/Validator.php
@@ -135,7 +135,8 @@ class Validator
 	{
 		/*
 		 * The regex below is based on the HTML standard with the modification
-		 * that we do allow Unicode letters do not allow dotless domains.
+		 * that we do allow Unicode letters and numbers and do not allow
+		 * consecutive dots and dotless domains.
 		 *
 		 * @see https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
 		 */

--- a/core-bundle/contao/library/Contao/Validator.php
+++ b/core-bundle/contao/library/Contao/Validator.php
@@ -135,11 +135,11 @@ class Validator
 	{
 		/*
 		 * The regex below is based on the HTML standard with the modification
-		 * that we do not allow dotless domains.
+		 * that we do allow Unicode letters do not allow dotless domains.
 		 *
 		 * @see https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
 		 */
-		return 1 === preg_match('/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/', Idna::encodeEmail($varValue));
+		return 1 === preg_match('/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~\p{L}-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/u', Idna::encodeEmail($varValue));
 	}
 
 	/**

--- a/core-bundle/contao/library/Contao/Validator.php
+++ b/core-bundle/contao/library/Contao/Validator.php
@@ -139,7 +139,7 @@ class Validator
 		 *
 		 * @see https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
 		 */
-		return 1 === preg_match('/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~\p{L}-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/u', Idna::encodeEmail($varValue));
+		return 1 === preg_match('/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~\pL\pN-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/u', Idna::encodeEmail($varValue));
 	}
 
 	/**

--- a/core-bundle/tests/Contao/ValidatorTest.php
+++ b/core-bundle/tests/Contao/ValidatorTest.php
@@ -38,61 +38,65 @@ class ValidatorTest extends TestCase
         yield ['a.little.lengthy.but.fine@dept.example.com', true];
         yield ['disposable.style.email.with+symbol@example.com', true];
         yield ['other.email-with-dash@example.com', true];
-        yield ['"very.unusual.@.unusual.com"@example.com', true];
-        yield ['"very.(),:;<>[]\".VERY.\"very@\ \"very\".unusual"@strange.example.com', true];
         yield ['!#$%&\'*+-/=?^_`{}|~@example.org', true];
-        yield ['"()<>[]:,;@\"!#$%&\'*+-/=?^_`{}|~.a"@example.org', true];
 
-        // Valid with IP addresses
-        yield ['user@[255.255.255.255]', true];
-        yield ['user@[IPv6:2001:db8:1ff::a0b:dbd0]', true];
-        yield ['user@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]', true];
-        yield ['user@[IPv6:2001::7344]', true];
-        yield ['user@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]', true];
+        // Quoted ASCII
+        yield ['"very.unusual.@.unusual.com"@example.com', false];
+        yield ['"very.(),:;<>[]\".VERY.\"very@\ \"very\".unusual"@strange.example.com', false];
+        yield ['"()<>[]:,;@\"!#$%&\'*+-/=?^_`{}|~.a"@example.org', false];
+
+        // IP addresses square brackets
+        yield ['user@[255.255.255.255]', false];
+        yield ['user@[IPv6:2001:db8:1ff::a0b:dbd0]', false];
+        yield ['user@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]', false];
+        yield ['user@[IPv6:2001::7344]', false];
+        yield ['user@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]', false];
 
         // Valid with IDNA domains
         yield ['test@exämple.com', true];
         yield ['test@ä.xe', true];
         yield ['test@subexample.wizard', true];
         yield ['test@wähwähwäh.ümläüts.de', true];
-        yield ['"tes@t"@wähwähwäh.ümläüts.de', true];
+
+        // Quoted with IDNA domains
+        yield ['"tes@t"@wähwähwäh.ümläüts.de', false];
 
         // Valid with new TLDs
         yield ['test@example.photography', true];
         yield ['test@sub-domain.example.photography', true];
 
-        // Valid with Unicode characters in the local part
-        yield ['niceändsimple@example.com', true];
-        yield ['véry.çommon@example.com', true];
-        yield ['a.lîttle.lengthy.but.fiñe@dept.example.com', true];
-        yield ['dîsposable.style.émail.with+symbol@example.com', true];
-        yield ['other.émail-with-dash@example.com', true];
-        yield ['"verî.uñusual.@.uñusual.com"@example.com', true];
-        yield ['"verî.(),:;<>[]\".VERÎ.\"verî@\ \"verî\".unüsual"@strange.example.com', true];
-        yield ['üñîçøðé@example.com', true];
-        yield ['"üñîçøðé"@example.com', true];
-        yield ['ǅǼ੧ఘⅧ⒇৪@example.com', true];
+        // Unicode characters in the local part
+        yield ['niceändsimple@example.com', false];
+        yield ['véry.çommon@example.com', false];
+        yield ['a.lîttle.lengthy.but.fiñe@dept.example.com', false];
+        yield ['dîsposable.style.émail.with+symbol@example.com', false];
+        yield ['other.émail-with-dash@example.com', false];
+        yield ['"verî.uñusual.@.uñusual.com"@example.com', false];
+        yield ['"verî.(),:;<>[]\".VERÎ.\"verî@\ \"verî\".unüsual"@strange.example.com', false];
+        yield ['üñîçøðé@example.com', false];
+        yield ['"üñîçøðé"@example.com', false];
+        yield ['ǅǼ੧ఘⅧ⒇৪@example.com', false];
 
-        // Valid with IP addresses and Unicode characters in the local part
-        yield ['üser@[255.255.255.255]', true];
-        yield ['üser@[IPv6:2001:db8:1ff::a0b:dbd0]', true];
-        yield ['üser@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]', true];
-        yield ['üser@[IPv6:2001::7344]', true];
-        yield ['üser@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]', true];
+        // IP addresses square brackets and Unicode characters in the local part
+        yield ['üser@[255.255.255.255]', false];
+        yield ['üser@[IPv6:2001:db8:1ff::a0b:dbd0]', false];
+        yield ['üser@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]', false];
+        yield ['üser@[IPv6:2001::7344]', false];
+        yield ['üser@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]', false];
 
-        // Valid with IDNA domains and Unicode characters in the local part
-        yield ['tést@exämple.com', true];
-        yield ['tést@ä.xe', true];
-        yield ['tést@subexample.wizard', true];
-        yield ['tést@wähwähwäh.ümläüts.de', true];
-        yield ['"tés@t"@wähwähwäh.ümläüts.de', true];
+        // IDNA domains and Unicode characters in the local part
+        yield ['tést@exämple.com', false];
+        yield ['tést@ä.xe', false];
+        yield ['tést@subexample.wizard', false];
+        yield ['tést@wähwähwäh.ümläüts.de', false];
+        yield ['"tés@t"@wähwähwäh.ümläüts.de', false];
 
-        // Valid with new TLDs and Unicode characters in the local part
-        yield ['tést@example.photography', true];
-        yield ['tést@sub-domain.example.photography', true];
+        // New TLDs and Unicode characters in the local part
+        yield ['tést@example.photography', false];
+        yield ['tést@sub-domain.example.photography', false];
 
         // Invalid ASCII
-        yield ['test..child@example.com', false];
+        yield ['test..child@example.com', true];
         yield ['test@sub.-example.com', false];
         yield ['test@_smtp_.example.com', false];
         yield ['test@sub..example.com', false];
@@ -179,47 +183,17 @@ class ValidatorTest extends TestCase
             'little.lengthy.but.fine@dept.example.com',
             'disposable.style.email.with+symbol@example.com',
             'other.email-with-dash@example.com',
-            '"very.unusual.@.unusual.com"@example.com',
-            '"very.(),:;<>[]\".VERY.\"very@\ \"very\".unusual"@strange.example.com',
             '!#$%&\'*+-/=?^_`{}|~@example.org',
-            '"()<>[]:,;@\"!#$%&\'*+-/=?^_`{}|~.a"@example.org',
-            'user@[255.255.255.255]',
-            'user@[IPv6:2001:db8:1ff::a0b:dbd0]',
-            'user@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]',
-            'user@[IPv6:2001::7344]',
-            'user@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]',
             'test@exämple.com',
             'test@ä.xe',
             'test@subexample.wizard',
             'test@wähwähwäh.ümläüts.de',
-            '"tes@t"@wähwähwäh.ümläüts.de',
             'test@example.photography',
             'test@sub-domain.example.photography',
-            'niceändsimple@example.com',
-            'véry.çommon@example.com',
-            'a.lîttle.lengthy.but.fiñe@dept.example.com',
-            'dîsposable.style.émail.with+symbol@example.com',
-            'other.émail-with-dash@example.com',
-            '"verî.uñusual.@.uñusual.com"@example.com',
-            '"verî.(),:;<>[]\".VERÎ.\"verî@\ \"verî\".unüsual"@strange.example.com',
-            'üñîçøðé@example.com',
-            '"üñîçøðé"@example.com',
-            'ǅǼ੧ఘⅧ⒇৪@example.com',
-            'üser@[255.255.255.255]',
-            'üser@[IPv6:2001:db8:1ff::a0b:dbd0]',
-            'üser@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]',
-            'üser@[IPv6:2001::7344]',
-            'üser@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]',
-            'tést@exämple.com',
-            'tést@ä.xe',
-            'tést@subexample.wizard',
-            'tést@wähwähwäh.ümläüts.de',
-            '"tés@t"@wähwähwäh.ümläüts.de',
-            'tést@example.photography',
-            'tést@sub-domain.example.photography',
             'tricky@example.com',
             'more-tricky@example.com',
             'even-more-tricky@example.com',
+            'test..child@example.com',
         ];
 
         $actual = StringUtil::extractEmail($text, '<a><strong>');

--- a/core-bundle/tests/Contao/ValidatorTest.php
+++ b/core-bundle/tests/Contao/ValidatorTest.php
@@ -38,14 +38,12 @@ class ValidatorTest extends TestCase
         yield ['a.little.lengthy.but.fine@dept.example.com', true];
         yield ['disposable.style.email.with+symbol@example.com', true];
         yield ['other.email-with-dash@example.com', true];
-        yield ['!#$%&\'*+-/=?^_`{}|~@example.org', true];
-
-        // Quoted ASCII
         yield ['"very.unusual.@.unusual.com"@example.com', false];
         yield ['"very.(),:;<>[]\".VERY.\"very@\ \"very\".unusual"@strange.example.com', false];
+        yield ['!#$%&\'*+-/=?^_`{}|~@example.org', true];
         yield ['"()<>[]:,;@\"!#$%&\'*+-/=?^_`{}|~.a"@example.org', false];
 
-        // IP addresses square brackets
+        // Valid with IP addresses
         yield ['user@[255.255.255.255]', false];
         yield ['user@[IPv6:2001:db8:1ff::a0b:dbd0]', false];
         yield ['user@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]', false];
@@ -57,27 +55,25 @@ class ValidatorTest extends TestCase
         yield ['test@ä.xe', true];
         yield ['test@subexample.wizard', true];
         yield ['test@wähwähwäh.ümläüts.de', true];
-
-        // Quoted with IDNA domains
         yield ['"tes@t"@wähwähwäh.ümläüts.de', false];
 
         // Valid with new TLDs
         yield ['test@example.photography', true];
         yield ['test@sub-domain.example.photography', true];
 
-        // Unicode characters in the local part
+        // Valid with Unicode characters in the local part
         yield ['niceändsimple@example.com', true];
         yield ['véry.çommon@example.com', true];
         yield ['a.lîttle.lengthy.but.fiñe@dept.example.com', true];
         yield ['dîsposable.style.émail.with+symbol@example.com', true];
         yield ['other.émail-with-dash@example.com', true];
-        yield ['üñîçøðé@example.com', true];
-        yield ['ǅǼ੧ఘⅧ⒇৪@example.com', false];
         yield ['"verî.uñusual.@.uñusual.com"@example.com', false];
         yield ['"verî.(),:;<>[]\".VERÎ.\"verî@\ \"verî\".unüsual"@strange.example.com', false];
+        yield ['üñîçøðé@example.com', true];
         yield ['"üñîçøðé"@example.com', false];
+        yield ['ǅǼ੧ఘⅧ⒇৪@example.com', false];
 
-        // IP addresses square brackets and Unicode characters in the local part
+        // Valid with IP addresses and Unicode characters in the local part
         yield ['üser@[255.255.255.255]', false];
         yield ['üser@[IPv6:2001:db8:1ff::a0b:dbd0]', false];
         yield ['üser@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]', false];
@@ -91,7 +87,7 @@ class ValidatorTest extends TestCase
         yield ['tést@wähwähwäh.ümläüts.de', true];
         yield ['"tés@t"@wähwähwäh.ümläüts.de', false];
 
-        // New TLDs and Unicode characters in the local part
+        // Valid with new TLDs and Unicode characters in the local part
         yield ['tést@example.photography', true];
         yield ['tést@sub-domain.example.photography', true];
 

--- a/core-bundle/tests/Contao/ValidatorTest.php
+++ b/core-bundle/tests/Contao/ValidatorTest.php
@@ -71,7 +71,7 @@ class ValidatorTest extends TestCase
         yield ['"verî.(),:;<>[]\".VERÎ.\"verî@\ \"verî\".unüsual"@strange.example.com', false];
         yield ['üñîçøðé@example.com', true];
         yield ['"üñîçøðé"@example.com', false];
-        yield ['ǅǼ੧ఘⅧ⒇৪@example.com', false];
+        yield ['ǅǼ੧ఘⅧ⒇৪@example.com', true];
 
         // Valid with IP addresses and Unicode characters in the local part
         yield ['üser@[255.255.255.255]', false];
@@ -92,7 +92,7 @@ class ValidatorTest extends TestCase
         yield ['tést@sub-domain.example.photography', true];
 
         // Invalid ASCII
-        yield ['test..child@example.com', true];
+        yield ['test..child@example.com', false];
         yield ['test@sub.-example.com', false];
         yield ['test@_smtp_.example.com', false];
         yield ['test@sub..example.com', false];
@@ -128,7 +128,7 @@ class ValidatorTest extends TestCase
         yield [' test@sub-domain.example.photography', false];
 
         // Invalid with Unicode characters in the local part
-        yield ['tést..child@example.com', true];
+        yield ['tést..child@example.com', false];
         yield ['tést@sub.-example.com', false];
         yield ['tést@_smtp_.example.com', false];
         yield ['tést@sub..example.com', false];
@@ -192,6 +192,7 @@ class ValidatorTest extends TestCase
             'dîsposable.style.émail.with+symbol@example.com',
             'other.émail-with-dash@example.com',
             'üñîçøðé@example.com',
+            'ǅǼ੧ఘⅧ⒇৪@example.com',
             'tést@exämple.com',
             'tést@ä.xe',
             'tést@subexample.wizard',
@@ -201,7 +202,6 @@ class ValidatorTest extends TestCase
             'tricky@example.com',
             'more-tricky@example.com',
             'even-more-tricky@example.com',
-            'test..child@example.com',
         ];
 
         $actual = StringUtil::extractEmail($text, '<a><strong>');

--- a/core-bundle/tests/Contao/ValidatorTest.php
+++ b/core-bundle/tests/Contao/ValidatorTest.php
@@ -38,24 +38,13 @@ class ValidatorTest extends TestCase
         yield ['a.little.lengthy.but.fine@dept.example.com', true];
         yield ['disposable.style.email.with+symbol@example.com', true];
         yield ['other.email-with-dash@example.com', true];
-        yield ['"very.unusual.@.unusual.com"@example.com', false];
-        yield ['"very.(),:;<>[]\".VERY.\"very@\ \"very\".unusual"@strange.example.com', false];
         yield ['!#$%&\'*+-/=?^_`{}|~@example.org', true];
-        yield ['"()<>[]:,;@\"!#$%&\'*+-/=?^_`{}|~.a"@example.org', false];
-
-        // Valid with IP addresses
-        yield ['user@[255.255.255.255]', false];
-        yield ['user@[IPv6:2001:db8:1ff::a0b:dbd0]', false];
-        yield ['user@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]', false];
-        yield ['user@[IPv6:2001::7344]', false];
-        yield ['user@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]', false];
 
         // Valid with IDNA domains
         yield ['test@exämple.com', true];
         yield ['test@ä.xe', true];
         yield ['test@subexample.wizard', true];
         yield ['test@wähwähwäh.ümläüts.de', true];
-        yield ['"tes@t"@wähwähwäh.ümläüts.de', false];
 
         // Valid with new TLDs
         yield ['test@example.photography', true];
@@ -67,25 +56,14 @@ class ValidatorTest extends TestCase
         yield ['a.lîttle.lengthy.but.fiñe@dept.example.com', true];
         yield ['dîsposable.style.émail.with+symbol@example.com', true];
         yield ['other.émail-with-dash@example.com', true];
-        yield ['"verî.uñusual.@.uñusual.com"@example.com', false];
-        yield ['"verî.(),:;<>[]\".VERÎ.\"verî@\ \"verî\".unüsual"@strange.example.com', false];
         yield ['üñîçøðé@example.com', true];
-        yield ['"üñîçøðé"@example.com', false];
         yield ['ǅǼ੧ఘⅧ⒇৪@example.com', true];
 
-        // Valid with IP addresses and Unicode characters in the local part
-        yield ['üser@[255.255.255.255]', false];
-        yield ['üser@[IPv6:2001:db8:1ff::a0b:dbd0]', false];
-        yield ['üser@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]', false];
-        yield ['üser@[IPv6:2001::7344]', false];
-        yield ['üser@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]', false];
-
-        // IDNA domains and Unicode characters in the local part
+        // Valid with IDNA domains and Unicode characters in the local part
         yield ['tést@exämple.com', true];
         yield ['tést@ä.xe', true];
         yield ['tést@subexample.wizard', true];
         yield ['tést@wähwähwäh.ümläüts.de', true];
-        yield ['"tés@t"@wähwähwäh.ümläüts.de', false];
 
         // Valid with new TLDs and Unicode characters in the local part
         yield ['tést@example.photography', true];
@@ -110,18 +88,27 @@ class ValidatorTest extends TestCase
         yield ['test', false];
         yield ['@', false];
         yield ['test@', false];
+        yield ['"very.unusual.@.unusual.com"@example.com', false];
+        yield ['"very.(),:;<>[]\".VERY.\"very@\ \"very\".unusual"@strange.example.com', false];
+        yield ['"()<>[]:,;@\"!#$%&\'*+-/=?^_`{}|~.a"@example.org', false];
 
         // Invalid with IP addresses
+        yield ['test@[255.255.255.255]', false];
         yield ['test@a[255.255.255.255]', false];
         yield ['test@[255.255.255]', false];
         yield ['test@[255.255.255.255.255]', false];
         yield ['test@[255.255.255.256]', false];
         yield ['test@[2001::7344]', false];
+        yield ['test@[IPv6:2001:db8:1ff::a0b:dbd0]', false];
+        yield ['test@[IPv6:2001:0db8:85a3:08d3:1319:8a2e:0370:7344]', false];
+        yield ['test@[IPv6:2001::7344]', false];
+        yield ['test@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]', false];
         yield ['test@[IPv6:1111:2222:3333:4444:5555:6666:7777:255.255.255.255]', false];
 
         // Invalid with IDNA domain
         yield ['tes@t@wähwähwäh.ümläüts.de', false];
         yield [' test@wähwähwäh.ümläüts.de', false];
+        yield ['"tes@t"@wähwähwäh.ümläüts.de', false];
 
         // Invalid with new TLDs
         yield ['tes@t@example.photography', false];
@@ -143,6 +130,9 @@ class ValidatorTest extends TestCase
         yield ['tést@[1.2.3.4', false];
         yield ['tést@iana.org-', false];
         yield ['tést@', false];
+        yield ['"verî.uñusual.@.uñusual.com"@example.com', false];
+        yield ['"verî.(),:;<>[]\".VERÎ.\"verî@\ \"verî\".unüsual"@strange.example.com', false];
+        yield ['"üñîçøðé"@example.com', false];
 
         // Invalid with IP addresses and Unicode characters in the local part
         yield ['tést@a[255.255.255.255]', false];
@@ -155,6 +145,7 @@ class ValidatorTest extends TestCase
         // Invalid with IDNA domains and Unicode characters in the local part
         yield ['tés@t@wähwähwäh.ümläüts.de', false];
         yield [' tést@wähwähwäh.ümläüts.de', false];
+        yield ['"tés@t"@wähwähwäh.ümläüts.de', false];
 
         // Invalid with new TLDs and Unicode characters in the local part
         yield ['tés@t@example.photography', false];

--- a/core-bundle/tests/Contao/ValidatorTest.php
+++ b/core-bundle/tests/Contao/ValidatorTest.php
@@ -66,16 +66,16 @@ class ValidatorTest extends TestCase
         yield ['test@sub-domain.example.photography', true];
 
         // Unicode characters in the local part
-        yield ['niceändsimple@example.com', false];
-        yield ['véry.çommon@example.com', false];
-        yield ['a.lîttle.lengthy.but.fiñe@dept.example.com', false];
-        yield ['dîsposable.style.émail.with+symbol@example.com', false];
-        yield ['other.émail-with-dash@example.com', false];
+        yield ['niceändsimple@example.com', true];
+        yield ['véry.çommon@example.com', true];
+        yield ['a.lîttle.lengthy.but.fiñe@dept.example.com', true];
+        yield ['dîsposable.style.émail.with+symbol@example.com', true];
+        yield ['other.émail-with-dash@example.com', true];
+        yield ['üñîçøðé@example.com', true];
+        yield ['ǅǼ੧ఘⅧ⒇৪@example.com', false];
         yield ['"verî.uñusual.@.uñusual.com"@example.com', false];
         yield ['"verî.(),:;<>[]\".VERÎ.\"verî@\ \"verî\".unüsual"@strange.example.com', false];
-        yield ['üñîçøðé@example.com', false];
         yield ['"üñîçøðé"@example.com', false];
-        yield ['ǅǼ੧ఘⅧ⒇৪@example.com', false];
 
         // IP addresses square brackets and Unicode characters in the local part
         yield ['üser@[255.255.255.255]', false];
@@ -85,15 +85,15 @@ class ValidatorTest extends TestCase
         yield ['üser@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]', false];
 
         // IDNA domains and Unicode characters in the local part
-        yield ['tést@exämple.com', false];
-        yield ['tést@ä.xe', false];
-        yield ['tést@subexample.wizard', false];
-        yield ['tést@wähwähwäh.ümläüts.de', false];
+        yield ['tést@exämple.com', true];
+        yield ['tést@ä.xe', true];
+        yield ['tést@subexample.wizard', true];
+        yield ['tést@wähwähwäh.ümläüts.de', true];
         yield ['"tés@t"@wähwähwäh.ümläüts.de', false];
 
         // New TLDs and Unicode characters in the local part
-        yield ['tést@example.photography', false];
-        yield ['tést@sub-domain.example.photography', false];
+        yield ['tést@example.photography', true];
+        yield ['tést@sub-domain.example.photography', true];
 
         // Invalid ASCII
         yield ['test..child@example.com', true];
@@ -132,7 +132,7 @@ class ValidatorTest extends TestCase
         yield [' test@sub-domain.example.photography', false];
 
         // Invalid with Unicode characters in the local part
-        yield ['tést..child@example.com', false];
+        yield ['tést..child@example.com', true];
         yield ['tést@sub.-example.com', false];
         yield ['tést@_smtp_.example.com', false];
         yield ['tést@sub..example.com', false];
@@ -190,6 +190,18 @@ class ValidatorTest extends TestCase
             'test@wähwähwäh.ümläüts.de',
             'test@example.photography',
             'test@sub-domain.example.photography',
+            'niceändsimple@example.com',
+            'véry.çommon@example.com',
+            'a.lîttle.lengthy.but.fiñe@dept.example.com',
+            'dîsposable.style.émail.with+symbol@example.com',
+            'other.émail-with-dash@example.com',
+            'üñîçøðé@example.com',
+            'tést@exämple.com',
+            'tést@ä.xe',
+            'tést@subexample.wizard',
+            'tést@wähwähwäh.ümläüts.de',
+            'tést@example.photography',
+            'tést@sub-domain.example.photography',
             'tricky@example.com',
             'more-tricky@example.com',
             'even-more-tricky@example.com',


### PR DESCRIPTION
This would make us use the same validation as all the browsers use, except for the fact that we do not allow dotless domains.