### PR TITLE
Check for the main request in more listeners

### DIFF
--- a/core-bundle/src/EventListener/BackendLocaleListener.php
+++ b/core-bundle/src/EventListener/BackendLocaleListener.php
@@ -38,6 +38,10 @@ class BackendLocaleListener
      */
     public function __invoke(RequestEvent $event): void
     {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
         $user = $this->security->getUser();
 
         if (!$user instanceof BackendUser || !$user->language) {

--- a/core-bundle/src/EventListener/BackendRebuildCacheMessageListener.php
+++ b/core-bundle/src/EventListener/BackendRebuildCacheMessageListener.php
@@ -36,9 +36,7 @@ class BackendRebuildCacheMessageListener
 
     public function __invoke(RequestEvent $event): void
     {
-        $request = $event->getRequest();
-
-        if (!$this->scopeMatcher->isBackendRequest($request)) {
+        if (!$this->scopeMatcher->isBackendMainRequest($event)) {
             return;
         }
 
@@ -46,7 +44,7 @@ class BackendRebuildCacheMessageListener
             return;
         }
 
-        $session = $request->getSession();
+        $session = $event->getRequest()->getSession();
 
         if (!$session instanceof Session) {
             return;

--- a/core-bundle/src/EventListener/InsecureInstallationListener.php
+++ b/core-bundle/src/EventListener/InsecureInstallationListener.php
@@ -33,6 +33,10 @@ class InsecureInstallationListener
      */
     public function __invoke(RequestEvent $event): void
     {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
         $request = $event->getRequest();
 
         // Skip the check on localhost

--- a/core-bundle/src/EventListener/PreviewAuthenticationListener.php
+++ b/core-bundle/src/EventListener/PreviewAuthenticationListener.php
@@ -42,7 +42,7 @@ class PreviewAuthenticationListener
 
         if (
             !$request->attributes->get('_preview', false)
-            || $this->scopeMatcher->isBackendRequest($request)
+            || $this->scopeMatcher->isBackendMainRequest($event)
             || $this->tokenChecker->canAccessPreview()
         ) {
             return;

--- a/core-bundle/tests/EventListener/BackendRebuildCacheMessageListenerTest.php
+++ b/core-bundle/tests/EventListener/BackendRebuildCacheMessageListenerTest.php
@@ -33,7 +33,7 @@ class BackendRebuildCacheMessageListenerTest extends TestCase
     {
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
         $scopeMatcher
-            ->method('isBackendRequest')
+            ->method('isBackendMainRequest')
             ->willReturn($backendRequest)
         ;
 
@@ -76,7 +76,7 @@ class BackendRebuildCacheMessageListenerTest extends TestCase
     {
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
         $scopeMatcher
-            ->method('isBackendRequest')
+            ->method('isBackendMainRequest')
             ->willReturn(true)
         ;
 

--- a/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
@@ -47,7 +47,7 @@ class PreviewAuthenticationListenerTest extends TestCase
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
         $scopeMatcher
             ->expects($this->once())
-            ->method('isBackendRequest')
+            ->method('isBackendMainRequest')
             ->willReturn(false)
         ;
 


### PR DESCRIPTION
Prompted by #10157 I was looking at which `RequestEvent` listeners may erroneously run on sub requests, even though they might not be intended to. This PR adds a main request check to them.

Of particular interest is the `InsecureInstallationListener` which currently executes its logic for _every content element_ on a page.

I have also added the check to the `PreviewAuthenticationListener`, as any firewall related logic should always only run on the main request, I think?