### PR TITLE
Fix the picker reload for row wizard fields and in edit multiple mode

### DIFF
--- a/core-bundle/contao/classes/Ajax.php
+++ b/core-bundle/contao/classes/Ajax.php
@@ -183,7 +183,7 @@ class Ajax extends Backend
 				$parts = null;
 
 				// Row wizard check
-				if (preg_match_all('/[a-zA-Z][a-zA-Z0-9]*/', $strField, $matches))
+				if (preg_match_all('/[^\[\]]+/', $strField, $matches))
 				{
 					$parts = $matches[0] ?? null;
 					$field = $parts[0] ?? null;

--- a/core-bundle/contao/classes/Ajax.php
+++ b/core-bundle/contao/classes/Ajax.php
@@ -188,10 +188,16 @@ class Ajax extends Backend
 					$parts = $matches[0] ?? null;
 					$field = $parts[0] ?? null;
 
+					// Handle the field in "edit multiple" mode
+					if (Input::get('act') == 'editAll')
+					{
+						$field = preg_replace('/(.*)_[0-9a-zA-Z]+$/', '$1', $field);
+					}
+
 					if (($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['inputType'] ?? null) === 'rowWizard')
 					{
 						$boolRowWizard = true;
-						$strField = $field;
+						$strField = $parts[0];
 					}
 				}
 


### PR DESCRIPTION
### Description

- fixes #10110

The row wizard check within the Ajax class only tokenized field names that were alphanumeric. Am widening this in this PR to split on the square brackets instead f11bbdce88c658a74364ad62daaac875a7d4dd9c

I additionally fixed another issue with a missing case and the pickers not working in edit multiple mode. Literally the next case after the row wizard check 🙈 f28be3dcffa7ab319920fc40b8e4c248bca233e3
