### PR TITLE
Autoload the core bundle test namespace in the single bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,7 @@ jobs:
                           if ("contao/core-bundle" !== $data["name"]) {
                               $data["repositories"][0]["type"] = "path";
                               $data["repositories"][0]["url"] = "../core-bundle";
+                              $data["autoload-dev"]["psr-4"]["Contao\\CoreBundle\\Tests\\"] = "../core-bundle/tests/";
                           }
                           if ("contao/news-bundle" !== $data["name"]) {
                               $data["repositories"][1]["type"] = "path";
@@ -427,9 +428,6 @@ jobs:
                           if ("contao/test-case" !== $data["name"]) {
                               $data["repositories"][2]["type"] = "path";
                               $data["repositories"][2]["url"] = "../test-case";
-                          }
-                          if ("contao/core-bundle" !== $data["name"]) {
-                              $data["autoload-dev"]["psr-4"]["Contao\\CoreBundle\\Tests\\"] = "../core-bundle/tests/";
                           }
                           file_put_contents(__DIR__."/composer.json", json_encode($data, JSON_UNESCAPED_SLASHES));
                       '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,7 +429,7 @@ jobs:
                               $data["repositories"][2]["url"] = "../test-case";
                           }
                           if ("contao/core-bundle" !== $data["name"]) {
-                            $data["autoload-dev"]["psr-4"]["Contao\\\\CoreBundle\\\\Tests\\\\"] = "../core-bundle/tests/";
+                              $data["autoload-dev"]["psr-4"]["Contao\\\\CoreBundle\\\\Tests\\\\"] = "../core-bundle/tests/";
                           }
                           file_put_contents(__DIR__."/composer.json", json_encode($data, JSON_UNESCAPED_SLASHES));
                       '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,7 +429,7 @@ jobs:
                               $data["repositories"][2]["url"] = "../test-case";
                           }
                           if ("contao/core-bundle" !== $data["name"]) {
-                              $data["autoload-dev"]["psr-4"]["Contao\\\\CoreBundle\\\\Tests\\\\"] = "../core-bundle/tests/";
+                              $data["autoload-dev"]["psr-4"]["Contao\\CoreBundle\\Tests\\"] = "../core-bundle/tests/";
                           }
                           file_put_contents(__DIR__."/composer.json", json_encode($data, JSON_UNESCAPED_SLASHES));
                       '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,9 @@ jobs:
                               $data["repositories"][2]["type"] = "path";
                               $data["repositories"][2]["url"] = "../test-case";
                           }
+                          if ("contao/core-bundle" !== $data["name"]) {
+                            $data["autoload-dev"]["psr-4"]["Contao\\\\CoreBundle\\\\Tests\\\\"] = "../core-bundle/tests/";
+                          }
                           file_put_contents(__DIR__."/composer.json", json_encode($data, JSON_UNESCAPED_SLASHES));
                       '
                       composer install --no-interaction --no-progress

--- a/calendar-bundle/composer.json
+++ b/calendar-bundle/composer.json
@@ -65,7 +65,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Contao\\CalendarBundle\\Tests\\": "tests/"
+            "Contao\\CalendarBundle\\Tests\\": "tests/",
+            "Contao\\CoreBundle\\Tests\\": "../core-bundle/tests/"
         }
     },
     "config": {

--- a/calendar-bundle/composer.json
+++ b/calendar-bundle/composer.json
@@ -65,8 +65,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Contao\\CalendarBundle\\Tests\\": "tests/",
-            "Contao\\CoreBundle\\Tests\\": "../core-bundle/tests/"
+            "Contao\\CalendarBundle\\Tests\\": "tests/"
         }
     },
     "config": {


### PR DESCRIPTION
The CI for the single bundle tests was failing because the CoreBundle test namespace is not available in the bundle autoloaders (See 8c8e9f521c88b672974cfbb22bbef9be6b1ce477 and https://github.com/contao/contao/actions/runs/33446961183/job/99668097679 for a successful test with the calendar-bundle -> which obv. breaks within the monorepo composer json 😁)

Since we already temporarily rewrite the paths within this CI job, I am writing the test namespace within the bundles `autoload-dev`