### PR TITLE
Process JSON-LD data for figures

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -441,6 +441,7 @@ services:
               contao.framework: '@contao.framework'
               contao.filesystem.virtual.files: '@contao.filesystem.virtual.files'
               event_dispatcher: '@event_dispatcher'
+              contao.string.html_decoder: '@contao.string.html_decoder'
             - '%kernel.project_dir%'
             - '%contao.upload_path%'
             - '%contao.web_dir%'

--- a/core-bundle/src/Image/Studio/Figure.php
+++ b/core-bundle/src/Image/Studio/Figure.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Image\Studio;
 
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\String\HtmlAttributes;
+use Contao\CoreBundle\String\HtmlDecoder;
 use Contao\File;
 use Contao\StringUtil;
 use Contao\Template;
@@ -44,6 +45,7 @@ final class Figure
         private \Closure|array|null $linkAttributes = null,
         private \Closure|LightboxResult|null $lightbox = null,
         private \Closure|array|null $options = null,
+        private readonly HtmlDecoder|null $htmlDecoder = null,
     ) {
     }
 
@@ -106,17 +108,27 @@ final class Figure
 
         $jsonLd = [
             '@type' => 'ImageObject',
-            'identifier' => $imageIdentifier,
             'contentUrl' => $this->getImage()->getImageSrc(),
+            'identifier' => $imageIdentifier,
         ];
 
         if (!$this->hasMetadata()) {
-            ksort($jsonLd);
-
             return $jsonLd;
         }
 
-        $jsonLd = [...$this->getMetadata()->getSchemaOrgData('ImageObject'), ...$jsonLd];
+        $imageJsonLd = $this->getMetadata()->getSchemaOrgData('ImageObject');
+
+        // Process the JSON-LD data (#10081)
+        if ($this->htmlDecoder) {
+            foreach ($imageJsonLd as $key => $value) {
+                $imageJsonLd[$key] = match ($key) {
+                    'caption' => $this->htmlDecoder->htmlToPlainText($value),
+                    default => $this->htmlDecoder->inputEncodedToPlainText($value),
+                };
+            }
+        }
+
+        $jsonLd = [...$imageJsonLd, ...$jsonLd];
         ksort($jsonLd);
 
         return $jsonLd;

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -675,6 +675,7 @@ class FigureBuilder
                 $settings,
             ),
             $settings->options,
+            $this->locator->get('contao.string.html_decoder'),
         );
     }
 

--- a/core-bundle/tests/Image/Studio/FigureTest.php
+++ b/core-bundle/tests/Image/Studio/FigureTest.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Image\ImageFactory;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\ImageResult;
 use Contao\CoreBundle\Image\Studio\LightboxResult;
+use Contao\CoreBundle\String\HtmlDecoder;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\File;
 use Contao\Files;
@@ -651,6 +652,45 @@ class FigureTest extends TestCase
                 'caption' => 'caption',
                 'contentUrl' => 'https://assets.url/files/public/foo.jpg',
                 'identifier' => '#/schema/image/uuid',
+            ],
+            $figure->getSchemaOrgData(),
+        );
+    }
+
+    public function testTransformsSchemaOrgData(): void
+    {
+        $htmlDecoder = $this->createMock(HtmlDecoder::class);
+        $htmlDecoder
+            ->expects($this->once())
+            ->method('htmlToPlainText')
+            ->with('caption')
+            ->willReturn('plain-text-caption')
+        ;
+
+        $htmlDecoder
+            ->expects($this->once())
+            ->method('inputEncodedToPlainText')
+            ->with('title')
+            ->willReturn('plain-text-title')
+        ;
+
+        $figure = new Figure(
+            $this->mockImage(),
+            new Metadata([
+                Metadata::VALUE_ALT => 'alt',
+                Metadata::VALUE_TITLE => 'title',
+                Metadata::VALUE_CAPTION => 'caption',
+            ]),
+            htmlDecoder: $htmlDecoder,
+        );
+
+        $this->assertSame(
+            [
+                '@type' => 'ImageObject',
+                'caption' => 'plain-text-caption',
+                'contentUrl' => 'https://assets.url/files/public/foo.jpg',
+                'identifier' => 'https://assets.url/files/public/foo.jpg',
+                'name' => 'plain-text-title',
             ],
             $figure->getSchemaOrgData(),
         );


### PR DESCRIPTION
Fixes #10081

This applies the `HtmlDecoder` to the schema.org data created by a `Figure`, just like we do in other places. So instead of (in Contao 5.7 with an `fe_page.html.twig`)

```json
"caption": "Foo {{br}}bar <strong>bas<\/strong>",
"name": "Foo {{br}}bar <strong>bas<\/strong>"
```

it will be

```json
"caption": "Foo\nbar bas",
"name": "Foo bar bas"
```