### PR TITLE
Fix a copy and paste error in `moo_tablesort.html.twig`

### DIFF
--- a/core-bundle/contao/templates/twig/moo_tablesort.html.twig
+++ b/core-bundle/contao/templates/twig/moo_tablesort.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'contao_default' %}
 {% use '@Contao/component/_stylesheet.html.twig' %}
 
-{% add 'moo_mediabox' to stylesheets %}
+{% add 'moo_tablesort' to stylesheets %}
     {% with {file: 'assets/tablesort/css/tablesort.min.css'} %}{{ block('stylesheet_component') }}{% endwith %}
 {% endadd %}
 


### PR DESCRIPTION
Backports a small fix from #10116