### PR TITLE
Do not set the translator locale for subrequests

### DIFF
--- a/core-bundle/src/EventListener/LocaleSubscriber.php
+++ b/core-bundle/src/EventListener/LocaleSubscriber.php
@@ -54,6 +54,11 @@ class LocaleSubscriber implements EventSubscriberInterface
      */
     public function setTranslatorLocale(RequestEvent $event): void
     {
+        // Do not overwrite the page locale before Symfony stores it for a subrequest
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
         $this->translator->setLocale($event->getRequest()->getPreferredLanguage($this->availableLocales));
     }
 

--- a/core-bundle/src/EventListener/LocaleSubscriber.php
+++ b/core-bundle/src/EventListener/LocaleSubscriber.php
@@ -54,7 +54,6 @@ class LocaleSubscriber implements EventSubscriberInterface
      */
     public function setTranslatorLocale(RequestEvent $event): void
     {
-        // Do not overwrite the page locale before Symfony stores it for a subrequest
         if (!$event->isMainRequest()) {
             return;
         }

--- a/core-bundle/tests/EventListener/LocaleSubscriberTest.php
+++ b/core-bundle/tests/EventListener/LocaleSubscriberTest.php
@@ -177,6 +177,30 @@ class LocaleSubscriberTest extends TestCase
         $listener->setTranslatorLocale($event);
     }
 
+    public function testDoesNotSetTheTranslatorLocaleForSubRequests(): void
+    {
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects($this->never())
+            ->method('getPreferredLanguage')
+        ;
+
+        $event = new RequestEvent(
+            $this->createMock(KernelInterface::class),
+            $request,
+            HttpKernelInterface::SUB_REQUEST,
+        );
+
+        $translator = $this->createMock(LocaleAwareInterface::class);
+        $translator
+            ->expects($this->never())
+            ->method('setLocale')
+        ;
+
+        $listener = new LocaleSubscriber($translator, $this->mockScopeMatcher(), $this->mockLocales(['en', 'de']));
+        $listener->setTranslatorLocale($event);
+    }
+
     private function mockLocales(array $locales): Locales&MockObject
     {
         $localesService = $this->createMock(Locales::class);


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/10156

Symfony fixed a legitimate locale-restoration bug in https://github.com/symfony/symfony/pull/65526.
The old behavior accidentally cleaned up a Contao side effect and with the bugfix, we are now missing this cleanup 😊 

Previously, after a subrequest Symfony restored locale-aware services from the parent `Request`:

```php
$translator->setLocale($parentRequest->getLocale());
```

That was incorrect when an application had deliberately changed the translator with e.g. the locale switcher without changing the parent request. Rendering a fragment would silently undo that deliberate change. The PR https://github.com/symfony/symfony/pull/65526 fixes this by remembering the translator’s actual value before the subrequest and restoring that exact value afterward. So from Symfony's point of view, this fix is correct.

The problem is listener ordering in Contao:

1. The page locale and translator are`en`.
2. A subrequest starts.
3. Contao’s listener runs at priority `100` and sets the translator from `Accept-Language`, e.g. `de`.
4. Symfony’s listener runs later at priority `15` and records the current translator locale - which is now `de`.
5. After the subrequest, Symfony correctly restores the recorded value: `de`.

Before the Symfony fix, step 5 ignored that recorded state and restored the parent request locale. Which was `en`. This side effect happened to undo Contao’s (unwanted) subrequest change.

So Symfony did not introduce the original incorrect mutation. It stopped masking it.

We need to fix this in Contao because it is semantically correct here. Browser-locale initialization belongs to the main request. A subrequest should inherit/use the already-resolved page locale. It should not reconsider the visitor’s browser language for every subrequest. 

@bytehead @qzminski - can you confirm this fixes the issue when using the latest Symfony bugfix releases?