### PR TITLE
Ignore the LinkedIn click identifier in the HTTP cache

### DIFF
--- a/core-bundle/src/EventListener/HttpCache/StripQueryParametersSubscriber.php
+++ b/core-bundle/src/EventListener/HttpCache/StripQueryParametersSubscriber.php
@@ -29,6 +29,9 @@ class StripQueryParametersSubscriber implements EventSubscriberInterface
         // Facebook click identifier
         'fbclid',
 
+        // LinkedIn click identifier
+        'li_fat_id',
+
         // TikTok click identifier
         'ttclid',
 


### PR DESCRIPTION
The `li_fat_id` query parameter is a unique click identifier added by LinkedIn Ads.

Other comparable click identifiers such as `gclid`, `fbclid`, `ttclid` and `msclkid` are already stripped from the request used for HTTP caching.

Since `li_fat_id` is currently not included in the fallback deny list, every unique LinkedIn click can create a separate cache entry although the generated page content is identical.

In one production installation, `li_fat_id` was found in 1,398 HTTP cache files, while `gclid`, which is already stripped by Contao, occurred only once.

This adds `li_fat_id` to the fallback deny list.