### PR TITLE
Consider non-ASCII characters in virtual fields when creating backups

### DIFF
--- a/core-bundle/src/Doctrine/Backup/Dumper.php
+++ b/core-bundle/src/Doctrine/Backup/Dumper.php
@@ -19,8 +19,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Types\BinaryType;
-use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\JsonType;
 
 class Dumper implements DumperInterface

--- a/core-bundle/src/Doctrine/Backup/Dumper.php
+++ b/core-bundle/src/Doctrine/Backup/Dumper.php
@@ -129,7 +129,7 @@ class Dumper implements DumperInterface
             $columnBindingTypes[$columnName] = $column->getType()->getBindingType();
 
             $charset = strtolower($column->getPlatformOptions()['charset'] ?? '');
-            $columnUtf8Charsets[$columnName] = \in_array($charset, ['utf8', 'utf8mb4'], true) || (\in_array($charset, ['', 'binary'], true) && $column->getType() instanceof JsonType);
+            $columnUtf8Charsets[$columnName] = \in_array($charset, ['utf8', 'utf8mb4'], true) || $column->getType() instanceof JsonType);
         }
 
         $values = implode(', ', $values);

--- a/core-bundle/src/Doctrine/Backup/Dumper.php
+++ b/core-bundle/src/Doctrine/Backup/Dumper.php
@@ -19,6 +19,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\BinaryType;
+use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\JsonType;
 
 class Dumper implements DumperInterface
@@ -129,7 +131,7 @@ class Dumper implements DumperInterface
             $columnBindingTypes[$columnName] = $column->getType()->getBindingType();
 
             $charset = strtolower($column->getPlatformOptions()['charset'] ?? '');
-            $columnUtf8Charsets[$columnName] = \in_array($charset, ['utf8', 'utf8mb4'], true) || $column->getType() instanceof JsonType);
+            $columnUtf8Charsets[$columnName] = \in_array($charset, ['utf8', 'utf8mb4'], true) || $column->getType() instanceof JsonType;
         }
 
         $values = implode(', ', $values);

--- a/core-bundle/src/Doctrine/Backup/Dumper.php
+++ b/core-bundle/src/Doctrine/Backup/Dumper.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\JsonType;
 
 class Dumper implements DumperInterface
 {
@@ -126,7 +127,9 @@ class Dumper implements DumperInterface
             $columnName = $column->getName();
             $values[] = "`$columnName` AS `$columnName`";
             $columnBindingTypes[$columnName] = $column->getType()->getBindingType();
-            $columnUtf8Charsets[$columnName] = \in_array(strtolower($column->getPlatformOptions()['charset'] ?? ''), ['utf8', 'utf8mb4'], true);
+
+            $charset = strtolower($column->getPlatformOptions()['charset'] ?? '');
+            $columnUtf8Charsets[$columnName] = \in_array($charset, ['utf8', 'utf8mb4'], true) || (\in_array($charset, ['', 'binary'], true) && $column->getType() instanceof JsonType);
         }
 
         $values = implode(', ', $values);

--- a/core-bundle/tests/Doctrine/Backup/DumperTest.php
+++ b/core-bundle/tests/Doctrine/Backup/DumperTest.php
@@ -333,6 +333,40 @@ class DumperTest extends ContaoTestCase
                 'SET FOREIGN_KEY_CHECKS = 1;',
             ],
         ];
+
+        yield 'Table with JSON data containing umlauts' => [
+            [new Table(
+                'tl_page',
+                [
+                    new Column('jsonData', Type::getType(Types::JSON)),
+                ],
+                [],
+                [],
+                [],
+                $tableOptions,
+            )],
+            [],
+            [
+                'SELECT `jsonData` AS `jsonData` FROM `tl_page`' => [
+                    [
+                        'jsonData' => '{"foo": "bar"}',
+                    ],
+                    [
+                        'jsonData' => '{"foo": "bär"}',
+                    ],
+                ],
+            ],
+            [
+                'SET FOREIGN_KEY_CHECKS = 0;',
+                '-- BEGIN STRUCTURE tl_page',
+                'DROP TABLE IF EXISTS `tl_page`;',
+                "CREATE TABLE `tl_page` (`jsonData` $jsonDecl) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB;",
+                '-- BEGIN DATA tl_page',
+                'INSERT INTO `tl_page` (`jsonData`) VALUES (\'{"foo": "bar"}\');',
+                'INSERT INTO `tl_page` (`jsonData`) VALUES (\'{"foo": "bär"}\');',
+                'SET FOREIGN_KEY_CHECKS = 1;',
+            ],
+        ];
     }
 
     /**

--- a/core-bundle/tests/Doctrine/Backup/DumperTest.php
+++ b/core-bundle/tests/Doctrine/Backup/DumperTest.php
@@ -328,7 +328,7 @@ class DumperTest extends ContaoTestCase
                 "CREATE TABLE `tl_page` (`x_string` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL, `x_json` $jsonDecl, `x_ascii` VARCHAR(255) NOT NULL, `x_binary` VARBINARY(255) NOT NULL, `x_blob` LONGBLOB NOT NULL, `x_simple_array` $arrayDecl) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB;",
                 '-- BEGIN DATA tl_page',
                 'INSERT INTO `tl_page` (`x_string`, `x_json`, `x_ascii`, `x_binary`, `x_blob`, `x_simple_array`) VALUES (\'ascii\', \'a:1:{i:0;s:5:"ascii";}\', \'ascii\', \'ascii\', \'ascii\', \'asc,ii\');',
-                'INSERT INTO `tl_page` (`x_string`, `x_json`, `x_ascii`, `x_binary`, `x_blob`, `x_simple_array`) VALUES (\'ütf-🎱\', 0x613a313a7b693a303b733a393a22c3bc74662df09f8eb1223b7d, 0xc3bc74662df09f8eb1, 0xc3bc74662df09f8eb1, 0xc3bc74662df09f8eb1, 0xc3bc74662cf09f8eb1);',
+                'INSERT INTO `tl_page` (`x_string`, `x_json`, `x_ascii`, `x_binary`, `x_blob`, `x_simple_array`) VALUES (\'ütf-🎱\', \'a:1:{i:0;s:9:"ütf-🎱";}\', 0xc3bc74662df09f8eb1, 0xc3bc74662df09f8eb1, 0xc3bc74662df09f8eb1, 0xc3bc74662cf09f8eb1);',
                 'INSERT INTO `tl_page` (`x_string`, `x_json`, `x_ascii`, `x_binary`, `x_blob`, `x_simple_array`) VALUES (0xb14ea559, 0x613a313a7b693a303b733a343a22b14ea559223b7d, 0xb14ea559, 0xb14ea559, 0xb14ea559, 0xb14ea559);',
                 'SET FOREIGN_KEY_CHECKS = 1;',
             ],


### PR DESCRIPTION
### Description

See discussion: https://github.com/contao/contao/pull/10195#issuecomment-5600261842

___

### Original description

Currently, umlauts within virtual fields create broken backups that can not be restored anymore, leading to the following error when restoring:

When restoring such a backup, the following error occurs:

```
[ERROR] An exception occurred while executing a query: SQLSTATE[22032]: <<Unknown error>>:
        3144 Cannot create a JSON value from a string with CHARACTER SET 'binary'.
```


The VirtualFieldsMappingListener treats virtual field target columns as JSON and MySQL ~~reports the charset of JSON columns as binary~~ reports it without a charset. Thus `Dumper::dumpTableData` always returns false, and any values containing non-ASCII characters are hex-encoded.

### Explanation

1. Umlaut wrongfully converted to binary 
3cb36f89000591fb4b3b97e3dc11fe44c395e2da adds a test for this case and is expected to fail to demonstrate the behaviour -> see https://github.com/contao/contao/actions/runs/34334921221/job/102411966928?pr=10195

2. Considering json (behavior change)
bf3e45d0ea148efa0c08b36a5fa2fbff991d09e2 is expected to break `Table with binary data` as there may be a behavior change due to having umlauts in the tests -> see https://github.com/contao/contao/actions/runs/34335424370/job/102413568350?pr=10195

3. Updating tests to match the behavior
e91c1739d9aedde9dd2e100e2b6f9924c21c109c updates the test for the json column to match the new behavior https://github.com/contao/contao/actions/runs/34335926003/job/102416693288?pr=10195
