### PR TITLE
Fix a potential Twig error in the backend undo module

### DIFF
--- a/core-bundle/contao/templates/twig/backend/undo/label.html.twig
+++ b/core-bundle/contao/templates/twig/backend/undo/label.html.twig
@@ -22,12 +22,12 @@
     <div class="tl_undo_preview cte_preview">
         <div inert>
             {% if preview is not iterable %}
-                {{ preview|sanitize_html('contao') }}
+                {{ preview|default|sanitize_html('contao') }}
             {% else %}
                 <table>
                     <tr>
                         {% for value in preview %}
-                            <td>{{ value|sanitize_html('contao') }}</td>
+                            <td>{{ value|default|sanitize_html('contao') }}</td>
                         {% endfor %}
                     </tr>
                 </table>


### PR DESCRIPTION
Prevent a potential Twig error in the backend undo module when the `preview` variable is `null`, or it is iterable but contains a `null` value.

```
An exception has been thrown during the rendering of a template ("Contao\CoreBundle\Twig\Runtime\SanitizerRuntime::sanitizeHtml():
Argument #1 ($html) must be of type string, null given, called in /home/www/var/cache/prod/twig/e8/e8aa5db075a566da4e3d32c0f69ee08a.php on line 121") in "@Contao/backend/undo/label.html.twig" at line 30.
```