### PR TITLE
Support `allowHtml` on only the `caption` field in the meta wizard

### DIFF
--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -274,14 +274,13 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 			'inputType'               => 'metaWizard',
 			'eval'                    => array
 			(
-				'allowHtml'           => true,
 				'multiple'            => true,
 				'metaFields'          => array
 				(
 					'title'           => 'maxlength="255"',
 					'alt'             => 'maxlength="255"',
 					'link'            => array('attributes'=>'maxlength="2048"', 'dcaPicker'=>true),
-					'caption'         => array('type'=>'textarea', 'basicEntities'=>true),
+					'caption'         => array('type'=>'textarea', 'basicEntities'=>true, 'allowHtml' => true),
 					'license'         => array(
 						'attributes'  => 'maxlength="255"',
 						'dcaPicker'   => true,

--- a/core-bundle/contao/widgets/MetaWizard.php
+++ b/core-bundle/contao/widgets/MetaWizard.php
@@ -110,7 +110,7 @@ class MetaWizard extends Widget
 
 					if ($this->metaFields[$kk]['basicEntities'] ?? false)
 					{
-						$v[$kk] = StringUtil::restoreBasicEntities($vv, $this->metaFields[$kk]['allowHtml'] ?? false);
+						$v[$kk] = StringUtil::restoreBasicEntities($vv, $this->metaFields[$kk]['allowHtml'] ?? $this->allowHtml);
 					}
 				}
 
@@ -190,7 +190,7 @@ class MetaWizard extends Widget
 
 				if (($meta[$field] ?? null) && ($fieldConfig['basicEntities'] ?? false))
 				{
-					$meta[$field] = StringUtil::convertBasicEntities($meta[$field], $fieldConfig['allowHtml'] ?? false);
+					$meta[$field] = StringUtil::convertBasicEntities($meta[$field], $fieldConfig['allowHtml'] ?? $this->allowHtml);
 				}
 
 				if (isset($fieldConfig['type']) && 'textarea' === $fieldConfig['type'])

--- a/core-bundle/contao/widgets/MetaWizard.php
+++ b/core-bundle/contao/widgets/MetaWizard.php
@@ -71,7 +71,7 @@ class MetaWizard extends Widget
 	{
 		if ('allowHtml' === $strKey)
 		{
-			// Set allowHtml if any field has it to make sure postHtml is called for fields
+			// Return true if any field is set to allowHtml to make sure postHtml is called
 			return parent::__get($strKey) || array_any($this->metaFields, static fn ($field) => $field['allowHtml'] ?? false);
 		}
 

--- a/core-bundle/contao/widgets/MetaWizard.php
+++ b/core-bundle/contao/widgets/MetaWizard.php
@@ -71,7 +71,7 @@ class MetaWizard extends Widget
 	{
 		if ('allowHtml' === $strKey)
 		{
-			// Set allowHtml if any field has it to make sure getPost is called
+			// Set allowHtml if any field has it to make sure postHtml is called for fields
 			return parent::__get($strKey) || array_any($this->metaFields, static fn ($field) => $field['allowHtml'] ?? false);
 		}
 
@@ -253,27 +253,21 @@ class MetaWizard extends Widget
 	{
 		$varValue = parent::getPost($strKey);
 
-		if (\is_callable($this->inputCallback) || !\is_array($varValue))
+		$arrHtmlFields = array_filter($this->metaFields, static fn ($c) => $c['allowHtml'] ?? false);
+
+		if (!$arrHtmlFields || $this->allowHtml || !\is_array($varValue) || \is_callable($this->inputCallback))
 		{
 			return $varValue;
 		}
 
-		$allowHtmlFields = array_filter($this->metaFields, static fn ($field) => $field['allowHtml'] ?? false);
-
-		if (array() === $allowHtmlFields)
-		{
-			return $varValue;
-		}
-
-		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
-
-		$raw = $request->request->all()[$strKey] ?? array();
-
-		foreach ($varValue as $language => $meta)
+		foreach ($varValue as $lang => $meta)
 		{
 			if (\is_array($meta))
 			{
-				$varValue[$language] = array_replace($meta, array_diff_key($raw[$language] ?? array(), $allowHtmlFields));
+				foreach (array_intersect_key($meta, $arrHtmlFields) as $field => $v)
+				{
+					$varValue[$lang][$field] = Input::encodeInputRecursive($v, InputEncodingMode::sanitizeHtml, false);
+				}
 			}
 		}
 

--- a/core-bundle/contao/widgets/MetaWizard.php
+++ b/core-bundle/contao/widgets/MetaWizard.php
@@ -67,6 +67,17 @@ class MetaWizard extends Widget
 		}
 	}
 
+	public function __get($strKey)
+	{
+		if ('allowHtml' === $strKey)
+		{
+			// Set allowHtml if any field has it to make sure getPost is called
+			return parent::__get($strKey) || array_any($this->metaFields, static fn ($field) => $field['allowHtml'] ?? false);
+		}
+
+		return parent::__get($strKey);
+	}
+
 	/**
 	 * Trim the values and add new languages if necessary
 	 *
@@ -236,5 +247,36 @@ class MetaWizard extends Widget
 		});
 
 		return '<ul id="ctrl_' . $this->strId . '" class="tl_metawizard dcapicker">' . implode('', $items) . '</ul>';
+	}
+
+	protected function getPost($strKey): mixed
+	{
+		$varValue = parent::getPost($strKey);
+
+		if (\is_callable($this->inputCallback) || !\is_array($varValue))
+		{
+			return $varValue;
+		}
+
+		$allowHtmlFields = array_filter($this->metaFields, static fn ($field) => $field['allowHtml'] ?? false);
+
+		if (array() === $allowHtmlFields)
+		{
+			return $varValue;
+		}
+
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+
+		$raw = $request->request->all()[$strKey] ?? array();
+
+		foreach ($varValue as $language => $meta)
+		{
+			if (\is_array($meta))
+			{
+				$varValue[$language] = array_replace($meta, array_diff_key($raw[$language] ?? array(), $allowHtmlFields));
+			}
+		}
+
+		return $varValue;
 	}
 }

--- a/core-bundle/contao/widgets/MetaWizard.php
+++ b/core-bundle/contao/widgets/MetaWizard.php
@@ -67,17 +67,6 @@ class MetaWizard extends Widget
 		}
 	}
 
-	public function __get($strKey)
-	{
-		if ('allowHtml' === $strKey)
-		{
-			// Return true if any field is set to allowHtml to make sure postHtml is called
-			return parent::__get($strKey) || array_any($this->metaFields, static fn ($field) => $field['allowHtml'] ?? false);
-		}
-
-		return parent::__get($strKey);
-	}
-
 	/**
 	 * Trim the values and add new languages if necessary
 	 *
@@ -121,7 +110,7 @@ class MetaWizard extends Widget
 
 					if ($this->metaFields[$kk]['basicEntities'] ?? false)
 					{
-						$v[$kk] = StringUtil::restoreBasicEntities($vv, $this->allowHtml);
+						$v[$kk] = StringUtil::restoreBasicEntities($vv, $this->metaFields[$kk]['allowHtml'] ?? false);
 					}
 				}
 
@@ -201,7 +190,7 @@ class MetaWizard extends Widget
 
 				if (($meta[$field] ?? null) && ($fieldConfig['basicEntities'] ?? false))
 				{
-					$meta[$field] = StringUtil::convertBasicEntities($meta[$field], $this->allowHtml);
+					$meta[$field] = StringUtil::convertBasicEntities($meta[$field], $fieldConfig['allowHtml'] ?? false);
 				}
 
 				if (isset($fieldConfig['type']) && 'textarea' === $fieldConfig['type'])


### PR DESCRIPTION
### Description

- fixes #10142

This PR adds per field `allowHtml` to the MetaWizard widget to fix #10142

Basically:
`Widget::getPost()` encodes everything via `Input::postHtml`, we get the raw data in our `getPost` and save that for any field that does not have `allowHtml`.