### PR TITLE
Exclude `+intl-icu` from being a Contao translation domain

### DIFF
--- a/core-bundle/src/Translation/MessageCatalogue.php
+++ b/core-bundle/src/Translation/MessageCatalogue.php
@@ -181,11 +181,7 @@ final class MessageCatalogue implements MessageCatalogueInterface
 
     private function isContaoDomain(string|null $domain): bool
     {
-        if (!str_starts_with($domain ?? '', 'contao_')) {
-            return false;
-        }
-
-        return 1 === preg_match('/^[a-z0-9_-]+$/i', substr($domain, 7));
+        return 1 === preg_match('/^contao_[a-zA-Z0-9_-]+$/', $domain ?? '');
     }
 
     private function loadMessage(string $id, string $domain): string|null

--- a/core-bundle/src/Translation/MessageCatalogue.php
+++ b/core-bundle/src/Translation/MessageCatalogue.php
@@ -181,8 +181,11 @@ final class MessageCatalogue implements MessageCatalogueInterface
 
     private function isContaoDomain(string|null $domain): bool
     {
-        return str_starts_with($domain ?? '', 'contao_')
-            && !str_ends_with($domain ?? '', MessageCatalogueInterface::INTL_DOMAIN_SUFFIX);
+        if (!str_starts_with($domain ?? '', 'contao_')) {
+            return false;
+        }
+
+        return 1 === preg_match('/^[a-z0-9_-]+$/i', $domain);
     }
 
     private function loadMessage(string $id, string $domain): string|null

--- a/core-bundle/src/Translation/MessageCatalogue.php
+++ b/core-bundle/src/Translation/MessageCatalogue.php
@@ -185,7 +185,7 @@ final class MessageCatalogue implements MessageCatalogueInterface
             return false;
         }
 
-        return 1 === preg_match('/^[a-z0-9_-]+$/i', $domain);
+        return 1 === preg_match('/^[a-z0-9_-]+$/i', substr($domain, 7));
     }
 
     private function loadMessage(string $id, string $domain): string|null

--- a/core-bundle/src/Translation/MessageCatalogue.php
+++ b/core-bundle/src/Translation/MessageCatalogue.php
@@ -181,7 +181,8 @@ final class MessageCatalogue implements MessageCatalogueInterface
 
     private function isContaoDomain(string|null $domain): bool
     {
-        return str_starts_with($domain ?? '', 'contao_');
+        return str_starts_with($domain ?? '', 'contao_')
+            && !str_ends_with($domain ?? '', MessageCatalogueInterface::INTL_DOMAIN_SUFFIX);
     }
 
     private function loadMessage(string $id, string $domain): string|null


### PR DESCRIPTION
While playing around with [`symfony lsp:check`](https://symfony.com/blog/introducing-symfony-lsp-check-symfony-aware-diagnostics-in-your-ci), I've noticed an issue with the Contao message catalogue. 

The LSP bridge's [translations section](https://github.com/symfony/language-tools/blob/73f22c8ca5a2813f126a99a523b04e63bc9e5f75/resources/bridge/sections/translations.php#L40) checks every message for ICU form with the standard Symfony idiom:                                               

```php                                                                                                                                                                                                                                           
$catalogue->defines($key, $domain.'+intl-icu')
```
                                                                                                                                                                                                                                           
Contao's [`MessageCatalogue::defines()`](https://github.com/contao/contao/blob/407421cf87f780abd3f9c4bb60da20c47df2758e/core-bundle/src/Translation/MessageCatalogue.php#L81) sees a domain starting with `contao_`, strips the prefix (in `loadMessage()`) and hands the rest to `System::loadLanguageFile()`, which rejects the name:
                                                                                              
```
InvalidArgumentException: Invalid language file name "default+intl-icu"
Contao\CoreBundle\Translation\MessageCatalogue->loadMessage('CTE.events', 'contao_default+intl-icu')
```
                                                                                                                                                                                                                                        
The bridge catches the Throwable, marks the section incomplete, and `lsp:check` aborts with exit 12 before reporting anything.