### PR TITLE
Move the `backendWidth` field into the back end settings

### DIFF
--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -86,12 +86,12 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 	'palettes' => array
 	(
 		'__selector__'                => array('inherit', 'admin'),
-		'login'                       => '{name_legend},name,email;{backend_legend},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{session_legend},session;{password_legend},password',
-		'admin'                       => '{name_legend},username,name,email;{backend_legend:hide},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{account_legend},disable,start,stop',
-		'default'                     => '{name_legend},username,name,email;{backend_legend:hide},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{account_legend},disable,start,stop',
-		'group'                       => '{name_legend},username,name,email;{backend_legend:hide},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{account_legend},disable,start,stop',
-		'extend'                      => '{name_legend},username,name,email;{backend_legend:hide},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{modules_legend},modules,themes,frontendModules;{elements_legend},elements,fields;{pagemounts_legend},pagemounts,alpty;{filemounts_legend},filemounts,fop;{imageSizes_legend},imageSizes;{forms_legend},forms;{amg_legend},amg;{cud_legend},cud;{account_legend},disable,start,stop',
-		'custom'                      => '{name_legend},username,name,email;{backend_legend:hide},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{modules_legend},modules,themes,frontendModules;{elements_legend},elements,fields;{pagemounts_legend},pagemounts,alpty;{filemounts_legend},filemounts,fop;{imageSizes_legend},imageSizes;{forms_legend},forms;{amg_legend},amg;{cud_legend},cud;{account_legend},disable,start,stop'
+		'login'                       => '{name_legend},name,email;{backend_legend},language,uploader,backendWidth,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{session_legend},session;{password_legend},password',
+		'admin'                       => '{name_legend},username,name,email;{backend_legend:hide},language,uploader,backendWidth,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{account_legend},disable,start,stop',
+		'default'                     => '{name_legend},username,name,email;{backend_legend:hide},language,uploader,backendWidth,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{account_legend},disable,start,stop',
+		'group'                       => '{name_legend},username,name,email;{backend_legend:hide},language,uploader,backendWidth,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{account_legend},disable,start,stop',
+		'extend'                      => '{name_legend},username,name,email;{backend_legend:hide},language,uploader,backendWidth,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{modules_legend},modules,themes,frontendModules;{elements_legend},elements,fields;{pagemounts_legend},pagemounts,alpty;{filemounts_legend},filemounts,fop;{imageSizes_legend},imageSizes;{forms_legend},forms;{amg_legend},amg;{cud_legend},cud;{account_legend},disable,start,stop',
+		'custom'                      => '{name_legend},username,name,email;{backend_legend:hide},language,uploader,backendWidth,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{modules_legend},modules,themes,frontendModules;{elements_legend},elements,fields;{pagemounts_legend},pagemounts,alpty;{filemounts_legend},filemounts,fop;{imageSizes_legend},imageSizes;{forms_legend},forms;{amg_legend},amg;{cud_legend},cud;{account_legend},disable,start,stop'
 	),
 
 	// Fields
@@ -151,13 +151,13 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 			'inputType'               => 'select',
 			'options'                 => array('DropZone', 'FileUpload'),
 			'reference'               => &$GLOBALS['TL_LANG']['tl_user'],
-			'eval'                    => array('tl_class'=>'w50'),
+			'eval'                    => array('tl_class'=>'w50 clr'),
 			'sql'                     => array('type'=>'string', 'length'=>32, 'default'=>'')
 		),
 		'showHelp' => array
 		(
 			'inputType'               => 'checkbox',
-			'eval'                    => array('tl_class'=>'w50 clr'),
+			'eval'                    => array('tl_class'=>'w50'),
 			'sql'                     => array('type'=>'boolean', 'default'=>true)
 		),
 		'thumbnails' => array

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -86,12 +86,12 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 	'palettes' => array
 	(
 		'__selector__'                => array('inherit', 'admin'),
-		'login'                       => '{name_legend},name,email;{backend_legend},language,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{session_legend},session;{password_legend},password;{theme_legend:hide},backendTheme,backendWidth',
-		'admin'                       => '{name_legend},username,name,email;{backend_legend:hide},language,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{theme_legend:hide},backendTheme,backendWidth;{password_legend:hide},password,pwChange;{admin_legend},admin;{account_legend},disable,start,stop',
-		'default'                     => '{name_legend},username,name,email;{backend_legend:hide},language,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{theme_legend:hide},backendTheme,backendWidth;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{account_legend},disable,start,stop',
-		'group'                       => '{name_legend},username,name,email;{backend_legend:hide},language,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{theme_legend:hide},backendTheme,backendWidth;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{account_legend},disable,start,stop',
-		'extend'                      => '{name_legend},username,name,email;{backend_legend:hide},language,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{theme_legend:hide},backendTheme,backendWidth;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{modules_legend},modules,themes,frontendModules;{elements_legend},elements,fields;{pagemounts_legend},pagemounts,alpty;{filemounts_legend},filemounts,fop;{imageSizes_legend},imageSizes;{forms_legend},forms;{amg_legend},amg;{cud_legend},cud;{account_legend},disable,start,stop',
-		'custom'                      => '{name_legend},username,name,email;{backend_legend:hide},language,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{theme_legend:hide},backendTheme,backendWidth;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{modules_legend},modules,themes,frontendModules;{elements_legend},elements,fields;{pagemounts_legend},pagemounts,alpty;{filemounts_legend},filemounts,fop;{imageSizes_legend},imageSizes;{forms_legend},forms;{amg_legend},amg;{cud_legend},cud;{account_legend},disable,start,stop'
+		'login'                       => '{name_legend},name,email;{backend_legend},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{session_legend},session;{password_legend},password',
+		'admin'                       => '{name_legend},username,name,email;{backend_legend:hide},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{account_legend},disable,start,stop',
+		'default'                     => '{name_legend},username,name,email;{backend_legend:hide},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{account_legend},disable,start,stop',
+		'group'                       => '{name_legend},username,name,email;{backend_legend:hide},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{account_legend},disable,start,stop',
+		'extend'                      => '{name_legend},username,name,email;{backend_legend:hide},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{modules_legend},modules,themes,frontendModules;{elements_legend},elements,fields;{pagemounts_legend},pagemounts,alpty;{filemounts_legend},filemounts,fop;{imageSizes_legend},imageSizes;{forms_legend},forms;{amg_legend},amg;{cud_legend},cud;{account_legend},disable,start,stop',
+		'custom'                      => '{name_legend},username,name,email;{backend_legend:hide},language,backendWidth,uploader,showHelp,thumbnails,useRTE,useCE,doNotCollapse,doNotHideMessages;{password_legend:hide},password,pwChange;{admin_legend},admin;{groups_legend},groups,inherit;{modules_legend},modules,themes,frontendModules;{elements_legend},elements,fields;{pagemounts_legend},pagemounts,alpty;{filemounts_legend},filemounts,fop;{imageSizes_legend},imageSizes;{forms_legend},forms;{amg_legend},amg;{cud_legend},cud;{account_legend},disable,start,stop'
 	),
 
 	// Fields
@@ -157,7 +157,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		'showHelp' => array
 		(
 			'inputType'               => 'checkbox',
-			'eval'                    => array('tl_class'=>'w50'),
+			'eval'                    => array('tl_class'=>'w50 clr'),
 			'sql'                     => array('type'=>'boolean', 'default'=>true)
 		),
 		'thumbnails' => array

--- a/core-bundle/contao/languages/en/tl_user.xlf
+++ b/core-bundle/contao/languages/en/tl_user.xlf
@@ -26,12 +26,6 @@
       <trans-unit id="tl_user.language.1">
         <source>Here you can choose the back end language.</source>
       </trans-unit>
-      <trans-unit id="tl_user.backendTheme.0">
-        <source>Back end theme</source>
-      </trans-unit>
-      <trans-unit id="tl_user.backendTheme.1">
-        <source>Here you can override the global back end theme.</source>
-      </trans-unit>
       <trans-unit id="tl_user.backendWidth.0">
         <source>Maximum width</source>
       </trans-unit>
@@ -244,9 +238,6 @@
       </trans-unit>
       <trans-unit id="tl_user.backend_legend">
         <source>Back end settings</source>
-      </trans-unit>
-      <trans-unit id="tl_user.theme_legend">
-        <source>Back end theme</source>
       </trans-unit>
       <trans-unit id="tl_user.password_legend">
         <source>Password settings</source>


### PR DESCRIPTION
### Description

- fixes #10130 

Moves the `backendWidth` into the back end settings. I decided against the [alternative](https://github.com/contao/contao/issues/10130#issuecomment-5326220735) to keep it simple + `backendWidth` has already been sorted between those two fields in the DCA 😁.

<img width="2118" height="790" alt="grafik" src="https://github.com/user-attachments/assets/85f988e1-c0de-4ccc-99b9-995fdbb4a36d" />

This PR also removes the still existing `backendTheme` field within the `tl_user` palettes, the translation and now also the legend.
