### PR TITLE
Remove redundant entity decoding

### DIFF
--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -1408,7 +1408,7 @@ abstract class DataContainer extends Backend
 	protected function markAsCopy(string $label, string $value): string
 	{
 		// Do not mark as copy more than once (see #6058)
-		if (preg_match('/' . preg_quote(\sprintf($label, ''), '/') . '/', StringUtil::decodeEntities($value)))
+		if (preg_match('/' . preg_quote(\sprintf($label, ''), '/') . '/', $value))
 		{
 			return $value;
 		}

--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -553,11 +553,11 @@ class Form extends Hybrid
 			// Attach CSV file
 			if ($this->format == 'csv')
 			{
-				$email->attachFileFromString(StringUtil::decodeEntities('"' . implode('";"', $keys) . '"' . "\n" . '"' . implode('";"', $values) . '"'), 'form.csv', 'text/comma-separated-values');
+				$email->attachFileFromString('"' . implode('";"', $keys) . '"' . "\n" . '"' . implode('";"', $values) . '"', 'form.csv', 'text/comma-separated-values');
 			}
 			elseif ($this->format == 'csv_excel')
 			{
-				$email->attachFileFromString(mb_convert_encoding("\u{FEFF}sep=;\n" . StringUtil::decodeEntities('"' . implode('";"', $keys) . '"' . "\n" . '"' . implode('";"', $values) . '"'), 'UTF-16LE', 'UTF-8'), 'form.csv', 'text/comma-separated-values');
+				$email->attachFileFromString(mb_convert_encoding("\u{FEFF}sep=;\n" . '"' . implode('";"', $keys) . '"' . "\n" . '"' . implode('";"', $values) . '"', 'UTF-16LE', 'UTF-8'), 'form.csv', 'text/comma-separated-values');
 			}
 
 			$uploaded = '';
@@ -587,7 +587,7 @@ class Form extends Hybrid
 			}
 
 			$uploaded = trim($uploaded) ? "\n\n---\n" . $uploaded : '';
-			$email->text = StringUtil::decodeEntities(trim($message)) . $uploaded . "\n\n";
+			$email->text = trim($message) . $uploaded . "\n\n";
 
 			// Set the transport
 			if (!empty($this->mailerTransport))

--- a/core-bundle/contao/library/Contao/Email.php
+++ b/core-bundle/contao/library/Contao/Email.php
@@ -146,7 +146,7 @@ class Email
 				break;
 
 			case 'text':
-				$this->strText = StringUtil::decodeEntities($varValue);
+				$this->strText = $varValue;
 				break;
 
 			case 'html':

--- a/core-bundle/contao/library/Contao/Search.php
+++ b/core-bundle/contao/library/Contao/Search.php
@@ -471,9 +471,6 @@ class Search
 	 */
 	public static function query(string $strKeywords, bool $blnOrSearch=false, array $arrPid=array(), bool $blnFuzzy=false, int $intMinlength=0): SearchResult
 	{
-		// Clean the keywords
-		$strKeywords = StringUtil::decodeEntities($strKeywords);
-
 		// Check keyword string
 		if (!\strlen($strKeywords))
 		{

--- a/core-bundle/contao/library/Contao/StringUtil.php
+++ b/core-bundle/contao/library/Contao/StringUtil.php
@@ -311,7 +311,6 @@ class StringUtil
 	 */
 	public static function generateAlias($strString)
 	{
-		$strString = static::decodeEntities($strString);
 		$strString = static::standardize(strip_tags($strString));
 
 		// Remove the prefix if the alias is not numeric (see #707)
@@ -332,10 +331,7 @@ class StringUtil
 	 */
 	public static function prepareSlug($strSlug)
 	{
-		$strSlug = static::stripInsertTags($strSlug);
-		$strSlug = static::decodeEntities($strSlug);
-
-		return $strSlug;
+		return static::stripInsertTags($strSlug);
 	}
 
 	/**

--- a/core-bundle/src/DataCollector/ContaoDataCollector.php
+++ b/core-bundle/src/DataCollector/ContaoDataCollector.php
@@ -24,7 +24,6 @@ use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Search\Backend\BackendSearch;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\LayoutModel;
-use Contao\StringUtil;
 use Imagine\Driver\InfoProvider;
 use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Gmagick\Imagine as GmagickImagine;
@@ -252,7 +251,7 @@ class ContaoDataCollector extends DataCollector implements FrameworkAwareInterfa
             return '';
         }
 
-        return \sprintf('%s (ID %s)', StringUtil::decodeEntities($page->title), $page->id);
+        return \sprintf('%s (ID %s)', $page->title, $page->id);
     }
 
     private function getPageUrl(): string
@@ -270,7 +269,7 @@ class ContaoDataCollector extends DataCollector implements FrameworkAwareInterfa
             return '';
         }
 
-        return \sprintf('%s (ID %s)', StringUtil::decodeEntities($layout->name), $layout->id);
+        return \sprintf('%s (ID %s)', $layout->name, $layout->id);
     }
 
     private function getLayoutUrl(): string
@@ -294,7 +293,7 @@ class ContaoDataCollector extends DataCollector implements FrameworkAwareInterfa
         foreach ($models as $article) {
             $articles[] = [
                 'url' => $this->router->generate('contao_backend', ['do' => 'article', 'table' => 'tl_content', 'id' => $article->id]),
-                'label' => \sprintf('%s (ID %s)', StringUtil::decodeEntities($article->title), $article->id),
+                'label' => \sprintf('%s (ID %s)', $article->title, $article->id),
             ];
         }
 

--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -17,7 +17,6 @@ use Contao\CoreBundle\Event\DataContainerRecordLabelEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\DataContainer;
 use Contao\DcaLoader;
-use Contao\StringUtil;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -60,7 +59,7 @@ class FallbackRecordLabelListener
 
             $value = $this->valueFormatter->format($table, $defaultSearchField, $label, $dc);
 
-            $event->setLabel(trim(StringUtil::decodeEntities(strip_tags($value))));
+            $event->setLabel(trim(strip_tags($value)));
         } else {
             $messageDomain = "contao_$table";
 

--- a/core-bundle/src/EventListener/Menu/BackendFavoritesListener.php
+++ b/core-bundle/src/EventListener/Menu/BackendFavoritesListener.php
@@ -15,7 +15,6 @@ namespace Contao\CoreBundle\EventListener\Menu;
 use Contao\BackendUser;
 use Contao\CoreBundle\Event\MenuEvent;
 use Contao\CoreBundle\Util\UrlUtil;
-use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
@@ -138,10 +137,10 @@ class BackendFavoritesListener
             $item = $factory
                 ->createItem('favorite_'.$node['id'])
                 ->setAttribute('id', 'favorites-menu-'.$node['id'])
-                ->setLabel(StringUtil::decodeEntities($node['title']))
+                ->setLabel($node['title'])
                 ->setUri($node['url'])
                 ->setLinkAttribute('class', 'navigation')
-                ->setLinkAttribute('title', StringUtil::decodeEntities($node['title']))
+                ->setLinkAttribute('title', $node['title'])
                 ->setLinkAttribute('data-contao--tooltips-target', 'tooltip')
                 ->setCurrent($node['url'] === $requestUri)
                 ->setExtra('translation_domain', false)

--- a/core-bundle/src/EventListener/Widget/CustomRgxpListener.php
+++ b/core-bundle/src/EventListener/Widget/CustomRgxpListener.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\Widget;
 
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
-use Contao\StringUtil;
 use Contao\Widget;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -36,7 +35,7 @@ class CustomRgxpListener
             return true;
         }
 
-        if (!preg_match(StringUtil::decodeEntities($widget->customRgxp), StringUtil::decodeEntities($input))) {
+        if (!preg_match($widget->customRgxp, $input)) {
             $widget->addError($widget->errorMsg ?: $this->translator->trans('ERR.customRgxp', [$widget->customRgxp], 'contao_default'));
         }
 

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -78,7 +78,7 @@ class StringUtilTest extends TestCase
         $this->assertSame('foo', StringUtil::generateAlias('FOO'));
         $this->assertSame('foo-bar', StringUtil::generateAlias('foo bar'));
         $this->assertSame('foo-bar', StringUtil::generateAlias('%foo&bar~'));
-        $this->assertSame('foo-bar', StringUtil::generateAlias('foo&amp;bar'));
+        $this->assertSame('foo-bar', StringUtil::generateAlias('foo&bar'));
         $this->assertSame('foo-bar', StringUtil::generateAlias('foo-{{link::12}}-bar'));
         $this->assertSame('id-123', StringUtil::generateAlias('123'));
         $this->assertSame('123foo', StringUtil::generateAlias('123foo'));

--- a/core-bundle/tests/DataCollector/ContaoDataCollectorTest.php
+++ b/core-bundle/tests/DataCollector/ContaoDataCollectorTest.php
@@ -79,17 +79,21 @@ class ContaoDataCollectorTest extends TestCase
     public function testCollectsDataInFrontEnd(): void
     {
         $layout = $this->createClassWithPropertiesStub(LayoutModel::class);
-        $layout->name = 'Default';
+        $layout->name = 'Default & custom';
         $layout->id = 2;
         $layout->template = 'fe_page';
 
         $adapter = $this->createConfiguredAdapterStub(['findById' => $layout]);
-        $articleModelAdapter = $this->createConfiguredAdapterStub(['findByPid' => []]);
+        $article = $this->createClassWithPropertiesStub(ArticleModel::class);
+        $article->id = 3;
+        $article->title = 'Article & content';
+
+        $articleModelAdapter = $this->createConfiguredAdapterStub(['findByPid' => [$article]]);
         $framework = $this->createContaoFrameworkStub([LayoutModel::class => $adapter, ArticleModel::class => $articleModelAdapter]);
 
         $page = $this->createClassWithPropertiesStub(PageModel::class);
         $page->id = 2;
-        $page->title = 'Page';
+        $page->title = 'Page & title';
         $page->layoutId = 2;
 
         $pageFinder = $this->createStub(PageFinder::class);
@@ -116,11 +120,16 @@ class ContaoDataCollectorTest extends TestCase
                 'framework' => true,
                 'frontend' => true,
                 'preview' => false,
-                'page' => 'Page (ID 2)',
+                'page' => 'Page & title (ID 2)',
                 'page_url' => '',
-                'layout' => 'Default (ID 2)',
+                'layout' => 'Default & custom (ID 2)',
                 'layout_url' => '',
-                'articles' => [],
+                'articles' => [
+                    [
+                        'url' => '',
+                        'label' => 'Article & content (ID 3)',
+                    ],
+                ],
                 'template' => 'fe_page',
             ],
             $collector->getSummary(),

--- a/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
@@ -98,8 +98,8 @@ class FallbackRecordLabelListenerTest extends TestCase
         $formatter
             ->expects($this->once())
             ->method('format')
-            ->with('tl_foo', 'fieldA', 'A <span>(B &amp; B)</span>')
-            ->willReturn('A (B & B)')
+            ->with('tl_foo', 'fieldA', 'A <span>(B & B)</span>')
+            ->willReturn('A <span>(B & B)</span>')
         ;
 
         $dataContainer = $this->createAdapterMock(['getDriverForTable']);
@@ -116,7 +116,7 @@ class FallbackRecordLabelListenerTest extends TestCase
         ;
 
         $listener = new FallbackRecordLabelListener($framework, $translator, $formatter);
-        $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123, 'fieldA' => 'A <span>(B &amp; B)</span>']));
+        $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123, 'fieldA' => 'A <span>(B & B)</span>']));
 
         $this->assertSame('A (B & B)', $event->getLabel());
     }

--- a/core-bundle/tests/EventListener/Menu/BackendFavoritesListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendFavoritesListenerTest.php
@@ -103,7 +103,7 @@ class BackendFavoritesListenerTest extends TestCase
                         'id' => 8,
                         'pid' => 7,
                         'tstamp' => 1671538402,
-                        'title' => 'Edit &quot;fe_page&quot;',
+                        'title' => 'Edit "fe_page"',
                         'url' => '/contao?do=tpl_editor&act=source&id=templates%2Ffe_page.html5',
                     ],
                 ],

--- a/core-bundle/tests/EventListener/Widget/CustomRgxpListenerTest.php
+++ b/core-bundle/tests/EventListener/Widget/CustomRgxpListenerTest.php
@@ -89,7 +89,7 @@ class CustomRgxpListenerTest extends TestCase
         $this->assertTrue($listener(CustomRgxpListener::RGXP_NAME, 'foobar', $widget));
     }
 
-    public function testDecodesEntities(): void
+    public function testUsesRawValues(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator
@@ -98,7 +98,7 @@ class CustomRgxpListenerTest extends TestCase
             ->willReturnArgument(0)
         ;
 
-        $widget = $this->createClassWithPropertiesMock(Widget::class, ['customRgxp' => '/^&lt;>$/i']);
+        $widget = $this->createClassWithPropertiesMock(Widget::class, ['customRgxp' => '/^<>$/i']);
         $widget
             ->expects($this->never())
             ->method('addError')
@@ -107,6 +107,6 @@ class CustomRgxpListenerTest extends TestCase
 
         $listener = new CustomRgxpListener($translator);
 
-        $this->assertTrue($listener(CustomRgxpListener::RGXP_NAME, '<&gt;', $widget));
+        $this->assertTrue($listener(CustomRgxpListener::RGXP_NAME, '<>', $widget));
     }
 }

--- a/core-bundle/tests/Slug/SlugTest.php
+++ b/core-bundle/tests/Slug/SlugTest.php
@@ -58,7 +58,7 @@ class SlugTest extends ContaoTestCase
         $this->assertSame('id-123', $slug->generate('123'));
         $this->assertSame('123', $slug->generate('123', 123, null, ''));
         $this->assertSame('12.3', $slug->generate('12.3'));
-        $this->assertSame('text<', $slug->generate('&#116;ext{{insert::tag}}&lt;', 123));
+        $this->assertSame('text<', $slug->generate('text{{insert::tag}}<', 123));
         $this->assertSame('text-2', $slug->generate('text', [], static fn ($alias) => 'text' === $alias));
         $this->assertSame('text-10', $slug->generate('text', [], static fn ($alias) => \strlen((string) $alias) < 7));
     }


### PR DESCRIPTION
Contao 6 stores input and database values in their raw form. This PR removes some more obsolete `StringUtil::decodeEntities()` calls that remained from input encoding.

Not sure about all of them as I also found usages in e.g. alias and slug generation. While this changes their previous standalone behavior, I think treating their input as raw is consistent with the rest of Contao 6.