### PR TITLE
Ignore dates that cannot be converted when loading a widget

### DIFF
--- a/core-bundle/contao/library/Contao/Widget.php
+++ b/core-bundle/contao/library/Contao/Widget.php
@@ -1411,8 +1411,15 @@ abstract class Widget extends Controller
 		// Convert timestamps
 		if ($varValue !== null && $varValue !== '' && \in_array($arrData['eval']['rgxp'] ?? null, array('date', 'time', 'datim')))
 		{
-			$objDate = new Date($varValue, Date::getFormatFromRgxp($arrData['eval']['rgxp']));
-			$arrAttributes['value'] = $objDate->{$arrData['eval']['rgxp']};
+			try
+			{
+				$objDate = new Date($varValue, Date::getFormatFromRgxp($arrData['eval']['rgxp']));
+				$arrAttributes['value'] = $objDate->{$arrData['eval']['rgxp']};
+			}
+			catch (\OutOfBoundsException)
+			{
+				// ignore if date could not be converted
+			}
 		}
 
 		// Convert URL insert tags


### PR DESCRIPTION
I added `rgxp = date` to an existing field with existing database values. When editing the record, an exception is thrown because the value could not be converted. I think the back end should show the original value in that case, it will show an error when trying to save the record.