### PR TITLE
Correctly load all filter panels

### DIFF
--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -1064,6 +1064,7 @@ abstract class DataContainer extends Backend
 			return '';
 		}
 
+		$intFilterPanel = 0;
 		$panels = StringUtil::trimsplit('[;,]', $panelLayout);
 
 		// Force consistent order in Contao 5.7+ because the filter panel has moved from the top to the right.
@@ -1073,6 +1074,7 @@ abstract class DataContainer extends Backend
 		if (empty(array_diff($panels, array('search', 'filter', 'sort', 'limit'))))
 		{
 			$panelLayout = implode(',', array_values(array_intersect(array('search', 'filter', 'sort', 'limit'), $panels)));
+			$intFilterPanel = -1;
 		}
 
 		// Reset all filters
@@ -1093,7 +1095,6 @@ abstract class DataContainer extends Backend
 			$this->reload();
 		}
 
-		$intFilterPanel = 0;
 		$arrPanels = array();
 		$arrPanes = StringUtil::trimsplit(';', $panelLayout);
 

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -5294,7 +5294,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		// Get the sorting fields
 		foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'] as $k=>$v)
 		{
-			if (($intFilterPanel !== 0 && ($v['filter'] ?? null) == $intFilterPanel) || ($intFilterPanel === 0 && ($v['filter'] ?? null)))
+			if (($v['filter'] ?? false) && ($intFilterPanel === 0 || $v['filter'] == $intFilterPanel))
 			{
 				$sortingFields[] = $k;
 			}

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -5294,7 +5294,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		// Get the sorting fields
 		foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'] as $k=>$v)
 		{
-			if (($v['filter'] ?? null) == $intFilterPanel)
+			if (($intFilterPanel !== 0 && ($v['filter'] ?? null) == $intFilterPanel) || ($intFilterPanel === 0 && ($v['filter'] ?? null)))
 			{
 				$sortingFields[] = $k;
 			}


### PR DESCRIPTION
Before Contao 5.7, you could have multiple filter panels to group them in multiple rows. This code still works, because `DC_Table::filterMenu` accepts a numeric `$intFilterPanel`. 

In my case, the `panelLayout` looks like this: `'filter;filter;sort,search,limit'`

Because we're trying to standardize the filter panel if it does not contain custom panels, the duplicate filter item is remove. This PR fixes that by rendering all filter fields in this case (`$intFilterPanel = 0`).