### PR TITLE
Remove deprecated config values

### DIFF
--- a/manager-bundle/skeleton/config/config.yaml
+++ b/manager-bundle/skeleton/config/config.yaml
@@ -172,15 +172,11 @@ webauthn:
     user_repository: contao.repository.webauthn_user_entity
     creation_profiles:
         contao_backend:
-            rp:
-                name: Contao Open Source CMS
             authenticator_selection_criteria:
                 require_resident_key: true
                 user_verification: !php/const Webauthn\AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED
                 resident_key: !php/const Webauthn\AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED
         contao_frontend:
-            rp:
-                name: Contao Open Source CMS
             authenticator_selection_criteria:
                 require_resident_key: true
                 user_verification: !php/const Webauthn\AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED


### PR DESCRIPTION
Stumbled upon a deprecation:

https://github.com/web-auth/webauthn-framework/blob/19ff89a88696f4d9b3175347a87079af7280f458/src/symfony/src/DependencyInjection/Configuration.php#L316-L320