### PR TITLE
Do not return from `finally` blocks

### DIFF
--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -222,9 +222,11 @@ class ResizeImagesCommand extends Command
 
             if (0 !== $failedCount && $count - $failedCount <= 0) {
                 $this->io->error('No image could be resized successfully.');
-
-                return Command::FAILURE;
             }
+        }
+
+        if (0 !== $failedCount && $count - $failedCount <= 0) {
+            return Command::FAILURE;
         }
 
         return Command::SUCCESS;


### PR DESCRIPTION
Returning from a finally block is deprecated, see https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_returning_from_a_finally_block

This fixes the *PHP nightly* job on the CI