### PR TITLE
Cast arguments for string functions

### DIFF
--- a/core-bundle/src/ContentComposition/ContentCompositionBuilder.php
+++ b/core-bundle/src/ContentComposition/ContentCompositionBuilder.php
@@ -196,11 +196,11 @@ class ContentCompositionBuilder
             // Add slot content
             foreach (StringUtil::deserialize($layout->modules, true) as $definition) {
                 if ($definition['enable'] ?? false) {
-                    $isContentElement = str_starts_with((string) $definition['mod'], 'content-');
+                    $isContentElement = \is_string($definition['mod']) && str_starts_with($definition['mod'], 'content-');
 
                     $this->addElementToSlot(
                         $definition['col'],
-                        (int) ($isContentElement ? substr((string) $definition['mod'], 8) : $definition['mod']),
+                        (int) ($isContentElement ? substr($definition['mod'], 8) : $definition['mod']),
                         $isContentElement,
                     );
                 }

--- a/core-bundle/src/ContentComposition/ContentCompositionBuilder.php
+++ b/core-bundle/src/ContentComposition/ContentCompositionBuilder.php
@@ -196,11 +196,11 @@ class ContentCompositionBuilder
             // Add slot content
             foreach (StringUtil::deserialize($layout->modules, true) as $definition) {
                 if ($definition['enable'] ?? false) {
-                    $isContentElement = str_starts_with($definition['mod'], 'content-');
+                    $isContentElement = str_starts_with((string) $definition['mod'], 'content-');
 
                     $this->addElementToSlot(
                         $definition['col'],
-                        (int) ($isContentElement ? substr($definition['mod'], 8) : $definition['mod']),
+                        (int) ($isContentElement ? substr((string) $definition['mod'], 8) : $definition['mod']),
                         $isContentElement,
                     );
                 }


### PR DESCRIPTION
Fixes error `str_starts_with(): Argument #1 ($haystack) must be of type string, int given`