### PR TITLE
`AbstractPublicUriProvider::getVersionParameter()` never returns `null`

### DIFF
--- a/core-bundle/src/Filesystem/PublicUri/AbstractPublicUriProvider.php
+++ b/core-bundle/src/Filesystem/PublicUri/AbstractPublicUriProvider.php
@@ -40,7 +40,7 @@ abstract class AbstractPublicUriProvider
         try {
             $mtime = $adapter->lastModified($adapterPath)->lastModified();
         } catch (\Throwable) {
-            $mtime = null;
+            return null;
         }
 
         // Hash because nobody needs to know the mtime


### PR DESCRIPTION
The `versionizeUri()` method checks the following:

```php
$version = $this->getVersionParameter($adapter, $adapterPath);

if (null === $version) {
    return $uri;
}
```

However, the `getVersionParameter()` never returns `null`.