### PR TITLE
Suppress warnings from failed DNS lookups

### DIFF
--- a/core-bundle/src/HttpClient/NoPrivateNetworkExceptRootPagesHttpClient.php
+++ b/core-bundle/src/HttpClient/NoPrivateNetworkExceptRootPagesHttpClient.php
@@ -202,7 +202,7 @@ final class NoPrivateNetworkExceptRootPagesHttpClient implements HttpClientInter
             return $host;
         }
 
-        if ($ip = dns_get_record($host, DNS_AAAA)) {
+        if ($ip = @dns_get_record($host, DNS_AAAA)) {
             $ip = $ip[0]['ipv6'];
         } elseif (\extension_loaded('sockets')) {
             if (!$info = socket_addrinfo_lookup($host, null, ['ai_socktype' => SOCK_STREAM, 'ai_family' => AF_INET6])) {


### PR DESCRIPTION
Same as https://github.com/symfony/symfony/pull/65914 for our implementation. So just syncing Symfony with Contao here.