### PR TITLE
Fix the debug mode toggle referer for path-based back end routes

### DIFF
--- a/manager-bundle/src/Controller/DebugController.php
+++ b/manager-bundle/src/Controller/DebugController.php
@@ -59,13 +59,23 @@ class DebugController
             throw new InvalidRequestTokenException('Invalid CSRF token. Please reload the page and try again.');
         }
 
-        $referer = '';
+        // Default to the back end root (e.g. if there is no or an invalid referer).
+        $target = $request->getBaseUrl().'/contao';
 
         if ($request->query->has('referer')) {
-            $referer = '?'.base64_decode($request->query->get('referer'), true);
+            $referer = base64_decode($request->query->get('referer'), true);
+
+            // The referer is the full request URI (path + query string) of the page the
+            // debug mode was toggled from, which also covers back end modules that are
+            // addressed via a path (e.g. "/contao/page") instead of the "do" query
+            // parameter. Only allow same-origin, absolute paths here, so a manipulated
+            // referer parameter cannot be used for an open redirect.
+            if (\is_string($referer) && str_starts_with($referer, '/') && !str_starts_with($referer, '//')) {
+                $target = $referer;
+            }
         }
 
-        $response = new RedirectResponse($request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo().$referer);
+        $response = new RedirectResponse($request->getSchemeAndHttpHost().$target);
 
         $this->jwtManager->addResponseCookie($response, ['debug' => $debug]);
 

--- a/manager-bundle/src/EventListener/BackendMenuListener.php
+++ b/manager-bundle/src/EventListener/BackendMenuListener.php
@@ -72,9 +72,9 @@ class BackendMenuListener
         $params = [
             'do' => 'debug',
             'key' => $this->debug ? 'disable' : 'enable',
-            // Use the full request URI (not just the query string), because back end
-            // modules can also be addressed via a path (e.g. "/contao/page") instead
-            // of the "do" query parameter.
+            // Use the full request URI (not just the query string), because back end modules
+            // can also be addressed via a path (e.g. "/contao/page") instead of the "do"
+            // query parameter.
             'referer' => base64_encode($request->getRequestUri()),
             'rt' => $this->tokenManager->getDefaultTokenValue(),
         ];

--- a/manager-bundle/src/EventListener/BackendMenuListener.php
+++ b/manager-bundle/src/EventListener/BackendMenuListener.php
@@ -72,7 +72,10 @@ class BackendMenuListener
         $params = [
             'do' => 'debug',
             'key' => $this->debug ? 'disable' : 'enable',
-            'referer' => base64_encode($request->server->get('QUERY_STRING', '')),
+            // Use the full request URI (not just the query string), because back end
+            // modules can also be addressed via a path (e.g. "/contao/page") instead
+            // of the "do" query parameter.
+            'referer' => base64_encode($request->getRequestUri()),
             'rt' => $this->tokenManager->getDefaultTokenValue(),
         ];
 

--- a/manager-bundle/tests/Controller/DebugControllerTest.php
+++ b/manager-bundle/tests/Controller/DebugControllerTest.php
@@ -69,8 +69,8 @@ class DebugControllerTest extends ContaoTestCase
 
     public function testResponseContainsRefererForPathBasedBackendRoute(): void
     {
-        // Back end modules can be addressed via a path (e.g. "/contao/page") instead
-        // of the "do" query parameter, in which case the module is not part of the
+        // Back end modules can be addressed via a path (e.g. "/contao/page") instead of
+        // the "do" query parameter, in which case the module is not part of the
         // referer's query string.
         $listener = new DebugController(
             $this->mockSecurityHelper(),
@@ -102,8 +102,8 @@ class DebugControllerTest extends ContaoTestCase
 
     public function testIgnoresARefererThatIsNotASameOriginPath(): void
     {
-        // A manipulated referer parameter must not be able to redirect to a foreign
-        // host (e.g. a protocol-relative "//evil.example.com/" URL).
+        // A manipulated referer parameter must not be able to redirect to a foreign host
+        // (e.g. a protocol-relative "//evil.example.com/" URL).
         $listener = new DebugController(
             $this->mockSecurityHelper(),
             $this->mockRequestStack('https://example.com/contao', '//evil.example.com/'),

--- a/manager-bundle/tests/Controller/DebugControllerTest.php
+++ b/manager-bundle/tests/Controller/DebugControllerTest.php
@@ -52,9 +52,11 @@ class DebugControllerTest extends ContaoTestCase
 
     public function testResponseContainsReferer(): void
     {
+        // The debug toggle is always requested via "/contao" (do=debug), while the
+        // referer points back to the page the button was clicked on.
         $listener = new DebugController(
             $this->mockSecurityHelper(),
-            $this->mockRequestStack('https://example.com/foo/bar.html', 'foo=bar'),
+            $this->mockRequestStack('https://example.com/contao', '/foo/bar.html?foo=bar'),
             $this->mockJwtManager(true, true),
             $this->mockTokenManager(true),
             'contao_csrf_token',
@@ -63,6 +65,56 @@ class DebugControllerTest extends ContaoTestCase
         $response = $listener->enableAction();
 
         $this->assertSame('https://example.com/foo/bar.html?foo=bar', $response->getTargetUrl());
+    }
+
+    public function testResponseContainsRefererForPathBasedBackendRoute(): void
+    {
+        // Back end modules can be addressed via a path (e.g. "/contao/page") instead
+        // of the "do" query parameter, in which case the module is not part of the
+        // referer's query string.
+        $listener = new DebugController(
+            $this->mockSecurityHelper(),
+            $this->mockRequestStack('https://example.com/contao', '/contao/page?act=edit&id=1'),
+            $this->mockJwtManager(true, true),
+            $this->mockTokenManager(true),
+            'contao_csrf_token',
+        );
+
+        $response = $listener->enableAction();
+
+        $this->assertSame('https://example.com/contao/page?act=edit&id=1', $response->getTargetUrl());
+    }
+
+    public function testFallsBackToTheBackendRootIfThereIsNoReferer(): void
+    {
+        $listener = new DebugController(
+            $this->mockSecurityHelper(),
+            $this->mockRequestStack('https://example.com/contao'),
+            $this->mockJwtManager(true, true),
+            $this->mockTokenManager(true),
+            'contao_csrf_token',
+        );
+
+        $response = $listener->enableAction();
+
+        $this->assertSame('https://example.com/contao', $response->getTargetUrl());
+    }
+
+    public function testIgnoresARefererThatIsNotASameOriginPath(): void
+    {
+        // A manipulated referer parameter must not be able to redirect to a foreign
+        // host (e.g. a protocol-relative "//evil.example.com/" URL).
+        $listener = new DebugController(
+            $this->mockSecurityHelper(),
+            $this->mockRequestStack('https://example.com/contao', '//evil.example.com/'),
+            $this->mockJwtManager(true, true),
+            $this->mockTokenManager(true),
+            'contao_csrf_token',
+        );
+
+        $response = $listener->enableAction();
+
+        $this->assertSame('https://example.com/contao', $response->getTargetUrl());
     }
 
     public function testThrowsAccessDeniedExceptionIfUserIsNotAdmin(): void

--- a/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -45,8 +45,10 @@ class BackendMenuListenerTest extends ContaoTestCase
 
     public function testAddsTheDebugButton(): void
     {
-        $request = new Request();
-        $request->server->set('QUERY_STRING', 'do=page');
+        // Back end modules can also be addressed via a path (e.g. "/contao/page")
+        // instead of the "do" query parameter, so the referer has to be the full
+        // request URI and not just the query string.
+        $request = Request::create('https://example.com/contao/page?act=edit&id=1');
 
         $requestStack = new RequestStack([$request]);
 
@@ -55,7 +57,7 @@ class BackendMenuListenerTest extends ContaoTestCase
         $params = [
             'do' => 'debug',
             'key' => 'enable',
-            'referer' => base64_encode('do=page'),
+            'referer' => base64_encode('/contao/page?act=edit&id=1'),
             'rt' => 'request-token-value',
         ];
 
@@ -64,7 +66,7 @@ class BackendMenuListenerTest extends ContaoTestCase
             ->expects($this->once())
             ->method('generate')
             ->with('contao_backend', $params)
-            ->willReturn('/contao?do=debug&key=enable&referer='.base64_encode('do=page'))
+            ->willReturn('/contao?do=debug&key=enable&referer='.base64_encode('/contao/page?act=edit&id=1'))
         ;
 
         $factory = new MenuFactory();
@@ -95,7 +97,7 @@ class BackendMenuListenerTest extends ContaoTestCase
         $debug = $children['debug'];
 
         $this->assertSame('debug_mode', $debug->getLabel());
-        $this->assertSame('/contao?do=debug&key=enable&referer=ZG89cGFnZQ==', $debug->getUri());
+        $this->assertSame('/contao?do=debug&key=enable&referer=L2NvbnRhby9wYWdlP2FjdD1lZGl0JmlkPTE=', $debug->getUri());
         $this->assertSame(['class' => 'icon-debug', 'title' => 'debug_mode', 'data-contao--tooltips-target' => 'tooltip', 'data-turbo-prefetch' => 'false'], $debug->getLinkAttributes());
         $this->assertSame(['translation_domain' => 'ContaoManagerBundle'], $debug->getExtras());
     }

--- a/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -46,8 +46,8 @@ class BackendMenuListenerTest extends ContaoTestCase
     public function testAddsTheDebugButton(): void
     {
         // Back end modules can also be addressed via a path (e.g. "/contao/page")
-        // instead of the "do" query parameter, so the referer has to be the full
-        // request URI and not just the query string.
+        // instead of the "do" query parameter, so the referer has to be the full request
+        // URI and not just the query string.
         $request = Request::create('https://example.com/contao/page?act=edit&id=1');
 
         $requestStack = new RequestStack([$request]);


### PR DESCRIPTION
## Summary

Toggling debug mode via the back end header button (`icon-debug`) only captured `QUERY_STRING` for the "referer" it redirects back to, and rebuilt the redirect target from the debug endpoint's own path info (always `/contao`). This works as long as a back end module is fully addressed via `?do=module&...`, but modules can also be addressed via a path (e.g. `/contao/page`), where `do` is not part of the query string at all.

As a result, toggling debug mode from a path-based module route (e.g. an edit view opened via `/contao/metamodels?...&act=edit&id=...`) silently dropped the module and landed on the Dashboard instead of the page the button was clicked on. I reproduced this against a Contao 6 instance: the redirect chain ends on `/contao?pid=...&table=...&act=edit&id=...` (no `do`), which Contao's back end then renders as the Dashboard.

- `BackendMenuListener::addDebugButton()` now captures `$request->getRequestUri()` (full path + query) instead of just `QUERY_STRING`.
- `DebugController::updateJwtCookie()` redirects straight to the decoded referer instead of reconstructing it from its own path info, falling back to the back end root if there is none. The decoded referer is validated to be a same-origin absolute path (rejecting e.g. `//evil.example.com/`) so a manipulated `referer` parameter cannot be used for an open redirect.

## Test plan

- [x] Updated `BackendMenuListenerTest::testAddsTheDebugButton` to use a path-based module route.
- [x] Updated `DebugControllerTest::testResponseContainsReferer` and added `testResponseContainsRefererForPathBasedBackendRoute`, `testFallsBackToTheBackendRootIfThereIsNoReferer`, and `testIgnoresARefererThatIsNotASameOriginPath`.
- [x] Manually verified the redirect logic against real `Symfony\Component\HttpFoundation\Request` objects for all four scenarios.
- [x] Reproduced the original bug against a running Contao 6 back end and confirmed the fix resolves it.
