### PR TITLE
Do not cast column values for aliases to binary

### DIFF
--- a/calendar-bundle/contao/models/CalendarEventsModel.php
+++ b/calendar-bundle/contao/models/CalendarEventsModel.php
@@ -232,7 +232,7 @@ class CalendarEventsModel extends Model
 		}
 
 		$t = static::$strTable;
-		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("CAST($t.alias AS BINARY)=?") : array("$t.id=?");
+		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("$t.alias=CAST(? AS BINARY)") : array("$t.id=?");
 		$arrColumns[] = "$t.pid IN(" . implode(',', array_map('\intval', $arrPids)) . ")";
 
 		if (!static::isPreviewMode($arrOptions))

--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -987,7 +987,7 @@ abstract class Model
 			array
 			(
 				'limit'  => 1,
-				'column' => $isAlias ? array("CAST($t.alias AS BINARY)=?") : array("$t.id=?"),
+				'column' => $isAlias ? array("$t.alias=CAST(? AS BINARY)") : array("$t.id=?"),
 				'value'  => $varId,
 				'return' => 'Model'
 			),

--- a/core-bundle/contao/models/ArticleModel.php
+++ b/core-bundle/contao/models/ArticleModel.php
@@ -123,7 +123,7 @@ class ArticleModel extends Model
 	public static function findByIdOrAliasAndPid($varId, $intPid, array $arrOptions=array())
 	{
 		$t = static::$strTable;
-		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("CAST($t.alias AS BINARY)=?") : array("$t.id=?");
+		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("$t.alias=CAST(? AS BINARY)") : array("$t.id=?");
 		$arrValues = array($varId);
 
 		if ($intPid)
@@ -147,7 +147,7 @@ class ArticleModel extends Model
 	public static function findPublishedByIdOrAliasAndPid($varId, $intPid, array $arrOptions=array())
 	{
 		$t = static::$strTable;
-		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("CAST($t.alias AS BINARY)=?") : array("$t.id=?");
+		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("$t.alias=CAST(? AS BINARY)") : array("$t.id=?");
 		$arrValues = array($varId);
 
 		if ($intPid)

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -649,7 +649,7 @@ class PageModel extends Model
 	public static function findPublishedByIdOrAlias($varId, array $arrOptions=array())
 	{
 		$t = static::$strTable;
-		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("CAST($t.alias AS BINARY)=?") : array("$t.id=?");
+		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("$t.alias=CAST(? AS BINARY)") : array("$t.id=?");
 
 		if (!static::isPreviewMode($arrOptions))
 		{

--- a/faq-bundle/contao/models/FaqModel.php
+++ b/faq-bundle/contao/models/FaqModel.php
@@ -152,7 +152,7 @@ class FaqModel extends Model
 		}
 
 		$t = static::$strTable;
-		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("CAST($t.alias AS BINARY)=?") : array("$t.id=?");
+		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("$t.alias=CAST(? AS BINARY)") : array("$t.id=?");
 		$arrColumns[] = "$t.pid IN(" . implode(',', array_map('\intval', $arrPids)) . ")";
 
 		if (!static::isPreviewMode($arrOptions))

--- a/news-bundle/contao/models/NewsModel.php
+++ b/news-bundle/contao/models/NewsModel.php
@@ -200,7 +200,7 @@ class NewsModel extends Model
 		}
 
 		$t = static::$strTable;
-		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("CAST($t.alias AS BINARY)=?") : array("$t.id=?");
+		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("$t.alias=CAST(? AS BINARY)") : array("$t.id=?");
 		$arrColumns[] = "$t.pid IN(" . implode(',', array_map('\intval', $arrPids)) . ")";
 
 		if (!static::isPreviewMode($arrOptions))

--- a/newsletter-bundle/contao/models/NewsletterModel.php
+++ b/newsletter-bundle/contao/models/NewsletterModel.php
@@ -121,7 +121,7 @@ class NewsletterModel extends Model
 		}
 
 		$t = static::$strTable;
-		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("CAST($t.alias AS BINARY)=?") : array("$t.id=?");
+		$arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? array("$t.alias=CAST(? AS BINARY)") : array("$t.id=?");
 		$arrColumns[] = "$t.pid IN(" . implode(',', array_map('\intval', $arrPids)) . ")";
 
 		if (!static::isPreviewMode($arrOptions))


### PR DESCRIPTION
Casting column values in SQL queries can prevent indexes from being used. This, combined with having to perform a cast for every row, can result in significantly slower queries.

Casting the value being compared to binary behaves the same as casting the column value, but indexes can still be used and of course the cast also only has to be performed once instead of once for each row.

For the site where I noticed this, this makes a ~220 ms difference across just 13 queries, so it’s a pretty substantial improvement.


### Before 
<img width="968" height="252" alt="Screenshot 2026-09-10 at 09 56 53" src="https://github.com/user-attachments/assets/c0b9b086-4776-4569-92ef-d53521ec3419" />

### After
<img width="964" height="184" alt="Screenshot 2026-09-10 at 09 57 42" src="https://github.com/user-attachments/assets/cb954b9b-78e0-4af5-9a66-c91b3d271bae" />
