### PR TITLE
Fix double encoded values in the calendar and news bundle

### DIFF
--- a/calendar-bundle/contao/languages/en/default.xlf
+++ b/calendar-bundle/contao/languages/en/default.xlf
@@ -6,10 +6,10 @@
         <source>%d event(s)</source>
       </trans-unit>
       <trans-unit id="MSC.cal_previous">
-        <source>&amp;lt;</source>
+        <source>&lt;</source>
       </trans-unit>
       <trans-unit id="MSC.cal_next">
-        <source>&amp;gt;</source>
+        <source>&gt;</source>
       </trans-unit>
       <trans-unit id="MSC.cal_timeSeparator">
         <source>–</source>

--- a/calendar-bundle/contao/modules/ModuleCalendar.php
+++ b/calendar-bundle/contao/modules/ModuleCalendar.php
@@ -285,7 +285,7 @@ class ModuleCalendar extends Events
 			// Empty cell
 			if ($intDay < 1 || $intDay > $intDaysInMonth)
 			{
-				$arrDays[$intWeek][$i]['label'] = '&nbsp;';
+				$arrDays[$intWeek][$i]['label'] = "\u{00A0}";
 				$arrDays[$intWeek][$i]['class'] = 'empty' . $strClass;
 				$arrDays[$intWeek][$i]['events'] = array();
 

--- a/news-bundle/contao/languages/en/default.xlf
+++ b/news-bundle/contao/languages/en/default.xlf
@@ -21,10 +21,10 @@
         <source>%d item(s)</source>
       </trans-unit>
       <trans-unit id="MSC.news_previous">
-        <source>&amp;lt;</source>
+        <source>&lt;</source>
       </trans-unit>
       <trans-unit id="MSC.news_next">
-        <source>&amp;gt;</source>
+        <source>&gt;</source>
       </trans-unit>
       <trans-unit id="MSC.newsPicker">
         <source>News</source>


### PR DESCRIPTION
### Description

- Fixes calendar-bundle and news-bundle double encoding within 6.0.x-dev

There are still double encoded string within the calendar bundle (and news bundle)

<img width="1116" height="1061" alt="Bildschirmfoto 2026-08-22 um 15 58 43" src="https://github.com/user-attachments/assets/4c8a1965-6a79-4d75-805f-81ae0ac45560" />

- `lt` and `gt` 035ba377d6bbdab4913a365ff7d7570ae77242af
- The nbsp won't work like this so I am passing it as a unicode character so Twig can handle it: 071d09b56becd12cc3abdecd702fbc9f07352dce (might just handle that in twig only)

I've also adjusted `MSC.news_previous` and `MSC.news_next` for the sake of it but really don't know where they are used within the code. Might be dead translations 🤔  4e19c4530e4c754683a935f9ee0f3c6e16cf8c4c