### PR TITLE
Remove the deprecated `xss_protection` option

### DIFF
--- a/manager-bundle/skeleton/config/config.yaml
+++ b/manager-bundle/skeleton/config/config.yaml
@@ -140,9 +140,6 @@ nelmio_security:
         policies:
             - no-referrer-when-downgrade
             - strict-origin-when-cross-origin
-    xss_protection:
-        enabled: true
-        mode_block: true
 
 # FOS HttpCache configuration
 fos_http_cache:


### PR DESCRIPTION
_The "xss_protection" option is deprecated, use Content Security Policy without allowing "unsafe-inline" scripts instead._