### PR TITLE
Backport the HTML5-to-Twig template override order

### DIFF
--- a/core-bundle/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/contao/library/Contao/TemplateInheritance.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Twig\ContaoTwigUtil;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -369,8 +370,9 @@ trait TemplateInheritance
 		}
 
 		$templateCandidate = "@Contao/$this->strTemplate.html.twig";
+		$loader = $container->get('contao.twig.filesystem_loader');
 
-		if (!$twig->getLoader()->exists($templateCandidate))
+		if (!$loader->exists($templateCandidate) || 'html5' === ContaoTwigUtil::getExtension($loader->getFirst($this->strTemplate)))
 		{
 			return null;
 		}

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -17,6 +17,7 @@ use Contao\Config;
 use Contao\CoreBundle\Controller\AbstractBackendController;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\Database;
 use Contao\Environment as ContaoEnvironment;
 use Contao\System;
@@ -139,6 +140,19 @@ class AbstractBackendControllerTest extends TestCase
             )
         ;
 
+        $filesystemLoader = $this->createMock(ContaoFilesystemLoader::class);
+        $filesystemLoader
+            ->method('exists')
+            ->willReturn(true)
+        ;
+
+        $filesystemLoader
+            ->method('getFirst')
+            ->willReturnCallback(
+                static fn (string $identifier) => "templates/$identifier.html5",
+            )
+        ;
+
         $requestStack = new RequestStack();
         $requestStack->push(new Request(server: $_SERVER));
 
@@ -148,6 +162,7 @@ class AbstractBackendControllerTest extends TestCase
         $container->set('database_connection', $this->createMock(Connection::class));
         $container->set('session', $this->createMock(Session::class));
         $container->set('twig', $twig);
+        $container->set('contao.twig.filesystem_loader', $filesystemLoader);
         $container->set('router', $this->createMock(RouterInterface::class));
         $container->set('request_stack', $requestStack);
 

--- a/core-bundle/tests/Controller/FrontendModule/FeedReaderControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/FeedReaderControllerTest.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Controller\FrontendModule\FeedReaderController;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Interop\ContextFactory;
+use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\Environment;
 use Contao\Input;
 use Contao\ModuleModel;
@@ -40,7 +41,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 use Symfony\Contracts\Cache\CacheInterface;
 use Twig\Environment as TwigEnvironment;
-use Twig\Loader\LoaderInterface;
 
 class FeedReaderControllerTest extends TestCase
 {
@@ -312,11 +312,21 @@ class FeedReaderControllerTest extends TestCase
 
     private function mockContainer(RequestStack|null $requestStack = null, callable|null $assertTwigContext = null): ContainerBuilder
     {
-        $loader = $this->createMock(LoaderInterface::class);
+        $loader = $this->createStub(ContaoFilesystemLoader::class);
         $loader
             ->method('exists')
-            ->with('@Contao/frontend_module/feed_reader.html.twig')
-            ->willReturn(true)
+            ->willReturnCallback(static fn ($template) => match ($template) {
+                '@Contao/frontend_module/feed_reader.html.twig' => true,
+                default => false,
+            })
+        ;
+
+        $loader
+            ->method('getFirst')
+            ->willReturnCallback(static fn ($template) => match ($template) {
+                '@Contao/frontend_module/feed_reader.html.twig' => '@Contao_ContaoCoreBundle/frontend_module/feed_reader.html.twig',
+                default => "$template.html5",
+            })
         ;
 
         $twig = $this->createMock(TwigEnvironment::class);

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -94,9 +94,23 @@ class TwigIntegrationTest extends TestCase
             ),
         );
 
+        $filesystemLoader = $this->createMock(ContaoFilesystemLoader::class);
+        $filesystemLoader
+            ->method('exists')
+            ->with('@Contao/form_text.html.twig')
+            ->willReturn(true)
+        ;
+
+        $filesystemLoader
+            ->method('getFirst')
+            ->with('form_text')
+            ->willReturn('/path/to/form_text.html.twig')
+        ;
+
         $container = $this->getContainerWithContaoConfiguration($this->getTempDir());
         $container->set('twig', $environment);
         $container->set(ContextFactory::class, new ContextFactory());
+        $container->set('contao.twig.filesystem_loader', $filesystemLoader);
 
         System::setContainer($container);
 
@@ -160,9 +174,23 @@ class TwigIntegrationTest extends TestCase
             ),
         );
 
+        $filesystemLoader = $this->createMock(ContaoFilesystemLoader::class);
+        $filesystemLoader
+            ->method('exists')
+            ->with('@Contao/twig_template.html.twig')
+            ->willReturn(true)
+        ;
+
+        $filesystemLoader
+            ->method('getFirst')
+            ->with('twig_template')
+            ->willReturn('/path/to/twig_template.html.twig')
+        ;
+
         $container = $this->getContainerWithContaoConfiguration($this->getTempDir());
         $container->set('twig', $environment);
         $container->set(ContextFactory::class, new ContextFactory());
+        $container->set('contao.twig.filesystem_loader', $filesystemLoader);
 
         $insertTagParser = new InsertTagParser($this->createMock(ContaoFramework::class), $this->createMock(LoggerInterface::class), $this->createMock(FragmentHandler::class));
         $insertTagParser->addSubscription(new InsertTagSubscription(new LegacyInsertTag($container), '__invoke', 'br', null, true, false));


### PR DESCRIPTION
Backports the part of https://github.com/contao/contao/pull/9046 that allows overriding Twig templates with html5 templates.

IIRC we wanted to backport this to improve compatibility for extensions as they now have to use Twig templates to be compatible with Contao 6.