### PR TITLE
Update `vstelmakh/url-highlight` to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -175,7 +175,7 @@
         "twig/string-extra": "^3.0",
         "twig/twig": "^3.21",
         "ua-parser/uap-php": "^3.9",
-        "vstelmakh/url-highlight": "^3.2",
+        "vstelmakh/url-highlight": "^4.0",
         "web-auth/webauthn-lib": "^5.0",
         "web-auth/webauthn-symfony-bundle": "^5.0",
         "webignition/robots-txt-file": "^3.0",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -158,7 +158,7 @@
         "twig/string-extra": "^3.0",
         "twig/twig": "^3.21",
         "ua-parser/uap-php": "^3.9",
-        "vstelmakh/url-highlight": "^3.2",
+        "vstelmakh/url-highlight": "^4.0",
         "web-auth/webauthn-lib": "^5.0",
         "web-auth/webauthn-symfony-bundle": "^5.0",
         "webignition/robots-txt-file": "^3.0",

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1595,16 +1595,6 @@ services:
 
     contao.url_highlight:
         class: VStelmakh\UrlHighlight\UrlHighlight
-        arguments:
-            - ~
-            - '@contao.url_highlight.html_highlighter'
-            - !service { class: VStelmakh\UrlHighlight\Encoder\HtmlSpecialcharsEncoder }
-
-    contao.url_highlight.html_highlighter:
-        class: VStelmakh\UrlHighlight\Highlighter\HtmlHighlighter
-        arguments:
-            - https
-            - { target: _blank, rel: noreferrer noopener }
 
     contao.webauthn.user_entity_guesser:
         class: Webauthn\Bundle\Security\Guesser\CurrentUserEntityGuesser

--- a/core-bundle/src/Twig/Runtime/AutolinkRuntime.php
+++ b/core-bundle/src/Twig/Runtime/AutolinkRuntime.php
@@ -13,19 +13,29 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Twig\Runtime;
 
 use Twig\Extension\RuntimeExtensionInterface;
+use VStelmakh\UrlHighlight\Format;
+use VStelmakh\UrlHighlight\Highlighter\CallbackHighlighter;
+use VStelmakh\UrlHighlight\Url;
 use VStelmakh\UrlHighlight\UrlHighlight;
 
 final class AutolinkRuntime implements RuntimeExtensionInterface
 {
+    private readonly CallbackHighlighter $highlighter;
+
     /**
      * @internal
      */
     public function __construct(private readonly UrlHighlight $urlHighlight)
     {
+        $this->highlighter = new CallbackHighlighter(fn (Url $url) => sprintf(
+            '<a href="%s" target="_blank" rel="noreferrer noopener">%s</a>',
+            htmlspecialchars($url->toHref('https')),
+            htmlspecialchars($url->full),
+        ));
     }
 
     public function linkUrls(string $text): string
     {
-        return $this->urlHighlight->highlightUrls($text);
+        return $this->urlHighlight->highlight($text, $this->highlighter, Format::HtmlEncoded);
     }
 }

--- a/core-bundle/src/Twig/Runtime/AutolinkRuntime.php
+++ b/core-bundle/src/Twig/Runtime/AutolinkRuntime.php
@@ -27,7 +27,7 @@ final class AutolinkRuntime implements RuntimeExtensionInterface
      */
     public function __construct(private readonly UrlHighlight $urlHighlight)
     {
-        $this->highlighter = new CallbackHighlighter(fn (Url $url) => sprintf(
+        $this->highlighter = new CallbackHighlighter(static fn (Url $url) => \sprintf(
             '<a href="%s" target="_blank" rel="noreferrer noopener">%s</a>',
             htmlspecialchars($url->toHref('https')),
             htmlspecialchars($url->full),

--- a/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
+++ b/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
@@ -223,7 +223,7 @@ final class GlobalStateWatcher implements Extension
                 'Symfony\Component\VarDumper\\',
                 'Symfony\Component\Yaml\\',
                 'Symfony\Polyfill\DeepClone\DeepClone',
-                'VStelmakh\UrlHighlight\\',
+                'VStelmakh\UrlHighlight\Matcher\Domains\TopLevelDomains',
                 'Webmozart\PathUtil\\',
             ] as $ignorePrefix) {
                 if (0 === strncmp($ignorePrefix, $class, \strlen($ignorePrefix))) {

--- a/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
+++ b/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
@@ -223,6 +223,7 @@ final class GlobalStateWatcher implements Extension
                 'Symfony\Component\VarDumper\\',
                 'Symfony\Component\Yaml\\',
                 'Symfony\Polyfill\DeepClone\DeepClone',
+                'VStelmakh\UrlHighlight\\',
                 'Webmozart\PathUtil\\',
             ] as $ignorePrefix) {
                 if (0 === strncmp($ignorePrefix, $class, \strlen($ignorePrefix))) {

--- a/core-bundle/tests/Twig/Runtime/AutolinkRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/AutolinkRuntimeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\Runtime;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Runtime\AutolinkRuntime;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class AutolinkRuntimeTest extends TestCase
+{
+    #[DataProvider('provideText')]
+    public function testLinkUrls(string $text, string $expected): void
+    {
+        /** @var AutolinkRuntime $runtime */
+        $runtime = $this->getContainerWithContaoConfiguration()->get('contao.twig.autolink_runtime');
+        $actual = $runtime->linkUrls($text);
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function provideText(): iterable
+    {
+        yield 'simple comment' => [
+            'Also see https://example.com for the full setup guide.',
+            'Also see <a href="https://example.com" target="_blank" rel="noreferrer noopener">https://example.com</a> for the full setup guide.',
+        ];
+
+        yield 'encoded html' => [
+            'Also see &lt;b&gt;https://example.com&lt;/b&gt; for the full setup guide.',
+            'Also see &lt;b&gt;<a href="https://example.com" target="_blank" rel="noreferrer noopener">https://example.com</a>&lt;/b&gt; for the full setup guide.',
+        ];
+
+        yield 'no links' => [
+            'Hello there! No links here.',
+            'Hello there! No links here.',
+        ];
+    }
+}

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -23,6 +23,7 @@ use Contao\CoreBundle\Twig\Inspector\InspectorNodeVisitor;
 use Contao\CoreBundle\Twig\Inspector\Storage;
 use Contao\CoreBundle\Twig\Interop\ContextFactory;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
+use Contao\CoreBundle\Twig\Runtime\AutolinkRuntime;
 use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\FormText;
@@ -361,5 +362,40 @@ class TwigIntegrationTest extends TestCase
                 </ul>
                 HTML,
         ];
+    }
+
+    public function testAutolinkUrls(): void
+    {
+        $templateContent = <<<'TEMPLATE'
+            <div class="comment">
+                {{ comment|autolink_url }}
+            </div>
+            TEMPLATE;
+
+        $expectedOutput = <<<'TEMPLATE'
+            <div class="comment">
+                Also see &lt;b&gt;<a href="https://example.com" target="_blank" rel="noreferrer noopener">https://example.com</a>&lt;/b&gt; for the full setup guide. If that one is down, the mirror at <a href="https://example.org" target="_blank" rel="noreferrer noopener">example.org</a> has the same content, just a &lt;b&gt;slightly older version&lt;/b&gt;.
+            </div>
+            TEMPLATE;
+
+        $runtime = $this->getContainerWithContaoConfiguration()->get('contao.twig.autolink_runtime');
+
+        $environment = new Environment(new ArrayLoader(['test.html.twig' => $templateContent]));
+        $environment->addRuntimeLoader(new FactoryRuntimeLoader([AutolinkRuntime::class => static fn () => $runtime]));
+
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $this->createStub(ContaoFilesystemLoader::class),
+                $this->createStub(ContaoVariable::class),
+                new InspectorNodeVisitor($this->createStub(Storage::class), $environment),
+            ),
+        );
+
+        $output = $environment->render('test.html.twig', [
+            'comment' => 'Also see <b>https://example.com</b> for the full setup guide. If that one is down, the mirror at example.org has the same content, just a <b>slightly older version</b>.',
+        ]);
+
+        $this->assertSame($expectedOutput, $output);
     }
 }


### PR DESCRIPTION
Hello 👋

Shortly after Contao adopted `vstelmakh/url-highlight`, version 4 was released. Bit of an unlucky timing 🙂

Version 4 has a new and much simpler public interface, as well as improved URL matching precision and performance. See the [changelog](https://github.com/vstelmakh/url-highlight/blob/main/CHANGELOG.md) and the [upgrade guide](https://github.com/vstelmakh/url-highlight/blob/main/docs/upgrade-4.0.md) for the details.

This PR updates the library to v4 and adds some (missing) tests to cover the related functionality. I think it can go to Contao 6.0, since there are no BC breaks for Contao users.

Happy to adjust anything if you see a better fit for the codebase.