### PR TITLE
Remove usage of the obsolete `$strTagEnding`

### DIFF
--- a/core-bundle/contao/library/Contao/Widget.php
+++ b/core-bundle/contao/library/Contao/Widget.php
@@ -526,7 +526,7 @@ abstract class Widget extends Controller
 	{
 		if ($strSeparator === null)
 		{
-			$strSeparator = '<br' . $this->strTagEnding . "\n";
+			$strSeparator = "<br>\n";
 		}
 
 		return $this->hasErrors() ? implode($strSeparator, $this->arrErrors) : '';


### PR DESCRIPTION
`TemplateInheritance::$strTagEnding` got removed in #9484